### PR TITLE
Normalize module docstrings to ts_opt format

### DIFF
--- a/pdb2reaction/add_elem_info.py
+++ b/pdb2reaction/add_elem_info.py
@@ -1,16 +1,16 @@
 # pdb2reaction/add_elem_info.py
 
 """
-add_elem_info — Add/repair PDB element symbols (columns 77–78) using Biopython
+pdb2reaction add_elem_info — Add/repair PDB element symbols (columns 77–78) using Biopython
 ====================================================================
 
-Usage
+Usage (CLI)
 -----
-	pdb2reaction add_elem_info -i input.pdb [-o fixed.pdb] [--overwrite]
+    pdb2reaction add_elem_info -i input.pdb [-o fixed.pdb] [--overwrite]
 
 Examples::
-	pdb2reaction add_elem_info -i 1abc.pdb
-	pdb2reaction add_elem_info -i 1abc.pdb -o 1abc_fixed.pdb --overwrite
+    pdb2reaction add_elem_info -i 1abc.pdb
+    pdb2reaction add_elem_info -i 1abc.pdb -o 1abc_fixed.pdb --overwrite
 
 
 Description

--- a/pdb2reaction/align_freeze_atoms.py
+++ b/pdb2reaction/align_freeze_atoms.py
@@ -1,7 +1,7 @@
 # pdb2reaction/align_freeze_atoms.py
 
 """
-align_freeze_atoms — Rigid alignment and staged “scan + relaxation” utilities for pysisyphus Geometry objects
+pdb2reaction align_freeze_atoms — Rigid alignment and staged “scan + relaxation” utilities for pysisyphus Geometry objects
 ====================================================================
 
 Description

--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -1,10 +1,10 @@
 # pdb2reaction/all.py
 
 """
-all — Executes the entire workflow with a SINGLE command: Extract pockets → run MEP (recursive GSM) → merge to full systems, with optional TS optimization, pseudo‑IRC, thermochemistry, and DFT per reactive segment
+pdb2reaction all — Executes the entire workflow with a SINGLE command: Extract pockets → run MEP (recursive GSM) → merge to full systems, with optional TS optimization, pseudo‑IRC, thermochemistry, and DFT per reactive segment
 ====================================================================
 
-Usage
+Usage (CLI)
 -----
     pdb2reaction all -i R.pdb [I1.pdb ...] P.pdb -c <substrate-spec> [--ligand-charge <map-or-number>]
                       [--spin <2S+1>] [--freeze-links True|False] [--max-nodes N] [--max-cycles N]

--- a/pdb2reaction/bond_changes.py
+++ b/pdb2reaction/bond_changes.py
@@ -1,7 +1,7 @@
 # pdb2reaction/bond_changes.py
 
 """
-pdb2reaction.bond_changes — Bond-change detection and reporting utilities
+pdb2reaction bond_changes — Bond-change detection and reporting utilities
 ====================================================================
 
 Description

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -1,12 +1,14 @@
 # pdb2reaction/dft.py
 
 """
-dft — Single-point DFT (GPU4PySCF with CPU PySCF fallback)
+pdb2reaction dft — Single-point DFT (GPU4PySCF with CPU PySCF fallback)
 ====================================================================
 
-Usage (CLI; include -q/-s explicitly to avoid wrong electronic states)
+Usage (CLI)
 -----
     pdb2reaction dft -i INPUT -q CHARGE -s SPIN [--func-basis "FUNC/BASIS"] [--max-cycle N] [--conv-tol Eh] [--grid-level L] [--out-dir OUT_DIR] [--args-yaml YAML]
+
+    # Always include -q/-s explicitly to avoid wrong electronic states.
 
 Examples::
     pdb2reaction dft -i input.pdb -q 0 -s 1 --func-basis "wb97m-v/6-31g**"

--- a/pdb2reaction/extract.py
+++ b/pdb2reaction/extract.py
@@ -1,11 +1,13 @@
 # pdb2reaction/extract.py
 
 """
