### PR TITLE
Normalize CLI documentation and comments

### DIFF
--- a/pdb2reaction/add_elem_info.py
+++ b/pdb2reaction/add_elem_info.py
@@ -1,21 +1,24 @@
 # pdb2reaction/add_elem_info.py
 
 """
-Add or repair PDB element symbols (columns 77–78) in files that lack or have incomplete
-element fields.
+Add or repair PDB element symbols (columns 77–78) in files that lack or have
+incomplete element fields.
 
-- Reads a PDB with Biopython, sets `atom.element`, then writes with `PDBIO`.
-- Infers elements using both atom names and residue names (protein / nucleic acid / water / ions).
-- If no output path is given, the input file is overwritten in place.
-- NEW: Atoms that already have an element field in the input are left unchanged unless
-  `--overwrite` is specified.
+- Parse the input PDB with Biopython, assign ``atom.element``, and write via ``PDBIO``.
+- Infer elements using atom names and residue context (protein, nucleic acid, water,
+  ions).
+- Overwrite the input file when no output path is provided.
+- Preserve existing element annotations unless ``--overwrite`` is specified.
 
-Usage:
-  # As a standalone script
-  python add_elem_info.py input.pdb [-o fixed.pdb] [--overwrite]
+Usage
+-----
+Standalone script::
 
-  # As a pdb2reaction subcommand
-  pdb2reaction add_elem_info -i input.pdb [-o fixed.pdb] [--overwrite]
+    python add_elem_info.py input.pdb [-o fixed.pdb] [--overwrite]
+
+As a pdb2reaction subcommand::
+
+    pdb2reaction add_elem_info -i input.pdb [-o fixed.pdb] [--overwrite]
 """
 from __future__ import annotations
 

--- a/pdb2reaction/extract.py
+++ b/pdb2reaction/extract.py
@@ -482,7 +482,7 @@ def find_substrate_by_idspec(complex_struct, spec: str) -> List[PDB.Residue.Resi
 
     return found
 
-# ---------- NEW: Residue‑name–based substrate selection ----------
+# ---------- Residue-name-based substrate selection ----------
 
 def find_substrate_by_resname(complex_struct, spec: str) -> List[PDB.Residue.Residue]:
     """

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -1460,7 +1460,7 @@ def _merge_final_and_write(final_images: List[Any],
     show_default=True,
     help="If False, skip initial single-structure optimizations of inputs."
 )
-# NEW: input alignment switch (default True)
+# Input alignment switch (default True)
 @click.option(
     "--align/--no-align",
     "align",
@@ -1633,7 +1633,7 @@ def cli(
         click.echo(pretty_block("sopt."+sopt_kind, sopt_cfg))
         click.echo(pretty_block("bond", bond_cfg))
         click.echo(pretty_block("search", search_cfg))
-        # NEW: show align flag
+        # Echo pre-optimization and alignment flags
         click.echo(pretty_block("run_flags", {"pre_opt": bool(pre_opt), "align": bool(align)}))
 
         # --------------------------
@@ -1671,7 +1671,7 @@ def cli(
         else:
             click.echo("[init] Skipping endpoint pre-optimization as requested by --pre-opt False.")
 
-        # NEW: Align all inputs to the first, freeze-guided, if requested
+        # Align all inputs to the first structure, guided by freeze constraints, when requested
         if align:
             try:
                 click.echo("\n=== Aligning all inputs to the first structure (freeze-guided scan + relaxation) ===\n")


### PR DESCRIPTION
## Summary
- rewrite the CLI usage docstrings in freq.py, ts_opt.py, all.py, and add_elem_info.py to provide consistent English guidance
- translate remaining non-English or "NEW" inline comments across ts_opt.py, freq.py, path_search.py, and extract.py
- remove editing notes while keeping script behaviour unchanged

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913d858fbd8832db7537d2f273dda5c)