### PR TITLE
Refactor CLI helpers to use shared utilities

### DIFF
--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -34,7 +34,7 @@ import numpy as np
 
 from pysisyphus.helpers import geom_loader
 
-from .utils import load_yaml_dict, apply_yaml_overrides
+from .utils import load_yaml_dict, apply_yaml_overrides, pretty_block
 
 
 # -----------------------------------------------
@@ -55,13 +55,6 @@ DFT_KW: Dict[str, Any] = {
 # -----------------------------------------------
 
 HARTREE_TO_KCALMOL = 627.5094740631  # Commonly used Hartree → kcal/mol conversion factor
-
-
-def _pretty_block(title: str, content: Dict[str, Any]) -> str:
-    body = yaml.safe_dump(content, sort_keys=False, allow_unicode=True).strip()
-    return f"{title}\n" + "-" * len(title) + "\n" + (body if body else "(empty)") + "\n"
-
-
 def _parse_func_basis(s: str) -> Tuple[str, str]:
     """
     Parse "FUNC/BASIS" into (xc, basis).
@@ -279,7 +272,7 @@ def cli(
             "grid_level": dft_cfg["grid_level"],
             "out_dir": str(out_dir_path),
         }
-        click.echo(_pretty_block("dft", echo_cfg))
+        click.echo(pretty_block("dft", echo_cfg))
 
         # --------------------------
         # 2) Load geometry

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -90,6 +90,8 @@ from pdb2reaction.utils import (
     convert_xyz_to_pdb,
     load_yaml_dict,
     apply_yaml_overrides,
+    pretty_block,
+    format_geom_for_echo,
 )
 
 
@@ -144,21 +146,6 @@ IRC_KW_DEFAULT: Dict[str, Any] = {
     "loose_cycles": 3,
     "corr_func": "mbs",
 }
-
-
-def _pretty_block(title: str, content: Dict[str, Any]) -> str:
-    body = yaml.safe_dump(content, sort_keys=False, allow_unicode=True).strip()
-    return f"{title}\n" + "-" * len(title) + "\n" + (body if body else "(empty)") + "\n"
-
-
-def _format_geom_for_echo(geom_cfg: Dict[str, Any]) -> Dict[str, Any]:
-    g = dict(geom_cfg)
-    fa = g.get("freeze_atoms")
-    if isinstance(fa, (list, tuple)):
-        g["freeze_atoms"] = ",".join(map(str, fa)) if fa else ""
-    return g
-
-
 def _echo_convert_trj_to_pdb_if_exists(trj_path: Path, ref_pdb: Path, out_path: Path) -> None:
     if trj_path.exists():
         try:
@@ -251,9 +238,9 @@ def cli(
         out_dir_path.mkdir(parents=True, exist_ok=True)
 
         # 画面表示用（freeze_atoms を見やすく）
-        click.echo(_pretty_block("geom", _format_geom_for_echo(geom_cfg)))
-        click.echo(_pretty_block("calc", calc_cfg))
-        click.echo(_pretty_block("irc",  {**irc_cfg, "out_dir": str(out_dir_path)}))
+        click.echo(pretty_block("geom", format_geom_for_echo(geom_cfg)))
+        click.echo(pretty_block("calc", calc_cfg))
+        click.echo(pretty_block("irc",  {**irc_cfg, "out_dir": str(out_dir_path)}))
 
         # --------------------------
         # 2) 幾何のロード & UMA 設定

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -140,13 +140,16 @@ from Bio.PDB import PDBParser, PDBIO
 from .uma_pysis import uma_pysis
 from .utils import (
     convert_xyz_to_pdb,
-    freeze_links,
+    freeze_links as detect_freeze_links,
     load_yaml_dict,
     apply_yaml_overrides,
+    pretty_block,
+    format_geom_for_echo,
+    merge_freeze_atom_indices,
+    build_energy_diagram,
 )
 from .trj2fig import run_trj2fig  # auto‑generate an energy plot when a .trj is produced
 from .bond_changes import compare_structures, summarize_changes
-from .utils import build_energy_diagram  # Plotly energy diagram
 from .align_freeze_atoms import align_and_refine_sequence_inplace, kabsch_R_t
 
 # -----------------------------------------------
@@ -272,25 +275,10 @@ SEARCH_KW: Dict[str, Any] = {
     "kink_max_nodes": 3,           # nodes for linear interpolation when skipping GSM at a kink
 }
 
-def _pretty_block(title: str, content: Dict[str, Any]) -> str:
-    """Render a titled YAML block for console echo."""
-    body = yaml.safe_dump(content, sort_keys=False, allow_unicode=True).strip()
-    return f"{title}\n" + "-" * len(title) + "\n" + (body if body else "(empty)") + "\n"
-
-
-def _format_geom_for_echo(geom_cfg: Dict[str, Any]) -> Dict[str, Any]:
-    """Pretty‑format `freeze_atoms` (CSV) for display."""
-    g = dict(geom_cfg)
-    fa = g.get("freeze_atoms")
-    if isinstance(fa, (list, tuple, np.ndarray)):
-        g["freeze_atoms"] = ",".join(map(str, fa)) if len(fa) else ""
-    return g
-
-
 def _freeze_links_for_pdb(pdb_path: Path) -> Sequence[int]:
     """Detect parent atoms of link hydrogens in a PDB; return 0‑based indices. Silent on failure."""
     try:
-        return freeze_links(pdb_path)
+        return detect_freeze_links(pdb_path)
     except Exception as e:
         click.echo(f"[freeze-links] WARNING: Could not detect link parents for '{pdb_path.name}': {e}", err=True)
         return []
@@ -306,12 +294,14 @@ def _load_two_endpoints(
     geoms = []
     for p in paths:
         g = geom_loader(p, coord_type=coord_type)
-        freeze = list(base_freeze)
+        cfg: Dict[str, Any] = {"freeze_atoms": list(base_freeze)}
         if auto_freeze_links and p.suffix.lower() == ".pdb":
             detected = _freeze_links_for_pdb(p)
-            if detected:
-                freeze = sorted(set(freeze).union(detected))
+            freeze = merge_freeze_atom_indices(cfg, detected)
+            if detected and freeze:
                 click.echo(f"[freeze-links] {p.name}: Freeze atoms (0-based): {','.join(map(str, freeze))}")
+        else:
+            freeze = merge_freeze_atom_indices(cfg)
         g.freeze_atoms = np.array(freeze, dtype=int)
         geoms.append(g)
     return geoms
@@ -328,12 +318,14 @@ def _load_structures(
     geoms: List[Any] = []
     for p in paths:
         g = geom_loader(p, coord_type=coord_type)
-        freeze = list(base_freeze)
+        cfg: Dict[str, Any] = {"freeze_atoms": list(base_freeze)}
         if auto_freeze_links and p.suffix.lower() == ".pdb":
             detected = _freeze_links_for_pdb(p)
-            if detected:
-                freeze = sorted(set(freeze).union(detected))
+            freeze = merge_freeze_atom_indices(cfg, detected)
+            if detected and freeze:
                 click.echo(f"[freeze-links] {p.name}: Freeze atoms (0-based): {','.join(map(str, freeze))}")
+        else:
+            freeze = merge_freeze_atom_indices(cfg)
         g.freeze_atoms = np.array(freeze, dtype=int)
         geoms.append(g)
     return geoms
@@ -1628,21 +1620,21 @@ def cli(
             search_cfg["max_nodes_segment"] = int(max_nodes)
 
         out_dir_path = Path(out_dir).resolve()
-        echo_geom = _format_geom_for_echo(geom_cfg)
+        echo_geom = format_geom_for_echo(geom_cfg)
         echo_calc = dict(calc_cfg)
         echo_gs   = dict(gs_cfg)
         echo_opt  = dict(opt_cfg)
         echo_opt["out_dir"] = str(out_dir_path)
 
-        click.echo(_pretty_block("geom", echo_geom))
-        click.echo(_pretty_block("calc", echo_calc))
-        click.echo(_pretty_block("gs",   echo_gs))
-        click.echo(_pretty_block("opt",  echo_opt))
-        click.echo(_pretty_block("sopt."+sopt_kind, sopt_cfg))
-        click.echo(_pretty_block("bond", bond_cfg))
-        click.echo(_pretty_block("search", search_cfg))
+        click.echo(pretty_block("geom", echo_geom))
+        click.echo(pretty_block("calc", echo_calc))
+        click.echo(pretty_block("gs",   echo_gs))
+        click.echo(pretty_block("opt",  echo_opt))
+        click.echo(pretty_block("sopt."+sopt_kind, sopt_cfg))
+        click.echo(pretty_block("bond", bond_cfg))
+        click.echo(pretty_block("search", search_cfg))
         # NEW: show align flag
-        click.echo(_pretty_block("run_flags", {"pre_opt": bool(pre_opt), "align": bool(align)}))
+        click.echo(pretty_block("run_flags", {"pre_opt": bool(pre_opt), "align": bool(align)}))
 
         # --------------------------
         # 2) Prepare inputs


### PR DESCRIPTION
## Summary
- centralize YAML pretty-printing and geometry echo helpers in utils to remove duplication across CLIs
- add a reusable freeze atom merging helper and apply it in optimization and scanning entry points
- update CLI modules to adopt the shared helpers while preserving existing behaviour

## Testing
- python -m compileall pdb2reaction

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913c7dfc9c8832dade90f88906eb980)