-extract — Automated binding‑pocket (active‑site) extractor
+pdb2reaction extract — Automated binding‑pocket (active‑site) extractor
 ====================================================================
 
-Usage (CLI input; include both minimal and full examples)
+Usage (CLI)
 -----
+    # Minimal and full examples shown below.
+
 Single structure:
     pdb2reaction extract -i complex.pdb -c <substrate_spec> [-o pocket.pdb]
                          [-r 2.6] [--radius-het2het 2.6]

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -1,10 +1,10 @@
 # pdb2reaction/freq.py
 
 """
-freq — Vibrational frequency analysis, mode export, and PHVA-based thermochemistry
+pdb2reaction freq — Vibrational frequency analysis, mode export, and PHVA-based thermochemistry
 ====================================================================
 
-Usage
+Usage (CLI)
 -----
     # Minimum (charge is effectively required to avoid wrong conditions)
     pdb2reaction freq -i INPUT.(pdb|xyz|trj) -q CHARGE

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -1,11 +1,12 @@
 # pdb2reaction/irc.py
 
 """
-irc — Concise CLI for IRC calculations with the EulerPC integrator
+pdb2reaction irc — Concise CLI for IRC calculations with the EulerPC integrator
 ====================================================================
 
-Usage (CLI; minimal and full examples)
+Usage (CLI)
 -----
+    # Minimal and full examples shown below.
     # Minimal (explicitly set charge/spin to avoid unintended conditions)
     pdb2reaction irc -i a.pdb -q 0 -s 1
 

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -1,16 +1,16 @@
 # pdb2reaction/opt.py
 
 """
-opt — Single-structure geometry optimization (LBFGS or RFO)
+pdb2reaction opt — Single-structure geometry optimization (LBFGS or RFO)
 ====================================================================
 
 Usage (CLI)
 -----
-	pdb2reaction opt -i INPUT -q CHARGE [-s SPIN] [--opt-mode {light|lbfgs|heavy|rfo}] [--freeze-links/--no-freeze-links] [--dump] [--out-dir DIR] [--max-cycles N] [--args-yaml FILE]
+    pdb2reaction opt -i INPUT -q CHARGE [-s SPIN] [--opt-mode {light|lbfgs|heavy|rfo}] [--freeze-links/--no-freeze-links] [--dump] [--out-dir DIR] [--max-cycles N] [--args-yaml FILE]
 
 Examples::
-	pdb2reaction opt -i input.pdb -q 0
-	pdb2reaction opt -i input.pdb -q 0 -s 1 --opt-mode rfo --dump --out-dir ./result_opt/ --args-yaml ./args.yaml
+    pdb2reaction opt -i input.pdb -q 0
+    pdb2reaction opt -i input.pdb -q 0 -s 1 --opt-mode rfo --dump --out-dir ./result_opt/ --args-yaml ./args.yaml
 
 Description
 -----

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -1,10 +1,10 @@
 # pdb2reaction/path_opt.py
 
 """
-path_opt — Minimum-energy path (MEP) optimization via the Growing String method (pysisyphus) with a UMA calculator
+pdb2reaction path_opt — Minimum-energy path (MEP) optimization via the Growing String method (pysisyphus) with a UMA calculator
 ====================================================================
 
