### PR TITLE
Normalize docstring formatting

### DIFF
--- a/pdb2reaction/add_elem_info.py
+++ b/pdb2reaction/add_elem_info.py
@@ -201,7 +201,9 @@ def _normalize_symbol(s: str) -> Optional[str]:
     return None
 
 def _symbol_from_resname(resname: str) -> Optional[str]:
-    """Extract an element symbol from an ion residue name (e.g., CA, FE2, Cl-, YB2, IOD)."""
+    """
+    Extract an element symbol from an ion residue name (e.g., CA, FE2, Cl-, YB2, IOD).
+    """
     res = resname.strip()
     sym = _normalize_symbol(res)
     if sym is None and res.upper().startswith("IOD"):
@@ -337,7 +339,9 @@ def scan_existing_elements_by_serial(pdb_path: str) -> Set[int]:
     return serials_with_elem
 
 def _get_atom_serial(atom) -> Optional[int]:
-    """Safely obtain the serial number from a Biopython Atom, handling version differences."""
+    """
+    Safely obtain the serial number from a Biopython Atom, handling version differences.
+    """
     sn = getattr(atom, "serial_number", None)
     if sn is None and hasattr(atom, "get_serial_number"):
         try:
@@ -475,7 +479,9 @@ def main():
     help="Re-infer and overwrite element fields even if present (by default, existing values are preserved).",
 )
 def cli(in_pdb: Path, out_pdb: Optional[Path], overwrite: bool) -> None:
-    """Click wrapper to run via the `pdb2reaction add_elem_info` subcommand."""
+    """
+    Click wrapper to run via the `pdb2reaction add_elem_info` subcommand.
+    """
     try:
         assign_elements(str(in_pdb), (str(out_pdb) if out_pdb else None), overwrite=overwrite)
     except SystemExit as e:

