### PR TITLE
Refactor YAML override merging into shared helper

### DIFF
--- a/pdb2reaction/backup/path_search.py
+++ b/pdb2reaction/backup/path_search.py
@@ -128,7 +128,12 @@ from Bio import PDB
 from Bio.PDB import PDBParser, PDBIO
 
 from .uma_pysis import uma_pysis
-from .utils import convert_xyz_to_pdb, freeze_links, deep_update, load_yaml_dict
+from .utils import (
+    convert_xyz_to_pdb,
+    freeze_links,
+    load_yaml_dict,
+    apply_yaml_overrides,
+)
 from .trj2fig import run_trj2fig  # auto‑generate an energy plot when a .trj is produced
 from .bond_changes import compare_structures, summarize_changes
 from .utils import build_energy_diagram  # Plotly energy diagram
@@ -1581,14 +1586,19 @@ def cli(
         bond_cfg  = dict(BOND_KW)
         search_cfg = dict(SEARCH_KW)
 
-        deep_update(geom_cfg, yaml_cfg.get("geom", {}))
-        deep_update(calc_cfg, yaml_cfg.get("calc", {}))
-        deep_update(gs_cfg,   yaml_cfg.get("gs",   {}))
-        deep_update(opt_cfg,  yaml_cfg.get("opt",  {}))
-        deep_update(lbfgs_cfg, yaml_cfg.get("sopt", {}).get("lbfgs", yaml_cfg.get("lbfgs", {})))
-        deep_update(rfo_cfg,   yaml_cfg.get("sopt", {}).get("rfo",   yaml_cfg.get("rfo",   {})))
-        deep_update(bond_cfg,  yaml_cfg.get("bond", {}))
-        deep_update(search_cfg,yaml_cfg.get("search", {}))
+        apply_yaml_overrides(
+            yaml_cfg,
+            [
+                (geom_cfg, (("geom",),)),
+                (calc_cfg, (("calc",),)),
+                (gs_cfg, (("gs",),)),
+                (opt_cfg, (("opt",),)),
+                (lbfgs_cfg, (("sopt", "lbfgs"), ("lbfgs",))),
+                (rfo_cfg, (("sopt", "rfo"), ("rfo",))),
+                (bond_cfg, (("bond",),)),
+                (search_cfg, (("search",),)),
+            ],
+        )
 
         calc_cfg["charge"] = int(charge)
         calc_cfg["spin"]   = int(spin)

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -34,7 +34,7 @@ import numpy as np
 
 from pysisyphus.helpers import geom_loader
 
-from .utils import deep_update, load_yaml_dict
+from .utils import load_yaml_dict, apply_yaml_overrides
 
 
 # -----------------------------------------------
@@ -252,7 +252,7 @@ def cli(
         # --------------------------
         yaml_cfg = load_yaml_dict(args_yaml)
         dft_cfg = dict(DFT_KW)
-        deep_update(dft_cfg, yaml_cfg.get("dft", {}))
+        apply_yaml_overrides(yaml_cfg, [(dft_cfg, (("dft",),))])
 
         # CLI overrides
         dft_cfg["conv_tol"] = float(conv_tol)

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -54,8 +54,8 @@ from pysisyphus.constants import BOHR2ANG, ANG2BOHR, AMU2AU, AU2EV
 # local helpers from pdb2reaction
 from .uma_pysis import uma_pysis
 from .utils import (
-    deep_update,
     load_yaml_dict,
+    apply_yaml_overrides,
     freeze_links as _freeze_links_from_utils,
     convert_xyz_to_pdb as _convert_xyz_to_pdb,
 )
@@ -489,9 +489,14 @@ def cli(
     freq_cfg = dict(FREQ_KW)
     thermo_cfg = dict(THERMO_KW)
 
-    deep_update(geom_cfg, yaml_cfg.get("geom", {}))
-    deep_update(calc_cfg, yaml_cfg.get("calc", {}))
-    deep_update(freq_cfg, yaml_cfg.get("freq", {}))
+    apply_yaml_overrides(
+        yaml_cfg,
+        [
+            (geom_cfg, (("geom",),)),
+            (calc_cfg, (("calc",),)),
+            (freq_cfg, (("freq",),)),
+        ],
+    )
 
     # CLI overrides
     calc_cfg["charge"] = int(charge)

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -86,7 +86,11 @@ import time
 from pysisyphus.helpers import geom_loader
 from pysisyphus.irc.EulerPC import EulerPC
 from pdb2reaction.uma_pysis import uma_pysis
-from pdb2reaction.utils import convert_xyz_to_pdb, deep_update, load_yaml_dict
+from pdb2reaction.utils import (
+    convert_xyz_to_pdb,
+    load_yaml_dict,
+    apply_yaml_overrides,
+)
 
 
 # --------------------------
@@ -217,9 +221,14 @@ def cli(
         calc_cfg: Dict[str, Any] = dict(CALC_KW_DEFAULT)
         irc_cfg:  Dict[str, Any] = dict(IRC_KW_DEFAULT)
 
-        deep_update(geom_cfg, yaml_cfg.get("geom", {}))
-        deep_update(calc_cfg, yaml_cfg.get("calc", {}))
-        deep_update(irc_cfg,  yaml_cfg.get("irc",  {}))
+        apply_yaml_overrides(
+            yaml_cfg,
+            [
+                (geom_cfg, (("geom",),)),
+                (calc_cfg, (("calc",),)),
+                (irc_cfg, (("irc",),)),
+            ],
+        )
 
         # CLI overrides
         calc_cfg["charge"] = int(charge)

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -38,7 +38,12 @@ from pysisyphus.optimizers.RFOptimizer import RFOptimizer
 from pysisyphus.optimizers.exceptions import OptimizationError, ZeroStepLength
 
 from .uma_pysis import uma_pysis
-from .utils import convert_xyz_to_pdb, freeze_links, deep_update, load_yaml_dict
+from .utils import (
+    convert_xyz_to_pdb,
+    freeze_links,
+    load_yaml_dict,
+    apply_yaml_overrides,
+)
 
 # -----------------------------------------------
 # Default settings (overridable via YAML/CLI)
@@ -292,11 +297,16 @@ def cli(
         rfo_cfg   = dict(RFO_KW)
 
         # Merge YAML → defaults
-        deep_update(geom_cfg, yaml_cfg.get("geom", {}))
-        deep_update(calc_cfg, yaml_cfg.get("calc", {}))
-        deep_update(opt_cfg,  yaml_cfg.get("opt",  {}))
-        deep_update(lbfgs_cfg, yaml_cfg.get("lbfgs", {}))
-        deep_update(rfo_cfg,   yaml_cfg.get("rfo",   {}))
+        apply_yaml_overrides(
+            yaml_cfg,
+            [
+                (geom_cfg, (("geom",),)),
+                (calc_cfg, (("calc",),)),
+                (opt_cfg, (("opt",),)),
+                (lbfgs_cfg, (("lbfgs",),)),
+                (rfo_cfg, (("rfo",),)),
+            ],
+        )
 
         # CLI overrides (CLI > YAML)
         calc_cfg["charge"] = charge

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -128,7 +128,12 @@ from Bio import PDB
 from Bio.PDB import PDBParser, PDBIO
 
 from .uma_pysis import uma_pysis
-from .utils import convert_xyz_to_pdb, freeze_links, deep_update, load_yaml_dict
+from .utils import (
+    convert_xyz_to_pdb,
+    freeze_links,
+    load_yaml_dict,
+    apply_yaml_overrides,
+)
 from .trj2fig import run_trj2fig  # auto‑generate an energy plot when a .trj is produced
 from .bond_changes import compare_structures, summarize_changes
 from .utils import build_energy_diagram  # Plotly energy diagram
@@ -1581,14 +1586,19 @@ def cli(
         bond_cfg  = dict(BOND_KW)
         search_cfg = dict(SEARCH_KW)
 
-        deep_update(geom_cfg, yaml_cfg.get("geom", {}))
-        deep_update(calc_cfg, yaml_cfg.get("calc", {}))
-        deep_update(gs_cfg,   yaml_cfg.get("gs",   {}))
-        deep_update(opt_cfg,  yaml_cfg.get("opt",  {}))
-        deep_update(lbfgs_cfg, yaml_cfg.get("sopt", {}).get("lbfgs", yaml_cfg.get("lbfgs", {})))
-        deep_update(rfo_cfg,   yaml_cfg.get("sopt", {}).get("rfo",   yaml_cfg.get("rfo",   {})))
-        deep_update(bond_cfg,  yaml_cfg.get("bond", {}))
-        deep_update(search_cfg,yaml_cfg.get("search", {}))
+        apply_yaml_overrides(
+            yaml_cfg,
+            [
+                (geom_cfg, (("geom",),)),
+                (calc_cfg, (("calc",),)),
+                (gs_cfg, (("gs",),)),
+                (opt_cfg, (("opt",),)),
+                (lbfgs_cfg, (("sopt", "lbfgs"), ("lbfgs",))),
+                (rfo_cfg, (("sopt", "rfo"), ("rfo",))),
+                (bond_cfg, (("bond",),)),
+                (search_cfg, (("search",),)),
+            ],
+        )
 
         calc_cfg["charge"] = int(charge)
         calc_cfg["spin"]   = int(spin)

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -138,7 +138,12 @@ from Bio import PDB
 from Bio.PDB import PDBParser, PDBIO
 
 from .uma_pysis import uma_pysis
-from .utils import convert_xyz_to_pdb, freeze_links, deep_update, load_yaml_dict
+from .utils import (
+    convert_xyz_to_pdb,
+    freeze_links,
+    load_yaml_dict,
+    apply_yaml_overrides,
+)
 from .trj2fig import run_trj2fig  # auto‑generate an energy plot when a .trj is produced
 from .bond_changes import compare_structures, summarize_changes
 from .utils import build_energy_diagram  # Plotly energy diagram
@@ -1612,14 +1617,19 @@ def cli(
         bond_cfg  = dict(BOND_KW)
         search_cfg = dict(SEARCH_KW)
 
-        deep_update(geom_cfg, yaml_cfg.get("geom", {}))
-        deep_update(calc_cfg, yaml_cfg.get("calc", {}))
-        deep_update(gs_cfg,   yaml_cfg.get("gs",   {}))
-        deep_update(opt_cfg,  yaml_cfg.get("opt",  {}))
-        deep_update(lbfgs_cfg, yaml_cfg.get("sopt", {}).get("lbfgs", yaml_cfg.get("lbfgs", {})))
-        deep_update(rfo_cfg,   yaml_cfg.get("sopt", {}).get("rfo",   yaml_cfg.get("rfo",   {})))
-        deep_update(bond_cfg,  yaml_cfg.get("bond", {}))
-        deep_update(search_cfg,yaml_cfg.get("search", {}))
+        apply_yaml_overrides(
+            yaml_cfg,
+            [
+                (geom_cfg, (("geom",),)),
+                (calc_cfg, (("calc",),)),
+                (gs_cfg, (("gs",),)),
+                (opt_cfg, (("opt",),)),
+                (lbfgs_cfg, (("sopt", "lbfgs"), ("lbfgs",))),
+                (rfo_cfg, (("sopt", "rfo"), ("rfo",))),
+                (bond_cfg, (("bond",),)),
+                (search_cfg, (("search",),)),
+            ],
+        )
 
         calc_cfg["charge"] = int(charge)
         calc_cfg["spin"]   = int(spin)

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -95,8 +95,8 @@ from .uma_pysis import uma_pysis
 from .utils import (
     convert_xyz_to_pdb,
     freeze_links as _freeze_links_util,
-    deep_update,
     load_yaml_dict,
+    apply_yaml_overrides,
 )
 from .bond_changes import compare_structures, summarize_changes
 
@@ -532,13 +532,18 @@ def cli(
         bias_cfg  = dict(BIAS_KW)
         bond_cfg  = dict(BOND_KW)  # <-- added
 
-        deep_update(geom_cfg, yaml_cfg.get("geom", {}))
-        deep_update(calc_cfg, yaml_cfg.get("calc", {}))
-        deep_update(opt_cfg,  yaml_cfg.get("opt",  {}))
-        deep_update(lbfgs_cfg, yaml_cfg.get("lbfgs", {}))
-        deep_update(rfo_cfg,   yaml_cfg.get("rfo",   {}))
-        deep_update(bias_cfg,  yaml_cfg.get("bias",  {}))
-        deep_update(bond_cfg,  yaml_cfg.get("bond",  {}))  # <-- added
+        apply_yaml_overrides(
+            yaml_cfg,
+            [
+                (geom_cfg, (("geom",),)),
+                (calc_cfg, (("calc",),)),
+                (opt_cfg, (("opt",),)),
+                (lbfgs_cfg, (("lbfgs",),)),
+                (rfo_cfg, (("rfo",),)),
+                (bias_cfg, (("bias",),)),
+                (bond_cfg, (("bond",),)),
+            ],
+        )
 
         # CLI overrides
         calc_cfg["charge"] = int(charge)

--- a/pdb2reaction/ts_opt.py
+++ b/pdb2reaction/ts_opt.py
@@ -97,8 +97,8 @@ from .uma_pysis import uma_pysis
 from .utils import (
     convert_xyz_to_pdb,
     freeze_links as _freeze_links_from_utils,
-    deep_update,
     load_yaml_dict,
+    apply_yaml_overrides,
 )
 
 
@@ -1361,11 +1361,16 @@ def cli(
     rsirfo_cfg = dict(RSIRFO_KW)
 
     # YAML → defaults
-    deep_update(geom_cfg, yaml_cfg.get("geom", {}))
-    deep_update(calc_cfg, yaml_cfg.get("calc", {}))
-    deep_update(opt_cfg,  yaml_cfg.get("opt",  {}))
-    deep_update(simple_cfg, yaml_cfg.get("hessian_dimer", {}))
-    deep_update(rsirfo_cfg, yaml_cfg.get("rsirfo", {}))
+    apply_yaml_overrides(
+        yaml_cfg,
+        [
+            (geom_cfg, (("geom",),)),
+            (calc_cfg, (("calc",),)),
+            (opt_cfg, (("opt",),)),
+            (simple_cfg, (("hessian_dimer",),)),
+            (rsirfo_cfg, (("rsirfo",),)),
+        ],
+    )
 
     # CLI overrides
     calc_cfg["charge"] = int(charge)


### PR DESCRIPTION
## Summary
- add an `apply_yaml_overrides` helper to consolidate YAML-to-config merging logic
- update the CLI entry points to use the shared helper instead of repeating deep_update sequences

## Testing
- python -m compileall pdb2reaction

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a746acc8832d9c9d68856c87bd92)