-Usage
+Usage (CLI)
 -----
     pdb2reaction path_opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} \
         -q <charge> [-s <multiplicity>] [--freeze-links {True|False}] \

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -1,38 +1,38 @@
 # pdb2reaction/path_search.py
 
 """
-path-search — Recursive GSM segmentation to build a continuous multistep MEP
+pdb2reaction path_search — Recursive GSM segmentation to build a continuous multistep MEP
 ====================================================================
 
 Usage (CLI)
 -----
-	pdb2reaction path-search -i A.pdb B.pdb -q <charge> [options]
+    pdb2reaction path-search -i A.pdb B.pdb -q <charge> [options]
 
 Required-like:
-	-i/--input           Two or more structures in reaction order (repeatable or space‑separated after a single -i).
-	-q/--charge          Total system charge (integer).
+    -i/--input           Two or more structures in reaction order (repeatable or space‑separated after a single -i).
+    -q/--charge          Total system charge (integer).
 
 Recommended/common:
-	-s/--spin            Spin multiplicity (2S+1); default 1.
-	--sopt-mode          Single-structure optimizer: lbfgs|rfo|light|heavy; default lbfgs.
-	--max-nodes          Internal nodes for segment GSM; default 10.
-	--max-cycles         Max optimization cycles; default 1000.
-	--climb/--no-climb   Enable TS search for the first segment; default on.
-	--pre-opt/--no-pre-opt  Pre-optimize endpoints; default on.
-	--align/--no-align   Rigidly co‑align all inputs after pre‑opt; default on.
-	--args-yaml PATH     YAML with overrides (sections: geom, calc, gs, opt, sopt, bond, search).
-	--ref-pdb PATH [...] Full template PDB(s) for final merge (see Notes).
-	--out-dir PATH       Output directory; default ./result_path_search/
-	--dump               Save optimizer dumps; default off.
-	--freeze-links/--no-freeze-links  Freeze parents of link hydrogens for PDB input; default on.
+    -s/--spin            Spin multiplicity (2S+1); default 1.
+    --sopt-mode          Single-structure optimizer: lbfgs|rfo|light|heavy; default lbfgs.
+    --max-nodes          Internal nodes for segment GSM; default 10.
+    --max-cycles         Max optimization cycles; default 1000.
+    --climb/--no-climb   Enable TS search for the first segment; default on.
+    --pre-opt/--no-pre-opt  Pre-optimize endpoints; default on.
+    --align/--no-align   Rigidly co‑align all inputs after pre‑opt; default on.
+    --args-yaml PATH     YAML with overrides (sections: geom, calc, gs, opt, sopt, bond, search).
+    --ref-pdb PATH [...] Full template PDB(s) for final merge (see Notes).
+    --out-dir PATH       Output directory; default ./result_path_search/
+    --dump               Save optimizer dumps; default off.
+    --freeze-links/--no-freeze-links  Freeze parents of link hydrogens for PDB input; default on.
 
 Examples::
-	# Minimal (pocket-only MEP; writes mep.trj or mep.pdb if inputs are PDB)
-	pdb2reaction path-search -i reactant.pdb product.pdb -q 0
+    # Minimal (pocket-only MEP; writes mep.trj or mep.pdb if inputs are PDB)
+    pdb2reaction path-search -i reactant.pdb product.pdb -q 0
 
-	# Multistep with intermediates, YAML overrides, and PDB merge to a full system
-	pdb2reaction path-search -i R.pdb IM1.pdb IM2.pdb P.pdb -q -1 \
-	    --args-yaml params.yaml --ref-pdb holo_template.pdb --out-dir ./run_ps
+    # Multistep with intermediates, YAML overrides, and PDB merge to a full system
+    pdb2reaction path-search -i R.pdb IM1.pdb IM2.pdb P.pdb -q -1 \
+        --args-yaml params.yaml --ref-pdb holo_template.pdb --out-dir ./run_ps
 
 Description
 -----

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -1,41 +1,41 @@
 # pdb2reaction/scan.py
 
 """
-scan — Bond-length–driven staged scan with harmonic distance restraints and full relaxation (UMA only)
+pdb2reaction scan — Bond-length–driven staged scan with harmonic distance restraints and full relaxation (UMA only)
 ====================================================================
 
-Usage (CLI input; include practically necessary flags such as -q even if not strictly required)
+Usage (CLI)
 -----
-  # Minimal (define at least one stage)
-  pdb2reaction scan -i INPUT.{pdb,xyz,trj,...} -q CHARGE \
-    --scan-lists "[(I,J,TARGET_ANG)]"
+    # Minimal (define at least one stage)
+    pdb2reaction scan -i INPUT.{pdb,xyz,trj,...} -q CHARGE \
+        --scan-lists "[(I,J,TARGET_ANG)]"
 
