### PR TITLE
Refactor YAML configuration helpers

### DIFF
--- a/pdb2reaction/backup/path_search.py
+++ b/pdb2reaction/backup/path_search.py
@@ -128,7 +128,7 @@ from Bio import PDB
 from Bio.PDB import PDBParser, PDBIO
 
 from .uma_pysis import uma_pysis
-from .utils import convert_xyz_to_pdb, freeze_links
+from .utils import convert_xyz_to_pdb, freeze_links, deep_update, load_yaml_dict
 from .trj2fig import run_trj2fig  # auto‑generate an energy plot when a .trj is produced
 from .bond_changes import compare_structures, summarize_changes
 from .utils import build_energy_diagram  # Plotly energy diagram
@@ -255,31 +255,6 @@ SEARCH_KW: Dict[str, Any] = {
     "max_nodes_bridge": 5,
     "kink_max_nodes": 3,           # nodes for linear interpolation when skipping GSM at a kink
 }
-
-# -----------------------------------------------
-# Utilities
-# -----------------------------------------------
-
-def _deep_update(dst: Dict[str, Any], src: Dict[str, Any]) -> Dict[str, Any]:
-    """Recursively overwrite mapping *dst* with *src* and return *dst*."""
-    for k, v in (src or {}).items():
-        if isinstance(v, dict) and isinstance(dst.get(k), dict):
-            _deep_update(dst[k], v)
-        else:
-            dst[k] = v
-    return dst
-
-
-def _load_yaml(path: Optional[Path]) -> Dict[str, Any]:
-    """Load YAML as dict (empty dict if *path* is None). Raise if top level is not a mapping."""
-    if not path:
-        return {}
-    with open(path, "r") as f:
-        data = yaml.safe_load(f) or {}
-    if not isinstance(data, dict):
-        raise ValueError(f"YAML root must be a mapping, got: {type(data)}")
-    return data
-
 
 def _pretty_block(title: str, content: Dict[str, Any]) -> str:
     """Render a titled YAML block for console echo."""