--- a/pdb2reaction/align_freeze_atoms.py
+++ b/pdb2reaction/align_freeze_atoms.py
@@ -102,7 +102,9 @@ except Exception:
 # =============================================================================
 
 def kabsch_R_t(P: np.ndarray, Q: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
-    """Row-vector Kabsch: find R, t minimizing ||(Q @ R + t) - P|| for (N, 3)."""
+    """
+    Row-vector Kabsch: find R, t minimizing ||(Q @ R + t) - P|| for (N, 3).
+    """
     P = np.asarray(P, float)
     Q = np.asarray(Q, float)
     if P.shape != Q.shape or P.ndim != 2 or P.shape[1] != 3:
@@ -120,7 +122,9 @@ def kabsch_R_t(P: np.ndarray, Q: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
 
 
 def _rodrigues(axis_unit: np.ndarray, theta: float) -> np.ndarray:
-    """3×3 rotation matrix for a rotation of angle `theta` about `axis_unit`."""
+    """
+    3×3 rotation matrix for a rotation of angle `theta` about `axis_unit`.
+    """
     u = np.asarray(axis_unit, float)
     n = np.linalg.norm(u)
     if n < 1e-16:
@@ -164,7 +168,9 @@ def _rotation_align_vectors(a: np.ndarray, b: np.ndarray) -> np.ndarray:
 
 
 def _orth_proj_perp(u: np.ndarray) -> np.ndarray:
-    """3×3 projector onto the plane perpendicular to vector `u`."""
+    """
+    3×3 projector onto the plane perpendicular to vector `u`.
+    """
     u = np.asarray(u, float)
     n = np.linalg.norm(u)
     if n < 1e-16:
@@ -178,19 +184,25 @@ def _orth_proj_perp(u: np.ndarray) -> np.ndarray:
 # =============================================================================
 
 def _coords3d(geom) -> np.ndarray:
-    """Return (N, 3) coordinates in bohr (float)."""
+    """
+    Return (N, 3) coordinates in bohr (float).
+    """
     return np.array(geom.coords3d, float)
 
 
 def _rmsd(A: np.ndarray, B: np.ndarray) -> float:
-    """Compute RMSD in Å (inputs are in bohr; conversion is applied internally)."""
+    """
+    Compute RMSD in Å (inputs are in bohr; conversion is applied internally).
+    """
     A = np.asarray(A, float) * BOHR2ANG
     B = np.asarray(B, float) * BOHR2ANG
     return float(np.sqrt(np.mean(np.sum((A - B) ** 2, axis=1)))) if len(A) else float("nan")
 
 
 def _set_all_coords_disabling_freeze(geom, coords3d_bohr: np.ndarray) -> None:
-    """Temporarily clear `freeze_atoms`, set all coordinates (bohr), then restore."""
+    """
+    Temporarily clear `freeze_atoms`, set all coordinates (bohr), then restore.
+    """
     old = np.array(getattr(geom, "freeze_atoms", []), int)
     try:
         geom.freeze_atoms = np.array([], int)
@@ -201,7 +213,9 @@ def _set_all_coords_disabling_freeze(geom, coords3d_bohr: np.ndarray) -> None:
 
 def _attach_calc_if_needed(geom, shared_calc=None, *, charge=0, spin=1,
                            model="uma-s-1p1", device="auto") -> None:
-    """Attach UMA if no calculator is present; prefer `shared_calc` when provided."""
+    """
+    Attach UMA if no calculator is present; prefer `shared_calc` when provided.
+    """
     try:
         has_calc = getattr(geom, "calculator", None) is not None
     except Exception:

--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -170,7 +170,9 @@ def _round_charge_with_note(q: float) -> int:
 # ---------- Post-processing helpers (minimal, reuse internals) ----------
 
 def _read_summary(summary_yaml: Path) -> List[Dict[str, Any]]:
-    """Read path_search/summary.yaml and return segments list (empty if not found)."""
+    """
+    Read path_search/summary.yaml and return segments list (empty if not found).
+    """
     try:
         if not summary_yaml.exists():
             return []
@@ -215,13 +217,17 @@ def _pdb_models_to_coords_and_elems(pdb_path: Path) -> Tuple[List[np.ndarray], L
 def _geom_from_angstrom(elems: Sequence[str],
                         coords_ang: np.ndarray,
                         freeze_atoms: Sequence[int]) -> Any:
-    """Create a Geometry from Å coordinates using _path_search._new_geom_from_coords (expects Bohr)."""
+    """
+    Create a Geometry from Å coordinates using _path_search._new_geom_from_coords (expects Bohr).
+    """
     coords_bohr = np.asarray(coords_ang, dtype=float) / BOHR2ANG
     return _path_search._new_geom_from_coords(elems, coords_bohr, coord_type="cart", freeze_atoms=freeze_atoms)
 
 
 def _load_segment_end_geoms(seg_pdb: Path, freeze_atoms: Sequence[int]) -> Tuple[Any, Any]:
-    """Load first/last model as Geometries from a per-segment pocket PDB."""
+    """
+    Load first/last model as Geometries from a per-segment pocket PDB.
+    """
     coords_list, elems = _pdb_models_to_coords_and_elems(seg_pdb)
     gL = _geom_from_angstrom(elems, coords_list[0], freeze_atoms)
     gR = _geom_from_angstrom(elems, coords_list[-1], freeze_atoms)
@@ -456,7 +462,9 @@ def _write_segment_energy_diagram(prefix: Path,
                                   labels: List[str],
                                   energies_eh: List[float],
                                   title_note: str) -> None:
-    """Write energy diagram (HTML + PNG) using utils.build_energy_diagram."""
+    """
+    Write energy diagram (HTML + PNG) using utils.build_energy_diagram.
+    """
     if not energies_eh:
         return
     e0 = energies_eh[0]
@@ -485,7 +493,9 @@ def _run_freq_for_state(pdb_path: Path,
                         out_dir: Path,
                         args_yaml: Optional[Path],
                         freeze_links: bool) -> Dict[str, Any]:
-    """Run freq CLI; return parsed thermo dict (may be empty)."""
+    """
+    Run freq CLI; return parsed thermo dict (may be empty).
+    """
     fdir = out_dir
     _ensure_dir(fdir)
     args = [
@@ -525,7 +535,9 @@ def _run_dft_for_state(pdb_path: Path,
                        out_dir: Path,
                        args_yaml: Optional[Path],
                        func_basis: str = "wb97x-v/def2-tzvp") -> Dict[str, Any]:
-    """Run dft CLI; return parsed result.yaml dict (may be empty)."""
+    """
+    Run dft CLI; return parsed result.yaml dict (may be empty).
+    """
     ddir = out_dir
     _ensure_dir(ddir)
     args = [

--- a/pdb2reaction/bond_changes.py
+++ b/pdb2reaction/bond_changes.py
@@ -181,7 +181,9 @@ def _bond_str(i: int, j: int, elems: List[str], one_based: bool = True) -> str:
 
 
 def summarize_changes(geom, result: BondChangeResult, one_based: bool = True) -> str:
-    """List bond formations and dissociations and report bond-length changes in Å."""
+    """
+    List bond formations and dissociations and report bond-length changes in Å.
+    """
     elems = [a.capitalize() for a in geom.atoms]
     lines: List[str] = []
 

--- a/pdb2reaction/extract.py
+++ b/pdb2reaction/extract.py
@@ -285,7 +285,9 @@ ResidueKey = Tuple[str, str, int, str, str]
 # ---------------------------------------------------------------------
 
 def str2bool(v: str) -> bool:
-    """Return a boolean for common truthy strings."""
+    """
+    Return a boolean for common truthy strings.
+    """
     if isinstance(v, bool):
         return v
     return v.lower() in {"true", "1", "yes", "y"}
@@ -370,7 +372,9 @@ def parse_args() -> argparse.Namespace:
 
 
 def load_structure(path: str, name: str) -> PDB.Structure.Structure:
-    """Load a PDB file into a Biopython Structure object."""
+    """
+    Load a PDB file into a Biopython Structure object.
+    """
     parser = PDB.PDBParser(QUIET=True)
     return parser.get_structure(name, path)
 
@@ -380,7 +384,9 @@ def load_structure(path: str, name: str) -> PDB.Structure.Structure:
 # ---------------------------------------------------------------------
 
 def _fmt_res_id(res: PDB.Residue.Residue) -> str:
-    """Return a compact residue tag like 'A:123A SER' or '123 SER'."""
+    """
+    Return a compact residue tag like 'A:123A SER' or '123 SER'.
+    """
     chain = res.get_parent().id or ""
     het, resseq, icode = res.id
     icode_txt = "" if icode == " " else icode
@@ -389,7 +395,9 @@ def _fmt_res_id(res: PDB.Residue.Residue) -> str:
 
 
 def _fmt_fid(structure, fid: Tuple) -> str:
-    """Format a full-id into a human-friendly residue tag."""
+    """
+    Format a full-id into a human-friendly residue tag.
+    """
     res: PDB.Residue.Residue = structure[fid[1]][fid[2]].child_dict[fid[3]]
     return _fmt_res_id(res)
 
@@ -400,7 +408,9 @@ def _fmt_fid(structure, fid: Tuple) -> str:
 
 def is_exact_match(lig_atoms: Dict[str, PDB.Vector.Vector],
                    cand: PDB.Residue.Residue) -> bool:
-    """Return True if candidate residue matches ligand atom names and positions within EXACT_EPS."""
+    """
+    Return True if candidate residue matches ligand atom names and positions within EXACT_EPS.
+    """
     for name, vec in lig_atoms.items():
         if name not in cand:
             return False
@@ -410,7 +420,9 @@ def is_exact_match(lig_atoms: Dict[str, PDB.Vector.Vector],
 
 
 def find_substrate_residues(complex_struct, substrate_struct) -> List[PDB.Residue.Residue]:
-    """Find substrate residues in the complex by **exact coordinate match** to a substrate PDB."""
+    """
+    Find substrate residues in the complex by **exact coordinate match** to a substrate PDB.
+    """
     substrate_res_list = list(substrate_struct.get_residues())
     matched: List[PDB.Residue.Residue] = []
     for lig in substrate_res_list:
@@ -444,7 +456,9 @@ _RES_TOKEN_RE = re.compile(r"""
 """, re.VERBOSE)
 
 def _parse_res_tokens(spec: str) -> List[Tuple[str | None, int, str | None]]:
-    """Parse a residue specification string into (chain, resseq, icode) tuples."""
+    """
+    Parse a residue specification string into (chain, resseq, icode) tuples.
+    """
     if not spec or not spec.strip():
         raise ValueError("Empty -c/--center specification.")
     tokens = [t.strip() for t in re.split(r"[,\s]+", spec) if t.strip()]
@@ -540,7 +554,9 @@ def find_substrate_by_resname(complex_struct, spec: str) -> List[PDB.Residue.Res
 
 
 def resolve_substrate_residues(complex_struct, center_spec: str) -> List[PDB.Residue.Residue]:
-    """Determine substrate residues from a PDB path, residue-ID list, or residue-name list."""
+    """
+    Determine substrate residues from a PDB path, residue-ID list, or residue-name list.
+    """
     if os.path.exists(center_spec):
         substrate_struct = load_structure(center_spec, "substrate")
         return find_substrate_residues(complex_struct, substrate_struct)
@@ -657,7 +673,9 @@ def select_residues(complex_struct,
 
 def augment_disulfides(structure, selected_ids: Set[Tuple],
                        cutoff: float = DISULFIDE_CUTOFF):
-    """Include Cys–Cys disulfide partners if either residue is selected (SG–SG ≤ cutoff)."""
+    """
+    Include Cys–Cys disulfide partners if either residue is selected (SG–SG ≤ cutoff).
+    """
     sg_atoms = [r["SG"] for r in structure.get_residues()
                 if r.get_resname() in {"CYS", "CYX"} and "SG" in r]
 
@@ -799,7 +817,9 @@ def augment_backbone_contact_neighbors(structure,
 # ---------------------------------------------------------------------
 
 def continuous_segments(sorted_ids: List[Tuple]):
-    """(Kept for compatibility; unused in TER-aware segmentation below.)"""
+    """
+    (Kept for compatibility; unused in TER-aware segmentation below.)
+    """
     segs, cur, prev = [], [], None
     for fid in sorted_ids:
         idx = fid[3][1]
@@ -966,11 +986,15 @@ def mark_atoms_to_skip(structure, selected_ids: Set[Tuple], substrate_ids: Set[T
 
 
 def _atom_present_in_output(res: PDB.Residue.Residue, name: str, skip_set: Set[str]) -> bool:
-    """True if the atom exists originally AND is not marked for deletion."""
+    """
+    True if the atom exists originally AND is not marked for deletion.
+    """
     return (name in res) and (name not in skip_set)
 
 def _atom_removed_by_truncation(res: PDB.Residue.Residue, name: str, skip_set: Set[str]) -> bool:
-    """True if the atom exists originally AND is marked for deletion."""
+    """
+    True if the atom exists originally AND is marked for deletion.
+    """
     return (name in res) and (name in skip_set)
 
 def compute_linkH_atoms(structure,
@@ -1029,7 +1053,9 @@ def compute_linkH_atoms(structure,
 
 
 def _max_serial_from_pdb_text(pdb_text: str) -> int:
-    """Find the maximum atom serial number in PDB text."""
+    """
+    Find the maximum atom serial number in PDB text.
+    """
     max_serial = 0
     for line in pdb_text.splitlines():
         if line.startswith("ATOM") or line.startswith("HETATM"):
@@ -1080,7 +1106,9 @@ def _format_linkH_block(link_coords: List[Tuple[float, float, float]],
 # ---------------------------------------------------------------------
 
 def _sorted_fids_by_file_order(structure, fids: Iterable[Tuple]) -> List[Tuple]:
-    """Sort full-ids by file order using a residue index map."""
+    """
+    Sort full-ids by file order using a residue index map.
+    """
     order: Dict[Tuple, int] = {}
     idx = 0
     for model in structure:
@@ -1091,14 +1119,18 @@ def _sorted_fids_by_file_order(structure, fids: Iterable[Tuple]) -> List[Tuple]:
     return sorted(set(fids), key=lambda fid: order.get(fid, 10**12))
 
 def _residue_key_from_res(res: PDB.Residue.Residue) -> ResidueKey:
-    """Build a cross-structure residue key from a residue."""
+    """
+    Build a cross-structure residue key from a residue.
+    """
     chain_id = res.get_parent().id
     hetflag, resseq, icode = res.id
     icode_str = icode if icode != " " else ""
     return (chain_id, hetflag, int(resseq), icode_str, res.get_resname())
 
 def _residue_key_from_fid(structure, fid: Tuple) -> ResidueKey:
-    """Build a cross-structure residue key from a full-id."""
+    """
+    Build a cross-structure residue key from a full-id.
+    """
     res = structure[fid[1]][fid[2]].child_dict[fid[3]]
     return _residue_key_from_res(res)
 
@@ -1259,7 +1291,9 @@ def compute_charge_summary(structure,
 
 def log_charge_summary(prefix: str,
                        summary: Dict[str, Any]):
-    """Emit concise charge summary logs."""
+    """
+    Emit concise charge summary logs.
+    """
     total = summary["total_charge"]
     protein = summary["protein_charge"]
     ligand = summary.get("ligand_total_charge", 0.0)
@@ -1292,7 +1326,9 @@ def log_charge_summary(prefix: str,
 # ==============================================================================
 
 def _build_key_maps(structure) -> Tuple[Dict[ResidueKey, Tuple], Dict[Tuple, ResidueKey]]:
-    """Create maps between ResidueKey and full-id for a structure."""
+    """
+    Create maps between ResidueKey and full-id for a structure.
+    """
     key2fid: Dict[ResidueKey, Tuple] = {}
     fid2key: Dict[Tuple, ResidueKey] = {}
     for model in structure:
@@ -1305,7 +1341,9 @@ def _build_key_maps(structure) -> Tuple[Dict[ResidueKey, Tuple], Dict[Tuple, Res
     return key2fid, fid2key
 
 def _keys_to_fids(structure, keys: Iterable[ResidueKey]) -> Set[Tuple]:
-    """Translate a set of ResidueKeys into full-ids for this structure."""
+    """
+    Translate a set of ResidueKeys into full-ids for this structure.
+    """
     key2fid, _ = _build_key_maps(structure)
     fids: Set[Tuple] = set()
     missing: List[ResidueKey] = []
@@ -1320,7 +1358,9 @@ def _keys_to_fids(structure, keys: Iterable[ResidueKey]) -> Set[Tuple]:
     return fids
 
 def _fids_to_keys(structure, fids: Iterable[Tuple]) -> Set[ResidueKey]:
-    """Translate a set of full-ids into ResidueKeys."""
+    """
+    Translate a set of full-ids into ResidueKeys.
+    """
     return {_residue_key_from_fid(structure, fid) for fid in fids}
 
 def _substrate_residues_for_structs(structs: List[PDB.Structure.Structure],
@@ -1363,7 +1403,9 @@ def _substrate_residues_for_structs(structs: List[PDB.Structure.Structure],
 
 def _disulfide_partner_keys(structure, candidate_keys: Set[ResidueKey],
                             cutoff: float = DISULFIDE_CUTOFF) -> Set[ResidueKey]:
-    """Return ResidueKeys of disulfide partners to include for any selected CYS/CYX."""
+    """
+    Return ResidueKeys of disulfide partners to include for any selected CYS/CYX.
+    """
     key2fid, _ = _build_key_maps(structure)
     sg_atoms: List[PDB.Atom.Atom] = []
     res_of_atom: Dict[PDB.Atom.Atom, ResidueKey] = {}
@@ -1387,7 +1429,9 @@ def _disulfide_partner_keys(structure, candidate_keys: Set[ResidueKey],
     return add
 
 def _assert_atom_ordering_identical(structs: List[PDB.Structure.Structure]):
-    """Ensure the same atom count and ordering across all input structures."""
+    """
+    Ensure the same atom count and ordering across all input structures.
+    """
     def signature(st: PDB.Structure.Structure) -> List[str]:
         sig: List[str] = []
         for model in st:
@@ -1416,7 +1460,9 @@ def _assert_atom_ordering_identical(structs: List[PDB.Structure.Structure]):
 
 
 def _strip_trailing_END(text: str) -> str:
-    """Remove trailing 'END' lines and ensure a final newline."""
+    """
+    Remove trailing 'END' lines and ensure a final newline.
+    """
     lines = [ln for ln in text.splitlines() if ln.strip() != "END"]
     out = "\n".join(lines)
     if not out.endswith("\n"):
@@ -1684,7 +1730,9 @@ def extract_multi(args: argparse.Namespace, api=False) -> Dict[str, Any]:
 #   PDB writer helper
 # ---------------------------------------------------------------------
 class AS_Select(PDB.Select):
-    """Biopython Select subclass that filters residues/atoms according to skip map."""
+    """
+    Biopython Select subclass that filters residues/atoms according to skip map.
+    """
     def __init__(self, selected_ids: Set[Tuple], skip_map: Dict[Tuple, Set[str]]):
         self.ids = selected_ids
         self.skip = skip_map

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -113,7 +113,9 @@ def _torch_device(auto: str = "auto") -> torch.device:
 
 def _build_tr_basis(coords_bohr_t: torch.Tensor,
                     masses_au_t: torch.Tensor) -> torch.Tensor:
-    """Mass-weighted translation/rotation basis (Tx, Ty, Tz, Rx, Ry, Rz), shape (3N, r<=6)."""
+    """
+    Mass-weighted translation/rotation basis (Tx, Ty, Tz, Rx, Ry, Rz), shape (3N, r<=6).
+    """
     device, dtype = coords_bohr_t.device, coords_bohr_t.dtype
     N = coords_bohr_t.shape[0]
     m_au = masses_au_t.to(dtype=dtype, device=device)
@@ -135,7 +137,9 @@ def _build_tr_basis(coords_bohr_t: torch.Tensor,
 def _tr_orthonormal_basis(coords_bohr_t: torch.Tensor,
                           masses_au_t: torch.Tensor,
                           rtol: float = 1e-12) -> Tuple[torch.Tensor, int]:
-    """Orthonormalize TR basis in mass-weighted space by SVD. Returns (Q, rank)."""
+    """
+    Orthonormalize TR basis in mass-weighted space by SVD. Returns (Q, rank).
+    """
     B = _build_tr_basis(coords_bohr_t, masses_au_t)
     U, S, Vh = torch.linalg.svd(B, full_matrices=False)
     r = int((S > rtol * S.max()).sum().item())
@@ -192,7 +196,9 @@ def _mw_projected_hessian(H_t: torch.Tensor,
 # ---- PHVA helper: mass-weighted Hessian without TR projection (for active subspace) ----
 def _mass_weighted_hessian(H_t: torch.Tensor,
                            masses_au_t: torch.Tensor) -> torch.Tensor:
-    """Return Hmw = M^{-1/2} H M^{-1/2} (no symmetrization/TR projection; in-place)."""
+    """
+    Return Hmw = M^{-1/2} H M^{-1/2} (no symmetrization/TR projection; in-place).
+    """
     dtype, device = H_t.dtype, H_t.device
     with torch.no_grad():
         masses_amu_t = (masses_au_t / AMU2AU).to(dtype=dtype, device=device)
@@ -377,7 +383,9 @@ def _frequencies_cm_and_modes(H_t: torch.Tensor,
 
 def _mw_mode_to_cart(mode_mw_3N_t: torch.Tensor,
                      masses_au_t: torch.Tensor) -> np.ndarray:
-    """Convert one mass-weighted eigenvector (3N,) to Cartesian (3N,) and L2-normalize."""
+    """
+    Convert one mass-weighted eigenvector (3N,) to Cartesian (3N,) and L2-normalize.
+    """
     with torch.no_grad():
         masses_amu_t = (masses_au_t / AMU2AU).to(dtype=mode_mw_3N_t.dtype, device=mode_mw_3N_t.device)
         m3 = torch.repeat_interleave(masses_amu_t, 3)
@@ -389,7 +397,9 @@ def _mw_mode_to_cart(mode_mw_3N_t: torch.Tensor,
 
 
 def _calc_full_hessian_torch(geom, uma_kwargs: dict, device: torch.device) -> torch.Tensor:
-    """UMA calculator producing Hessian as torch.Tensor in Hartree/Bohr^2 (3N or 3N_act square)."""
+    """
+    UMA calculator producing Hessian as torch.Tensor in Hartree/Bohr^2 (3N or 3N_act square).
+    """
     kw = dict(uma_kwargs or {})
     # Ensure torch tensor output & honor hessian mode / freeze / partial-return flags from cfg
     kw["out_hess_torch"] = True
@@ -399,7 +409,9 @@ def _calc_full_hessian_torch(geom, uma_kwargs: dict, device: torch.device) -> to
 
 
 def _calc_energy(geom, uma_kwargs: dict) -> float:
-    """Compute electronic energy (Hartree) from UMA calculator."""
+    """
+    Compute electronic energy (Hartree) from UMA calculator.
+    """
     calc = uma_pysis(out_hess_torch=False, **uma_kwargs)
     geom.set_calculator(calc)
     E = float(geom.energy)

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -267,7 +267,9 @@ def _maybe_convert_outputs_to_pdb(
     get_trj_fn,
     final_xyz_path: Path,
 ) -> None:
-    """If the input is a PDB, convert outputs (final_geometry.xyz and, if dump, optimization.trj) to PDB."""
+    """
+    If the input is a PDB, convert outputs (final_geometry.xyz and, if dump, optimization.trj) to PDB.
+    """
     if input_path.suffix.lower() != ".pdb":
         return
 
@@ -468,7 +470,9 @@ def cli(
 
 # Avoid shadowing the click option name `freeze_links` above
 def freeze_links_helper(pdb_path: Path):
-    """Small shim to keep the intent readable."""
+    """
+    Small shim to keep the intent readable.
+    """
     return freeze_links(pdb_path)
 
 

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -137,7 +137,9 @@ OPT_KW: Dict[str, Any] = {
 }
 
 def _freeze_links_for_pdb(pdb_path: Path) -> Sequence[int]:
-    """Detect the parent atoms of link hydrogens in a PDB and return 0‑based indices."""
+    """
+    Detect the parent atoms of link hydrogens in a PDB and return 0‑based indices.
+    """
     try:
         return detect_freeze_links(pdb_path)
     except Exception as e:
@@ -151,7 +153,9 @@ def _load_two_endpoints(
     base_freeze: Sequence[int],
     auto_freeze_links: bool,
 ) -> Sequence:
-    """Load the two endpoint structures and set `freeze_atoms` as needed."""
+    """
+    Load the two endpoint structures and set `freeze_atoms` as needed.
+    """
     geoms = []
     for p in paths:
         g = geom_loader(p, coord_type=coord_type)
@@ -444,7 +448,9 @@ def cli(
 
 
 def freeze_links_helper(pdb_path: Path):
-    """Expose freeze_links for external callers/tests."""
+    """
+    Expose freeze_links for external callers/tests.
+    """
     return freeze_links(pdb_path)
 
 

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -277,7 +277,9 @@ SEARCH_KW: Dict[str, Any] = {
 }
 
 def _freeze_links_for_pdb(pdb_path: Path) -> Sequence[int]:
-    """Detect parent atoms of link hydrogens in a PDB; return 0‑based indices. Silent on failure."""
+    """
+    Detect parent atoms of link hydrogens in a PDB; return 0‑based indices. Silent on failure.
+    """
     try:
         return detect_freeze_links(pdb_path)
     except Exception as e:
@@ -291,7 +293,9 @@ def _load_two_endpoints(
     base_freeze: Sequence[int],
     auto_freeze_links: bool,
 ) -> Sequence:
-    """Load two or more geometries and assign `freeze_atoms`; return pysisyphus geometries."""
+    """
+    Load two or more geometries and assign `freeze_atoms`; return pysisyphus geometries.
+    """
     geoms = []
     for p in paths:
         g = geom_loader(p, coord_type=coord_type)
@@ -315,7 +319,9 @@ def _load_structures(
     base_freeze: Sequence[int],
     auto_freeze_links: bool,
 ) -> List[Any]:
-    """Load multiple geometries and assign `freeze_atoms`; return a list of geometries."""
+    """
+    Load multiple geometries and assign `freeze_atoms`; return a list of geometries.
+    """
     geoms: List[Any] = []
     for p in paths:
         g = geom_loader(p, coord_type=coord_type)
@@ -333,7 +339,9 @@ def _load_structures(
 
 
 def _ensure_calc_on_geom(g, calc) -> None:
-    """Attach a pysisyphus Calculator to a Geometry (overwrite if necessary)."""
+    """
+    Attach a pysisyphus Calculator to a Geometry (overwrite if necessary).
+    """
     try:
         g.set_calculator(calc)
     except Exception:
@@ -341,7 +349,9 @@ def _ensure_calc_on_geom(g, calc) -> None:
 
 
 def _write_xyz_trj_with_energy(images: Sequence, energies: Sequence[float], path: Path) -> None:
-    """Write an XYZ `.trj` with the energy on line 2 of each block."""
+    """
+    Write an XYZ `.trj` with the energy on line 2 of each block.
+    """
     blocks: List[str] = []
     E = np.array(energies, dtype=float)
     for geom, e in zip(images, E):
@@ -390,12 +400,16 @@ def _kabsch_rmsd(A: np.ndarray, B: np.ndarray, align: bool = True, indices: Opti
 
 
 def _rmsd_between(ga, gb, align: bool = True, indices: Optional[Sequence[int]] = None) -> float:
-    """RMSD between two pysisyphus Geometries (no alignment; optional subset selection)."""
+    """
+    RMSD between two pysisyphus Geometries (no alignment; optional subset selection).
+    """
     return _kabsch_rmsd(np.array(ga.coords3d), np.array(gb.coords3d), align=False, indices=indices)
 
 
 def _has_bond_change(x, y, bond_cfg: Dict[str, Any]) -> Tuple[bool, str]:
-    """Return for covalent bonds forming/breaking between `x` and `y`."""
+    """
+    Return for covalent bonds forming/breaking between `x` and `y`.
+    """
     res = compare_structures(
         x, y,
         device=bond_cfg.get("device", "cuda"),
@@ -412,7 +426,9 @@ def _has_bond_change(x, y, bond_cfg: Dict[str, Any]) -> Tuple[bool, str]:
 # ---------- Minimal GS configuration helper ----------
 
 def _gs_cfg_with_overrides(base: Dict[str, Any], **overrides: Any) -> Dict[str, Any]:
-    """Shallow copy of a GS config with specified overrides."""
+    """
+    Shallow copy of a GS config with specified overrides.
+    """
     cfg = dict(base)
     for k, v in overrides.items():
         cfg[k] = v
@@ -424,7 +440,9 @@ def _gs_cfg_with_overrides(base: Dict[str, Any], **overrides: Any) -> Dict[str, 
 # -----------------------------------------------
 
 def _max_displacement_between(ga, gb, align: bool = True, indices: Optional[Sequence[int]] = None) -> float:
-    """Maximum per‑atom displacement (Å) between two structures (no alignment)."""
+    """
+    Maximum per‑atom displacement (Å) between two structures (no alignment).
+    """
     A = np.asarray(ga.coords3d, dtype=float)
     B = np.asarray(gb.coords3d, dtype=float)
     if A.shape != B.shape or A.shape[1] != 3:
@@ -434,7 +452,9 @@ def _max_displacement_between(ga, gb, align: bool = True, indices: Optional[Sequ
 
 
 def _new_geom_from_coords(atoms: Sequence[str], coords: np.ndarray, coord_type: str, freeze_atoms: Sequence[int]) -> Any:
-    """Create a pysisyphus Geometry from Bohr coords via temporary XYZ; attach `freeze_atoms`."""
+    """
+    Create a pysisyphus Geometry from Bohr coords via temporary XYZ; attach `freeze_atoms`.
+    """
     lines = [str(len(atoms)), ""]
     coords_ang = np.asarray(coords, dtype=float) * BOHR2ANG
     for sym, (x, y, z) in zip(atoms, coords_ang):
@@ -477,7 +497,9 @@ def _make_linear_interpolations(gL, gR, n_internal: int) -> List[Any]:
 
 
 def _energy_of(g) -> float:
-    """Return the energy (Hartree) of a Geometry (ensures calculator is attached)."""
+    """
+    Return the energy (Hartree) of a Geometry (ensures calculator is attached).
+    """
     _ensure_calc_on_geom(g, getattr(g, "calculator", None))
     return float(g.energy)
 
@@ -485,7 +507,9 @@ def _energy_of(g) -> float:
 # ---- Segment/bridge tagging helpers ----
 
 def _tag_images(images: Sequence[Any], **attrs: Any) -> None:
-    """Attach arbitrary attributes to Geometry images."""
+    """
+    Attach arbitrary attributes to Geometry images.
+    """
     for im in images:
         for k, v in attrs.items():
             try:
@@ -495,7 +519,9 @@ def _tag_images(images: Sequence[Any], **attrs: Any) -> None:
 
 
 def _segment_base_id(tag: str) -> str:
-    """Extract base id 'seg_XXX' from a tag like 'seg_000_refine'; fallback to `tag` or 'seg'."""
+    """
+    Extract base id 'seg_XXX' from a tag like 'seg_000_refine'; fallback to `tag` or 'seg'.
+    """
     m = re.search(r"(seg_\d{3})", tag or "")
     return m.group(1) if m else (tag or "seg")
 
@@ -528,7 +554,9 @@ def _run_gsm_between(
     tag: str,
     ref_pdb_path: Optional[Path],  # reference PDB for conversion
 ) -> GSMResult:
-    """Run GSM between `gA`–`gB`, save segment outputs, and return images/energies/HEI index."""
+    """
+    Run GSM between `gA`–`gB`, save segment outputs, and return images/energies/HEI index.
+    """
     # Attach calculator to endpoints
     for g in (gA, gB):
         _ensure_calc_on_geom(g, shared_calc)
@@ -623,7 +651,9 @@ def _optimize_single(
     tag: str,
     ref_pdb_path: Optional[Path],  # for PDB conversion
 ):
-    """Run single‑structure optimization (LBFGS/RFO) and return the final Geometry."""
+    """
+    Run single‑structure optimization (LBFGS/RFO) and return the final Geometry.
+    """
     _ensure_calc_on_geom(g, shared_calc)
 
     seg_dir = out_dir / f"{tag}_{sopt_kind}_opt"
@@ -664,7 +694,9 @@ def _refine_between(
     tag: str,
     ref_pdb_path: Optional[Path],  # for PDB conversion
 ) -> GSMResult:
-    """Refine End1–End2 via GSM (force climb=True)."""
+    """
+    Refine End1–End2 via GSM (force climb=True).
+    """
     gs_refine_cfg = _gs_cfg_with_overrides(gs_cfg, climb=True, climb_lanczos=True)
     return _run_gsm_between(gL, gR, shared_calc, gs_refine_cfg, opt_cfg, out_dir, tag=f"{tag}_refine", ref_pdb_path=ref_pdb_path)
 
@@ -680,7 +712,9 @@ def _maybe_bridge_segments(
     rmsd_thresh: float,
     ref_pdb_path: Optional[Path],  # for PDB conversion
 ) -> Optional[GSMResult]:
-    """Run a bridge GSM if two segment endpoints are farther than the threshold."""
+    """
+    Run a bridge GSM if two segment endpoints are farther than the threshold.
+    """
     rmsd = _rmsd_between(tail_g, head_g, align=False)
     if rmsd <= rmsd_thresh:
         return None
@@ -1094,7 +1128,9 @@ def _load_structures_and_chain_align(ref_paths: Sequence[Path]) -> Tuple[List[PD
 
 
 def _pocket_keys_from_pdb(pocket_pdb: Path) -> List[Tuple[str, str, str, str, str]]:
-    """Return atom identity keys for a pocket PDB file."""
+    """
+    Return atom identity keys for a pocket PDB file.
+    """
     parser = PDBParser(QUIET=True)
     st = parser.get_structure("pocket", str(pocket_pdb))
     keys: List[Tuple[str, str, str, str, str]] = []
@@ -1107,7 +1143,9 @@ def _pocket_keys_from_pdb(pocket_pdb: Path) -> List[Tuple[str, str, str, str, st
 
 def _write_model_block(structure: PDB.Structure.Structure,
                        remark_lines: List[str]) -> str:
-    """Render a single MODEL block (without 'MODEL/ENDMDL') with provided REMARK lines."""
+    """
+    Render a single MODEL block (without 'MODEL/ENDMDL') with provided REMARK lines.
+    """
     io = PDBIO()
     io.set_structure(structure)
     from io import StringIO
@@ -1121,7 +1159,9 @@ def _write_model_block(structure: PDB.Structure.Structure,
 
 
 def _chunk_remark_indices(indices: List[int], width: int = 60) -> List[str]:
-    """Wrap pocket atom indices into REMARK lines with limited width."""
+    """
+    Wrap pocket atom indices into REMARK lines with limited width.
+    """
     s = ",".join(map(str, indices))
     out: List[str] = []
     cur = ""
@@ -1256,7 +1296,9 @@ def _merge_final_and_write(final_images: List[Any],
                            ref_pdbs: Sequence[Path],
                            segments: List[SegmentReport],
                            out_dir: Path) -> None:
-    """Merge the entire pocket MEP into full templates (for all pairs) and write outputs."""
+    """
+    Merge the entire pocket MEP into full templates (for all pairs) and write outputs.
+    """
     # NOTE: In --align True mode, caller may pass a single ref PDB replicated per pair.
     if len(ref_pdbs) != len(pocket_inputs):
         raise click.BadParameter("--ref-pdb must match the number of --input after preprocessing (caller should replicate the first ref for all pairs when --align True).")

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -298,7 +298,9 @@ def _parse_scan_lists(args: Sequence[str], one_based: bool) -> List[List[Tuple[i
 
 
 def _pair_distances(coords_ang: np.ndarray, pairs: Iterable[Tuple[int, int]]) -> List[float]:
-    """coords_ang: (N,3) in Å; returns a list of distances (Å) for the given pairs."""
+    """
+    coords_ang: (N,3) in Å; returns a list of distances (Å) for the given pairs.
+    """
     dists: List[float] = []
     for i, j in pairs:
         v = coords_ang[i] - coords_ang[j]
@@ -338,7 +340,9 @@ def _schedule_for_stage(
 # --------------------------------------------------------------------------------------
 
 def _has_bond_change(x, y, bond_cfg: Dict[str, Any]) -> Tuple[bool, str]:
-    """Return for covalent bonds forming/breaking between `x` and `y`."""
+    """
+    Return for covalent bonds forming/breaking between `x` and `y`.
+    """
     res = compare_structures(
         x, y,
         device=bond_cfg.get("device", "cuda"),
@@ -411,7 +415,9 @@ class HarmonicBiasCalculator:
 
     # ---- bias core (coords in Bohr) ----
     def _bias_energy_forces_bohr(self, coords_bohr: np.ndarray) -> Tuple[float, np.ndarray]:
-        """coords_bohr: (N,3) in Bohr; returns (E_bias [Hartree], F_bias_flat [Hartree/Bohr])."""
+        """
+        coords_bohr: (N,3) in Bohr; returns (E_bias [Hartree], F_bias_flat [Hartree/Bohr]).
+        """
         coords = np.array(coords_bohr, dtype=float).reshape(-1, 3)  # (N,3)
         n = coords.shape[0]
         E_bias = 0.0
@@ -872,7 +878,9 @@ def cli(
         # 5) Final summary echo (human‑friendly)
         # ------------------------------------------------------------------
         def _echo_human_summary(_stages: List[Dict[str, Any]], _max_step_size: float) -> None:
-            """Print a readable end-of-run summary like the requested example."""
+            """
+            Print a readable end-of-run summary like the requested example.
+            """
             def _fmt_target_value(x: float) -> str:
                 # 2.600 -> "2.6", 1.500 -> "1.5"
                 s = f"{x:.3f}".rstrip("0").rstrip(".")

--- a/pdb2reaction/trj2fig.py
+++ b/pdb2reaction/trj2fig.py
@@ -84,7 +84,9 @@ MARKER_SIZE = 6        # marker size
 #  File helpers
 # ---------------------------------------------------------------------
 def read_energies_xyz(fname: Path | str) -> List[float]:
-    """Extract Hartree energies from the second-line comment of each XYZ frame."""
+    """
+    Extract Hartree energies from the second-line comment of each XYZ frame.
+    """
     energies: List[float] = []
     with open(fname, encoding="utf-8") as fh:
         while (hdr := fh.readline()):
@@ -196,7 +198,9 @@ def _axis_template() -> dict:
 
 
 def build_figure(delta_or_abs: Sequence[float], ylabel: str, reverse_x: bool) -> go.Figure:
-    """Build a Plotly figure without a title."""
+    """
+    Build a Plotly figure without a title.
+    """
     fig = go.Figure(
         go.Scatter(
             x=list(range(len(delta_or_abs)))),
@@ -234,7 +238,9 @@ def save_outputs(
     unit: str,
     is_delta: bool,
 ) -> None:
-    """Write all requested outputs."""
+    """
+    Write all requested outputs.
+    """
     for out in outs:
         ext = out.suffix.lower()
         if ext == ".csv":
@@ -261,7 +267,9 @@ def write_csv(
     unit: str,
     is_delta: bool,
 ) -> None:
-    """Save energies (hartree) and ΔE/E series to CSV."""
+    """
+    Save energies (hartree) and ΔE/E series to CSV.
+    """
     colname = (f"delta_{unit}" if is_delta else f"energy_{unit}")
     with out.open("w", newline="", encoding="utf-8") as fh:
         w = csv.writer(fh)

--- a/pdb2reaction/uma_pysis.py
+++ b/pdb2reaction/uma_pysis.py
@@ -98,7 +98,9 @@ _tdtype = torch.float32
 #                         UMA core wrapper
 # ===================================================================
 class UMAcore:
-    """Thin wrapper around fairchem-UMA predict_unit."""
+    """
+    Thin wrapper around fairchem-UMA predict_unit.
+    """
 
     def __init__(
         self,
@@ -142,14 +144,18 @@ class UMAcore:
 
     # ----------------------------------------------------------------
     def _model_backbone(self):
-        """Handle both plain and (D)DP-wrapped models."""
+        """
+        Handle both plain and (D)DP-wrapped models.
+        """
         mdl = self.predict.model
         mod = getattr(mdl, "module", mdl)
         return mod.backbone
 
     # ----------------------------------------------------------------
     def _ase_to_batch(self, atoms: Atoms):
-        """Convert ASE Atoms → UMA AtomicData (batched)."""
+        """
+        Convert ASE Atoms → UMA AtomicData (batched).
+        """
         backbone = self._model_backbone()
         default_max_neigh = getattr(backbone, "max_neighbors", None)
         default_radius    = getattr(backbone, "cutoff", None)
@@ -247,7 +253,9 @@ class UMAcore:
 #                    PySisyphus calculator class
 # ===================================================================
 class uma_pysis(Calculator):
-    """PySisyphus-compatible UMA calculator."""
+    """
+    PySisyphus-compatible UMA calculator.
+    """
 
     implemented_properties = ["energy", "forces", "hessian"]
 
@@ -486,7 +494,9 @@ class uma_pysis(Calculator):
 
 # ---------- CLI ----------------------------------------
 def run_pysis():
-    """Enable `uma_pysis input.yaml`."""
+    """
+    Enable `uma_pysis input.yaml`.
+    """
     run.CALC_DICT["uma_pysis"] = uma_pysis
     run.run()
 

--- a/pdb2reaction/utils.py
+++ b/pdb2reaction/utils.py
@@ -62,14 +62,18 @@ import plotly.graph_objs as go
 
 
 def pretty_block(title: str, content: Dict[str, Any]) -> str:
-    """Return a YAML-formatted block with an underlined title."""
+    """
+    Return a YAML-formatted block with an underlined title.
+    """
 
     body = yaml.safe_dump(content, sort_keys=False, allow_unicode=True).strip()
     return f"{title}\n" + "-" * len(title) + "\n" + (body if body else "(empty)") + "\n"
 
 
 def format_geom_for_echo(geom_cfg: Dict[str, Any]) -> Dict[str, Any]:
-    """Normalise geometry configuration for CLI echo output."""
+    """
+    Normalise geometry configuration for CLI echo output.
+    """
 
     g = dict(geom_cfg)
     freeze_atoms = g.get("freeze_atoms")
@@ -112,7 +116,9 @@ def merge_freeze_atom_indices(
 
 
 def deep_update(dst: Dict[str, Any], src: Optional[Dict[str, Any]]) -> Dict[str, Any]:
-    """Recursively update mapping *dst* with *src*, returning *dst*."""
+    """
+    Recursively update mapping *dst* with *src*, returning *dst*.
+    """
 
     for k, v in (src or {}).items():
         if isinstance(v, dict) and isinstance(dst.get(k), dict):
@@ -169,7 +175,9 @@ def apply_yaml_overrides(
 
 
 def load_yaml_dict(path: Optional[Path]) -> Dict[str, Any]:
-    """Load a YAML file whose root must be a mapping. Return an empty dict if *path* is None."""
+    """
+    Load a YAML file whose root must be a mapping. Return an empty dict if *path* is None.
+    """
 
     if not path:
         return {}


### PR DESCRIPTION
## Summary
- convert previously single-line docstrings across the package to the multi-line layout used in `ts_opt`
- ensure helper docstrings now include explicit summary sentences for readability

## Testing
- python -m compileall pdb2reaction

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915c16fa02c832dad19684bce563b7c)