-  # Full (repeat --scan-lists for multiple stages)
-  pdb2reaction scan -i INPUT.{pdb,xyz,trj,...} -q CHARGE \
-    -s SPIN \
-    --scan-lists "[(I,J,TARGET_ANG), ...]" [--scan-lists "..."]... \
-    [--one-based|--zero-based] \
-    --max-step-size FLOAT \
-    --bias-k FLOAT \
-    --relax-max-cycles INT \
-    --opt-mode {light,lbfgs,heavy,rfo} \
-    [--freeze-links/--no-freeze-links] \
-    [--dump/--no-dump] \
-    --out-dir PATH \
-    [--args-yaml FILE] \
-    [--preopt/--no-preopt] \
-    [--endopt/--no-endopt]
+    # Full (repeat --scan-lists for multiple stages)
+    pdb2reaction scan -i INPUT.{pdb,xyz,trj,...} -q CHARGE \
+        -s SPIN \
+        --scan-lists "[(I,J,TARGET_ANG), ...]" [--scan-lists "..."]... \
+        [--one-based|--zero-based] \
+        --max-step-size FLOAT \
+        --bias-k FLOAT \
+        --relax-max-cycles INT \
+        --opt-mode {light,lbfgs,heavy,rfo} \
+        [--freeze-links/--no-freeze-links] \
+        [--dump/--no-dump] \
+        --out-dir PATH \
+        [--args-yaml FILE] \
+        [--preopt/--no-preopt] \
+        [--endopt/--no-endopt]
 
 Examples::
-  # Single-stage, minimal inputs (PDB)
-  pdb2reaction scan -i input.pdb -q 0 --scan-lists "[(12,45,1.35)]"
+    # Single-stage, minimal inputs (PDB)
+    pdb2reaction scan -i input.pdb -q 0 --scan-lists "[(12,45,1.35)]"
 
-  # Two stages, LBFGS, dumping trajectories
-  pdb2reaction scan -i input.pdb -q 0 \
-    --scan-lists "[(12,45,1.35)]" \
-    --scan-lists "[(10,55,2.20),(23,34,1.80)]" \
-    --max-step-size 0.2 --dump True --out-dir ./result_scan/ --opt-mode lbfgs \
-    --preopt True --endopt True
+    # Two stages, LBFGS, dumping trajectories
+    pdb2reaction scan -i input.pdb -q 0 \
+        --scan-lists "[(12,45,1.35)]" \
+        --scan-lists "[(10,55,2.20),(23,34,1.80)]" \
+        --max-step-size 0.2 --dump True --out-dir ./result_scan/ --opt-mode lbfgs \
+        --preopt True --endopt True
 
 
 Description

--- a/pdb2reaction/trj2fig.py
+++ b/pdb2reaction/trj2fig.py
@@ -4,7 +4,7 @@
 pdb2reaction trj2fig — Energy-profile utility for XYZ trajectories
 ====================================================================
 
-Usage (CLI input; minimal and full command examples)
+Usage (CLI)
 -----
     Minimal:
         pdb2reaction trj2fig -i traj.xyz

--- a/pdb2reaction/uma_pysis.py
+++ b/pdb2reaction/uma_pysis.py
@@ -1,7 +1,7 @@
 # pdb2reaction/uma_pysis.py
 
 """
-uma_pysis — UMA calculator wrapper for PySisyphus
+pdb2reaction uma_pysis — UMA calculator wrapper for PySisyphus
 ====================================================================
 
 Description

--- a/pdb2reaction/utils.py
+++ b/pdb2reaction/utils.py
@@ -1,7 +1,7 @@
 # pdb2reaction/utils.py
 
 """
-pdb2reaction.utils — concise utilities for configuration, plotting, coordinates, and link-freezing
+pdb2reaction utils — concise utilities for configuration, plotting, coordinates, and link-freezing
 ====================================================================
 
 Description


### PR DESCRIPTION
## Summary
- update module docstrings to begin with the `pdb2reaction <module>` prefix for consistency
- align CLI documentation headers with the ts_opt style, using "Usage (CLI)" and uniform indentation across commands

## Testing
- Not run (docstring-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915c3b41760832dacef2b4bceb71566)