@@ -1595,7 +1570,7 @@ def cli(
         # --------------------------
         # 1) Resolve settings (defaults ← YAML ← CLI)
         # --------------------------
-        yaml_cfg = _load_yaml(args_yaml)
+        yaml_cfg = load_yaml_dict(args_yaml)
 
         geom_cfg = dict(GEOM_KW)
         calc_cfg = dict(CALC_KW)
@@ -1606,14 +1581,14 @@ def cli(
         bond_cfg  = dict(BOND_KW)
         search_cfg = dict(SEARCH_KW)
 
-        _deep_update(geom_cfg, yaml_cfg.get("geom", {}))
-        _deep_update(calc_cfg, yaml_cfg.get("calc", {}))
-        _deep_update(gs_cfg,   yaml_cfg.get("gs",   {}))
-        _deep_update(opt_cfg,  yaml_cfg.get("opt",  {}))
-        _deep_update(lbfgs_cfg, yaml_cfg.get("sopt", {}).get("lbfgs", yaml_cfg.get("lbfgs", {})))
-        _deep_update(rfo_cfg,   yaml_cfg.get("sopt", {}).get("rfo",   yaml_cfg.get("rfo",   {})))
-        _deep_update(bond_cfg,  yaml_cfg.get("bond", {}))
-        _deep_update(search_cfg,yaml_cfg.get("search", {}))
+        deep_update(geom_cfg, yaml_cfg.get("geom", {}))
+        deep_update(calc_cfg, yaml_cfg.get("calc", {}))
+        deep_update(gs_cfg,   yaml_cfg.get("gs",   {}))
+        deep_update(opt_cfg,  yaml_cfg.get("opt",  {}))
+        deep_update(lbfgs_cfg, yaml_cfg.get("sopt", {}).get("lbfgs", yaml_cfg.get("lbfgs", {})))
+        deep_update(rfo_cfg,   yaml_cfg.get("sopt", {}).get("rfo",   yaml_cfg.get("rfo",   {})))
+        deep_update(bond_cfg,  yaml_cfg.get("bond", {}))
+        deep_update(search_cfg,yaml_cfg.get("search", {}))
 
         calc_cfg["charge"] = int(charge)
         calc_cfg["spin"]   = int(spin)

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -34,6 +34,8 @@ import numpy as np
 
 from pysisyphus.helpers import geom_loader
 
+from .utils import deep_update, load_yaml_dict
+
 
 # -----------------------------------------------
 # Defaults (override via CLI / YAML)
@@ -53,26 +55,6 @@ DFT_KW: Dict[str, Any] = {
 # -----------------------------------------------
 
 HARTREE_TO_KCALMOL = 627.5094740631  # Commonly used Hartree → kcal/mol conversion factor
-
-
-def _deep_update(dst: Dict[str, Any], src: Dict[str, Any]) -> Dict[str, Any]:
-    """Recursively update dict 'dst' with 'src', returning 'dst'."""
-    for k, v in (src or {}).items():
-        if isinstance(v, dict) and isinstance(dst.get(k), dict):
-            _deep_update(dst[k], v)
-        else:
-            dst[k] = v
-    return dst
-
-
-def _load_yaml(path: Optional[Path]) -> Dict[str, Any]:
-    if not path:
-        return {}
-    with open(path, "r") as f:
-        data = yaml.safe_load(f) or {}
-    if not isinstance(data, dict):
-        raise ValueError(f"YAML top-level must be a mapping; got: {type(data)}")
-    return data
 
 
 def _pretty_block(title: str, content: Dict[str, Any]) -> str:
@@ -268,9 +250,9 @@ def cli(
         # --------------------------
         # 1) Assemble configuration
         # --------------------------
-        yaml_cfg = _load_yaml(args_yaml)
+        yaml_cfg = load_yaml_dict(args_yaml)
         dft_cfg = dict(DFT_KW)
-        _deep_update(dft_cfg, yaml_cfg.get("dft", {}))
+        deep_update(dft_cfg, yaml_cfg.get("dft", {}))
 
         # CLI overrides
         dft_cfg["conv_tol"] = float(conv_tol)

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -53,32 +53,17 @@ from pysisyphus.constants import BOHR2ANG, ANG2BOHR, AMU2AU, AU2EV
 
 # local helpers from pdb2reaction
 from .uma_pysis import uma_pysis
-from .utils import freeze_links as _freeze_links_from_utils, convert_xyz_to_pdb as _convert_xyz_to_pdb
+from .utils import (
+    deep_update,
+    load_yaml_dict,
+    freeze_links as _freeze_links_from_utils,
+    convert_xyz_to_pdb as _convert_xyz_to_pdb,
+)
 
 
 # ===================================================================
 #                         Generic helpers
 # ===================================================================
-
-def _deep_update(dst: Dict[str, Any], src: Dict[str, Any]) -> Dict[str, Any]:
-    """Recursively update dict *dst* with *src*, returning *dst*."""
-    for k, v in (src or {}).items():
-        if isinstance(v, dict) and isinstance(dst.get(k), dict):
-            _deep_update(dst[k], v)
-        else:
-            dst[k] = v
-    return dst
-
-
-def _load_yaml(path: Optional[Path]) -> Dict[str, Any]:
-    if not path:
-        return {}
-    with open(path, "r") as f:
-        data = yaml.safe_load(f) or {}
-    if not isinstance(data, dict):
-        raise ValueError(f"YAML root must be a mapping, got: {type(data)}")
-    return data
-
 
 def _pretty_block(title: str, content: Dict[str, Any]) -> str:
     body = yaml.safe_dump(content, sort_keys=False, allow_unicode=True).strip()
@@ -498,15 +483,15 @@ def cli(
     # --------------------------
     # 1) Assemble configuration
     # --------------------------
-    yaml_cfg = _load_yaml(args_yaml)
+    yaml_cfg = load_yaml_dict(args_yaml)
     geom_cfg = dict(GEOM_KW)
     calc_cfg = dict(CALC_KW)
     freq_cfg = dict(FREQ_KW)
     thermo_cfg = dict(THERMO_KW)
 
-    _deep_update(geom_cfg, yaml_cfg.get("geom", {}))
-    _deep_update(calc_cfg, yaml_cfg.get("calc", {}))
-    _deep_update(freq_cfg, yaml_cfg.get("freq", {}))
+    deep_update(geom_cfg, yaml_cfg.get("geom", {}))
+    deep_update(calc_cfg, yaml_cfg.get("calc", {}))
+    deep_update(freq_cfg, yaml_cfg.get("freq", {}))
 
     # CLI overrides
     calc_cfg["charge"] = int(charge)

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -38,7 +38,7 @@ from pysisyphus.optimizers.RFOptimizer import RFOptimizer
 from pysisyphus.optimizers.exceptions import OptimizationError, ZeroStepLength
 
 from .uma_pysis import uma_pysis
-from .utils import convert_xyz_to_pdb, freeze_links
+from .utils import convert_xyz_to_pdb, freeze_links, deep_update, load_yaml_dict
 
 # -----------------------------------------------
 # Default settings (overridable via YAML/CLI)
@@ -182,26 +182,6 @@ RFO_KW = {
 # Utilities
 # -----------------------------------------------
 
-def _deep_update(dst: Dict[str, Any], src: Dict[str, Any]) -> Dict[str, Any]:
-    """Recursively update dict *dst* with *src*, return *dst*."""
-    for k, v in (src or {}).items():
-        if isinstance(v, dict) and isinstance(dst.get(k), dict):
-            _deep_update(dst[k], v)
-        else:
-            dst[k] = v
-    return dst
-
-
-def _load_yaml(path: Optional[Path]) -> Dict[str, Any]:
-    if not path:
-        return {}
-    with open(path, "r") as f:
-        data = yaml.safe_load(f) or {}
-    if not isinstance(data, dict):
-        raise ValueError(f"YAML root must be a mapping, got: {type(data)}")
-    return data
-
-
 def _norm_opt_mode(mode: str) -> str:
     m = (mode or "").strip().lower()
     if m in ("light", "lbfgs"):
@@ -304,7 +284,7 @@ def cli(
     # 1) Assemble configuration
     # --------------------------
     try:
-        yaml_cfg = _load_yaml(args_yaml)
+        yaml_cfg = load_yaml_dict(args_yaml)
         geom_cfg = dict(GEOM_KW)
         calc_cfg = dict(CALC_KW)
         opt_cfg  = dict(OPT_BASE_KW)
@@ -312,11 +292,11 @@ def cli(
         rfo_cfg   = dict(RFO_KW)
 
         # Merge YAML → defaults
-        _deep_update(geom_cfg, yaml_cfg.get("geom", {}))
-        _deep_update(calc_cfg, yaml_cfg.get("calc", {}))
-        _deep_update(opt_cfg,  yaml_cfg.get("opt",  {}))
-        _deep_update(lbfgs_cfg, yaml_cfg.get("lbfgs", {}))
-        _deep_update(rfo_cfg,   yaml_cfg.get("rfo",   {}))
+        deep_update(geom_cfg, yaml_cfg.get("geom", {}))
+        deep_update(calc_cfg, yaml_cfg.get("calc", {}))
+        deep_update(opt_cfg,  yaml_cfg.get("opt",  {}))
+        deep_update(lbfgs_cfg, yaml_cfg.get("lbfgs", {}))
+        deep_update(rfo_cfg,   yaml_cfg.get("rfo",   {}))
 
         # CLI overrides (CLI > YAML)
         calc_cfg["charge"] = charge

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -128,7 +128,7 @@ from Bio import PDB
 from Bio.PDB import PDBParser, PDBIO
 
 from .uma_pysis import uma_pysis
-from .utils import convert_xyz_to_pdb, freeze_links
+from .utils import convert_xyz_to_pdb, freeze_links, deep_update, load_yaml_dict
 from .trj2fig import run_trj2fig  # auto‑generate an energy plot when a .trj is produced
 from .bond_changes import compare_structures, summarize_changes
 from .utils import build_energy_diagram  # Plotly energy diagram
@@ -255,31 +255,6 @@ SEARCH_KW: Dict[str, Any] = {
     "max_nodes_bridge": 5,
     "kink_max_nodes": 3,           # nodes for linear interpolation when skipping GSM at a kink
 }
-
-# -----------------------------------------------
-# Utilities
-# -----------------------------------------------
-
-def _deep_update(dst: Dict[str, Any], src: Dict[str, Any]) -> Dict[str, Any]:
-    """Recursively overwrite mapping *dst* with *src* and return *dst*."""
-    for k, v in (src or {}).items():
-        if isinstance(v, dict) and isinstance(dst.get(k), dict):
-            _deep_update(dst[k], v)
-        else:
-            dst[k] = v
-    return dst
-
-
-def _load_yaml(path: Optional[Path]) -> Dict[str, Any]:
-    """Load YAML as dict (empty dict if *path* is None). Raise if top level is not a mapping."""
-    if not path:
-        return {}
-    with open(path, "r") as f:
-        data = yaml.safe_load(f) or {}
-    if not isinstance(data, dict):
-        raise ValueError(f"YAML root must be a mapping, got: {type(data)}")
-    return data
-
 
 def _pretty_block(title: str, content: Dict[str, Any]) -> str:
     """Render a titled YAML block for console echo."""
@@ -1595,7 +1570,7 @@ def cli(
         # --------------------------
         # 1) Resolve settings (defaults ← YAML ← CLI)
         # --------------------------
-        yaml_cfg = _load_yaml(args_yaml)
+        yaml_cfg = load_yaml_dict(args_yaml)
 
         geom_cfg = dict(GEOM_KW)
         calc_cfg = dict(CALC_KW)
@@ -1606,14 +1581,14 @@ def cli(
         bond_cfg  = dict(BOND_KW)
         search_cfg = dict(SEARCH_KW)
 
-        _deep_update(geom_cfg, yaml_cfg.get("geom", {}))
-        _deep_update(calc_cfg, yaml_cfg.get("calc", {}))
-        _deep_update(gs_cfg,   yaml_cfg.get("gs",   {}))
-        _deep_update(opt_cfg,  yaml_cfg.get("opt",  {}))
-        _deep_update(lbfgs_cfg, yaml_cfg.get("sopt", {}).get("lbfgs", yaml_cfg.get("lbfgs", {})))
-        _deep_update(rfo_cfg,   yaml_cfg.get("sopt", {}).get("rfo",   yaml_cfg.get("rfo",   {})))
-        _deep_update(bond_cfg,  yaml_cfg.get("bond", {}))
-        _deep_update(search_cfg,yaml_cfg.get("search", {}))
+        deep_update(geom_cfg, yaml_cfg.get("geom", {}))
+        deep_update(calc_cfg, yaml_cfg.get("calc", {}))
+        deep_update(gs_cfg,   yaml_cfg.get("gs",   {}))
+        deep_update(opt_cfg,  yaml_cfg.get("opt",  {}))
+        deep_update(lbfgs_cfg, yaml_cfg.get("sopt", {}).get("lbfgs", yaml_cfg.get("lbfgs", {})))
+        deep_update(rfo_cfg,   yaml_cfg.get("sopt", {}).get("rfo",   yaml_cfg.get("rfo",   {})))
+        deep_update(bond_cfg,  yaml_cfg.get("bond", {}))
+        deep_update(search_cfg,yaml_cfg.get("search", {}))
 
         calc_cfg["charge"] = int(charge)
         calc_cfg["spin"]   = int(spin)

--- a/pdb2reaction/ts_opt.py
+++ b/pdb2reaction/ts_opt.py
@@ -94,31 +94,12 @@ from pysisyphus.tsoptimizers.RSIRFOptimizer import RSIRFOptimizer  # type: ignor
 
 # local helpers from pdb2reaction
 from .uma_pysis import uma_pysis
-from .utils import convert_xyz_to_pdb, freeze_links as _freeze_links_from_utils
-
-
-# ===================================================================
-#                         Generic helpers
-# ===================================================================
-
-def _deep_update(dst: Dict[str, Any], src: Dict[str, Any]) -> Dict[str, Any]:
-    """Recursively update dict *dst* with *src*, returning *dst*."""
-    for k, v in (src or {}).items():
-        if isinstance(v, dict) and isinstance(dst.get(k), dict):
-            _deep_update(dst[k], v)
-        else:
-            dst[k] = v
-    return dst
-
-
-def _load_yaml(path: Optional[Path]) -> Dict[str, Any]:
-    if not path:
-        return {}
-    with open(path, "r") as f:
-        data = yaml.safe_load(f) or {}
-    if not isinstance(data, dict):
-        raise ValueError(f"YAML root must be a mapping, got: {type(data)}")
-    return data
+from .utils import (
+    convert_xyz_to_pdb,
+    freeze_links as _freeze_links_from_utils,
+    deep_update,
+    load_yaml_dict,
+)
 
 
 def _pretty_block(title: str, content: Dict[str, Any]) -> str:
@@ -1372,7 +1353,7 @@ def cli(
     # --------------------------
     # 1) Assemble configuration
     # --------------------------
-    yaml_cfg = _load_yaml(args_yaml)
+    yaml_cfg = load_yaml_dict(args_yaml)
     geom_cfg = dict(GEOM_KW)
     calc_cfg = dict(CALC_KW)
     opt_cfg  = dict(OPT_BASE_KW)
@@ -1380,11 +1361,11 @@ def cli(
     rsirfo_cfg = dict(RSIRFO_KW)
 
     # YAML → defaults
-    _deep_update(geom_cfg, yaml_cfg.get("geom", {}))
-    _deep_update(calc_cfg, yaml_cfg.get("calc", {}))
-    _deep_update(opt_cfg,  yaml_cfg.get("opt",  {}))
-    _deep_update(simple_cfg, yaml_cfg.get("hessian_dimer", {}))
-    _deep_update(rsirfo_cfg, yaml_cfg.get("rsirfo", {}))
+    deep_update(geom_cfg, yaml_cfg.get("geom", {}))
+    deep_update(calc_cfg, yaml_cfg.get("calc", {}))
+    deep_update(opt_cfg,  yaml_cfg.get("opt",  {}))
+    deep_update(simple_cfg, yaml_cfg.get("hessian_dimer", {}))
+    deep_update(rsirfo_cfg, yaml_cfg.get("rsirfo", {}))
 
     # CLI overrides
     calc_cfg["charge"] = int(charge)

--- a/pdb2reaction/utils.py
+++ b/pdb2reaction/utils.py
@@ -3,10 +3,42 @@
 import sys
 import math
 from pathlib import Path
-from typing import Sequence, List
+from typing import Any, Dict, Optional, Sequence, List
 
+import yaml
 from ase.io import read, write
 import plotly.graph_objs as go
+
+
+# =============================================================================
+# Generic helpers
+# =============================================================================
+
+
+def deep_update(dst: Dict[str, Any], src: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Recursively update mapping *dst* with *src*, returning *dst*."""
+
+    for k, v in (src or {}).items():
+        if isinstance(v, dict) and isinstance(dst.get(k), dict):
+            deep_update(dst[k], v)
+        else:
+            dst[k] = v
+    return dst
+
+
+def load_yaml_dict(path: Optional[Path]) -> Dict[str, Any]:
+    """Load a YAML file whose root must be a mapping. Return an empty dict if *path* is None."""
+
+    if not path:
+        return {}
+
+    with open(path, "r") as f:
+        data = yaml.safe_load(f) or {}
+
+    if not isinstance(data, dict):
+        raise ValueError(f"YAML root must be a mapping, got: {type(data)}")
+
+    return data
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- add shared `deep_update` and `load_yaml_dict` helpers to `pdb2reaction.utils` for YAML configuration handling
- update CLI entry points to reuse the shared helpers instead of duplicating dictionary merge and YAML loading logic

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a427eaa0832db7a9382ea5db14b8)