### PR TITLE
Standardize module docstring bullet formatting

### DIFF
--- a/pdb2reaction/align_freeze_atoms.py
+++ b/pdb2reaction/align_freeze_atoms.py
@@ -13,18 +13,18 @@ that moves the frozen atoms toward the reference in small steps while relaxing t
 All updates are applied in place on the mobile geometry.
 
 Provided functionality (concise):
-• kabsch_R_t(P, Q)
+- kabsch_R_t(P, Q)
     Row-vector Kabsch solver for two (N, 3) point sets. Returns (R, t) minimizing ||(Q @ R + t) − P||.
-• align_second_to_first_kabsch_inplace(g_ref, g_mob, *, verbose=True)
+- align_second_to_first_kabsch_inplace(g_ref, g_mob, *, verbose=True)
     Rigidly aligns `g_mob` to `g_ref` in place. Special cases:
-      – freeze_atoms length = 1: translate to match the anchor; restrict rotations about that anchor;
+      - freeze_atoms length = 1: translate to match the anchor; restrict rotations about that anchor;
         minimizes all-atom RMSD; RMSD reported on all atoms.
-      – freeze_atoms length = 2: align the axis defined by the two anchors; optimize rotation around
+      - freeze_atoms length = 2: align the axis defined by the two anchors; optimize rotation around
         that axis; RMSD reported on all atoms.
-      – otherwise: Kabsch on the union of `freeze_atoms` from both geometries (or all atoms if empty);
+      - otherwise: Kabsch on the union of `freeze_atoms` from both geometries (or all atoms if empty);
         apply the transform to all atoms; RMSD reported on the Kabsch selection.
     Returns: dict(before_A, after_A, n_used, mode) with RMSD in Å and mode ∈ {"one_anchor","two_anchor","kabsch"}.
-• scan_freeze_atoms_toward_target_inplace(
+- scan_freeze_atoms_toward_target_inplace(
       g_ref, g_mob, *, step_A=0.1, per_step_cycles=50, final_cycles=200, max_steps=1000,
       shared_calc=None, out_dir=Path("./result_align_refine/"), charge=0, spin=1,
       model="uma-s-1p1", device="auto", verbose=True)
@@ -32,13 +32,13 @@ Provided functionality (concise):
     are held fixed and the surroundings are relaxed with LBFGS. When the maximum remaining distance is
     below one step, enforce exact coincidence of the frozen atoms and run a finishing relaxation.
     Returns: dict(max_remaining_A, n_steps, converged).
-• align_and_refine_pair_inplace(
+- align_and_refine_pair_inplace(
       g_ref, g_mob, *, shared_calc=None, out_dir=Path("./result_align_refine/"),
       step_A=0.1, per_step_cycles=50, final_cycles=200, max_steps=1000,
       charge=0, spin=1, model="uma-s-1p1", device="auto", verbose=True)
     High-level pair API: (1) rigid alignment, then (2) scan + relaxation toward the reference.
     Returns: {"align": {...}, "scan": {...}}.
-• align_and_refine_sequence_inplace(
+- align_and_refine_sequence_inplace(
       geoms, *, shared_calc=None, out_dir=Path("./result_align_refine/"),
       step_A=0.1, per_step_cycles=1000, final_cycles=1000, max_steps=10000,
       charge=0, spin=1, model="uma-s-1p1", device="auto", verbose=True)
@@ -46,34 +46,34 @@ Provided functionality (concise):
 
 Outputs (& Directory Layout)
 -----
-• Default base directory: `./result_align_refine/`
-  – Pair API: uses `out_dir/` for stepwise and final LBFGS runs.
-  – Sequence API: creates subdirectories `pair_00/`, `pair_01/`, ... under `out_dir/`, one per adjacent pair.
-• Directories are created even when optimizer dumping is disabled; LBFGS is invoked with `dump=False`.
+- Default base directory: `./result_align_refine/`
+  - Pair API: uses `out_dir/` for stepwise and final LBFGS runs.
+  - Sequence API: creates subdirectories `pair_00/`, `pair_01/`, ... under `out_dir/`, one per adjacent pair.
+- Directories are created even when optimizer dumping is disabled; LBFGS is invoked with `dump=False`.
 
 Notes:
 -----
-• Units & conventions:
-  – User-facing distances/thresholds are in Å; internal coordinates are in bohr (conversion via `BOHR2ANG`).
-  – Row-vector convention for rigid transforms: points `Q` are mapped as `Q @ R + t`.
-  – Indices in `freeze_atoms` are 0-based.
-• Calculator handling:
-  – If a `Geometry` already has a calculator, it is reused.
-  – Otherwise UMA (`uma_pysis`) is attached automatically; `charge`, `spin`, `model`, and `device` are configurable,
+- Units & conventions:
+  - User-facing distances/thresholds are in Å; internal coordinates are in bohr (conversion via `BOHR2ANG`).
+  - Row-vector convention for rigid transforms: points `Q` are mapped as `Q @ R + t`.
+  - Indices in `freeze_atoms` are 0-based.
+- Calculator handling:
+  - If a `Geometry` already has a calculator, it is reused.
+  - Otherwise UMA (`uma_pysis`) is attached automatically; `charge`, `spin`, `model`, and `device` are configurable,
     or a `shared_calc` can be supplied.
-• Rigid alignment priority and RMSD reporting:
-  – freeze=1 → rotations about the single anchor only; RMSD minimized and reported on all atoms.
-  – freeze=2 → align anchor-defined axis; optimize rotation about that axis; RMSD reported on all atoms.
-  – else → Kabsch on the union of `freeze_atoms` (or all atoms if empty); transform applied to all atoms;
+- Rigid alignment priority and RMSD reporting:
+  - freeze=1 → rotations about the single anchor only; RMSD minimized and reported on all atoms.
+  - freeze=2 → align anchor-defined axis; optimize rotation about that axis; RMSD reported on all atoms.
+  - else → Kabsch on the union of `freeze_atoms` (or all atoms if empty); transform applied to all atoms;
     RMSD reported on the same selection used by Kabsch.
-• Scan + relaxation details:
-  – At each step: move frozen atoms by `step_A` Å toward reference, hold them fixed, run a short LBFGS on the surroundings.
-  – Finalization: enforce exact coincidence of frozen atoms, then run a finishing LBFGS.
-  – The original `freeze_atoms` of `g_mob` is restored after the scan, even on exceptions.
-• Error handling:
-  – `LBFGS` exceptions (`ZeroStepLength`, `OptimizationError`) are caught and logged; the procedure continues when reasonable.
-• Internals:
-  – Uses Rodrigues-based rotations, vector-alignment, and planar projection helpers to implement axis-constrained motions.
+- Scan + relaxation details:
+  - At each step: move frozen atoms by `step_A` Å toward reference, hold them fixed, run a short LBFGS on the surroundings.
+  - Finalization: enforce exact coincidence of frozen atoms, then run a finishing LBFGS.
+  - The original `freeze_atoms` of `g_mob` is restored after the scan, even on exceptions.
+- Error handling:
+  - `LBFGS` exceptions (`ZeroStepLength`, `OptimizationError`) are caught and logged; the procedure continues when reasonable.
+- Internals:
+  - Uses Rodrigues-based rotations, vector-alignment, and planar projection helpers to implement axis-constrained motions.
 """
 
 from __future__ import annotations

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -49,24 +49,24 @@ Notes:
 - Input geometry: .pdb, .xyz, .trj (via pysisyphus ``geom_loader``). For PDB, ``--freeze-links`` (default: True)
   detects parent atoms of link hydrogens and merges them with any ``geom.freeze_atoms``; the merged list is echoed.
 - UMA settings:
-  * ``--hessian-calc-mode``: ``Analytical`` (default) or ``FiniteDifference``; may also be set in YAML.
-  * ``return_partial_hessian`` defaults to True so PHVA can use a reduced active‑block Hessian when possible.
-  * Device: ``auto`` selects CUDA if available; otherwise CPU.
+  - ``--hessian-calc-mode``: ``Analytical`` (default) or ``FiniteDifference``; may also be set in YAML.
+  - ``return_partial_hessian`` defaults to True so PHVA can use a reduced active‑block Hessian when possible.
+  - Device: ``auto`` selects CUDA if available; otherwise CPU.
 - PHVA and projections:
-  * With frozen atoms, eigenanalysis is performed in the active DOF subspace and translation/rotation (TR) modes are projected in that subspace.
-  * Both full Hessians (3N×3N) and pre‑reduced active blocks (3N_act×3N_act) are accepted.
-  * Frequencies are reported in cm^-1 (negative values denote imaginary modes).
+  - With frozen atoms, eigenanalysis is performed in the active DOF subspace and translation/rotation (TR) modes are projected in that subspace.
+  - Both full Hessians (3N×3N) and pre‑reduced active blocks (3N_act×3N_act) are accepted.
+  - Frequencies are reported in cm^-1 (negative values denote imaginary modes).
 - Mode writing:
-  * ``--max-write`` limits how many modes are exported (ascending by value, or by absolute value with ``--sort abs``).
-  * ``--amplitude-ang`` (Å) and ``--n-frames`` control the sinusoidal animation.
-  * For PDB inputs, the .trj is converted to a .pdb animation using the input PDB as a template; if conversion fails, an ASE fallback is used.
+  - ``--max-write`` limits how many modes are exported (ascending by value, or by absolute value with ``--sort abs``).
+  - ``--amplitude-ang`` (Å) and ``--n-frames`` control the sinusoidal animation.
+  - For PDB inputs, the .trj is converted to a .pdb animation using the input PDB as a template; if conversion fails, an ASE fallback is used.
 - Thermochemistry:
-  * Requires the optional ``thermoanalysis`` package; if absent, the summary is skipped with a warning.
-  * Default model is QRRHO; the summary includes EE, ZPE, and thermal corrections to E/H/G. Values in cal·mol^-1 and cal·(mol·K)^-1 are also printed.
+  - Requires the optional ``thermoanalysis`` package; if absent, the summary is skipped with a warning.
+  - Default model is QRRHO; the summary includes EE, ZPE, and thermal corrections to E/H/G. Values in cal·mol^-1 and cal·(mol·K)^-1 are also printed.
 - Performance and numerical details:
-  * GPU memory usage is minimized by keeping only one Hessian in memory, using upper‑triangular eigendecompositions (``UPLO="U"``), and avoiding redundant allocations.
+  - GPU memory usage is minimized by keeping only one Hessian in memory, using upper‑triangular eigendecompositions (``UPLO="U"``), and avoiding redundant allocations.
 - Exit behavior:
-  * On keyboard interrupt, exits with code 130; on other errors, prints a traceback and exits with code 1.
+  - On keyboard interrupt, exits with code 130; on other errors, prints a traceback and exits with code 1.
 """
 
 from __future__ import annotations

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -40,17 +40,17 @@ Description
   Final configuration precedence: built-in defaults → YAML → CLI.
 - Strong recommendation: Provide both `-q/--charge` and `-s/--spin` explicitly to avoid running under unintended conditions.
 - CLI options:
-  * `-i/--input PATH` (required): Structure file (.pdb/.xyz/.trj/…).
-  * `-q/--charge INT` (strongly recommended): Total charge; overrides `calc.charge` from YAML.
-  * `-s/--spin INT` (default 1; strongly recommended): Spin multiplicity (2S+1); overrides `calc.spin`.
-  * `--max-cycles INT`: Max number of IRC steps; overrides `irc.max_cycles`.
-  * `--step-size FLOAT`: Step length in mass-weighted coordinates; overrides `irc.step_length`.
-  * `--root INT`: Imaginary mode index for the initial displacement; overrides `irc.root`.
-  * `--forward BOOL`: Run the forward IRC (explicit `True`/`False`); overrides `irc.forward`.
-  * `--backward BOOL`: Run the backward IRC (explicit `True`/`False`); overrides `irc.backward`.
-  * `--out-dir STR` (default `./result_irc/`): Output directory; overrides `irc.out_dir`.
-  * `--hessian-calc-mode {Analytical,FiniteDifference}`: How UMA builds the Hessian; overrides `calc.hessian_calc_mode`.
-  * `--args-yaml PATH`: YAML file with sections `geom`, `calc`, and `irc`.
+  - `-i/--input PATH` (required): Structure file (.pdb/.xyz/.trj/…).
+  - `-q/--charge INT` (strongly recommended): Total charge; overrides `calc.charge` from YAML.
+  - `-s/--spin INT` (default 1; strongly recommended): Spin multiplicity (2S+1); overrides `calc.spin`.
+  - `--max-cycles INT`: Max number of IRC steps; overrides `irc.max_cycles`.
+  - `--step-size FLOAT`: Step length in mass-weighted coordinates; overrides `irc.step_length`.
+  - `--root INT`: Imaginary mode index for the initial displacement; overrides `irc.root`.
+  - `--forward BOOL`: Run the forward IRC (explicit `True`/`False`); overrides `irc.forward`.
+  - `--backward BOOL`: Run the backward IRC (explicit `True`/`False`); overrides `irc.backward`.
+  - `--out-dir STR` (default `./result_irc/`): Output directory; overrides `irc.out_dir`.
+  - `--hessian-calc-mode {Analytical,FiniteDifference}`: How UMA builds the Hessian; overrides `calc.hessian_calc_mode`.
+  - `--args-yaml PATH`: YAML file with sections `geom`, `calc`, and `irc`.
 
 Outputs (& Directory Layout)
 -----

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -23,48 +23,48 @@ Description
 
 Key options (YAML keys → meaning; defaults)
 - Geometry (`geom`):
-  * `coord_type`: "cart" (default) | "dlc" (often better for small molecules).
-  * `freeze_atoms`: list[int], 0-based indices to freeze (default: []).
+  - `coord_type`: "cart" (default) | "dlc" (often better for small molecules).
+  - `freeze_atoms`: list[int], 0-based indices to freeze (default: []).
 - Calculator (`calc`, UMA via `uma_pysis`):
-  * `charge` (required via `-q`), `spin` (multiplicity; default 1—set explicitly for the correct state).
-  * `model`: "uma-s-1p1" (default) | "uma-m-1p1"; `task_name`: "omol".
-  * `device`: "auto" (GPU if available) | "cuda" | "cpu".
-  * `max_neigh`: Optional[int]; `radius`: Optional[float] (Å); `r_edges`: bool.
-  * `out_hess_torch`: bool; when True, provide a torch.Tensor Hessian (CUDA); else numpy on CPU.
+  - `charge` (required via `-q`), `spin` (multiplicity; default 1—set explicitly for the correct state).
+  - `model`: "uma-s-1p1" (default) | "uma-m-1p1"; `task_name`: "omol".
+  - `device`: "auto" (GPU if available) | "cuda" | "cpu".
+  - `max_neigh`: Optional[int]; `radius`: Optional[float] (Å); `r_edges`: bool.
+  - `out_hess_torch`: bool; when True, provide a torch.Tensor Hessian (CUDA); else numpy on CPU.
 - Optimizer base (`opt`):
-  * `thresh` presets (forces in Hartree/bohr, steps in bohr):
+  - `thresh` presets (forces in Hartree/bohr, steps in bohr):
     - `gau_loose`: max|F| 2.5e-3, RMS(F) 1.7e-3, max|step| 1.0e-2, RMS(step) 6.7e-3.
     - `gau` (default): max|F| 4.5e-4, RMS(F) 3.0e-4, max|step| 1.8e-3, RMS(step) 1.2e-3.
     - `gau_tight`: max|F| 1.5e-5, RMS(F) 1.0e-5, max|step| 6.0e-5, RMS(step) 4.0e-5.
     - `gau_vtight`: max|F| 2.0e-6, RMS(F) 1.0e-6, max|step| 6.0e-6, RMS(step) 4.0e-6.
     - `baker`: converged if (max|F| < 3.0e-4) AND (|ΔE| < 1.0e-6 OR max|step| < 3.0e-4).
     - `never`: disable built-in convergence (for external stopping).
-  * `max_cycles` 10000; `print_every` 1; `min_step_norm` 1e-8 with `assert_min_step` True.
-  * Convergence toggles: `rms_force`, `rms_force_only`, `max_force_only`, `force_only`.
-  * Extras: `converge_to_geom_rms_thresh` (RMSD target), `overachieve_factor`, `check_eigval_structure` (TS mode checks).
-  * Bookkeeping: `dump` (write `optimization.trj`), `dump_restart` (YAML every N cycles), `prefix`, `out_dir` (default `./result_opt/`).
+  - `max_cycles` 10000; `print_every` 1; `min_step_norm` 1e-8 with `assert_min_step` True.
+  - Convergence toggles: `rms_force`, `rms_force_only`, `max_force_only`, `force_only`.
+  - Extras: `converge_to_geom_rms_thresh` (RMSD target), `overachieve_factor`, `check_eigval_structure` (TS mode checks).
+  - Bookkeeping: `dump` (write `optimization.trj`), `dump_restart` (YAML every N cycles), `prefix`, `out_dir` (default `./result_opt/`).
 
 - LBFGS-specific (`lbfgs`, used when `--opt-mode light|lbfgs`):
-  * Memory: `keep_last` 7.
-  * Scaling: `beta` 1.0; `gamma_mult` False.
-  * Step control: `max_step` 0.30; `control_step` True; `double_damp` True; `line_search` True.
-  * Regularized L‑BFGS: `mu_reg` (disables double_damp/control_step/line_search); `max_mu_reg_adaptions` 10.
+  - Memory: `keep_last` 7.
+  - Scaling: `beta` 1.0; `gamma_mult` False.
+  - Step control: `max_step` 0.30; `control_step` True; `double_damp` True; `line_search` True.
+  - Regularized L‑BFGS: `mu_reg` (disables double_damp/control_step/line_search); `max_mu_reg_adaptions` 10.
 
 - RFO-specific (`rfo`, used when `--opt-mode heavy|rfo`):
-  * Trust region: `trust_radius` 0.30; `trust_update` True; bounds: `trust_min` 0.01, `trust_max` 0.30; `max_energy_incr` Optional[float].
-  * Hessian: `hessian_update` "bfgs" | "bofill"; `hessian_init` "calc"; `hessian_recalc` Optional[int] (e.g., 100); `hessian_recalc_adapt` 2.0.
-  * Numerics: `small_eigval_thresh` 1e-8; `line_search` True; `alpha0` 1.0; `max_micro_cycles` 25; `rfo_overlaps` False.
-  * DIIS helpers: `gdiis` True; `gediis` False; `gdiis_thresh` 2.5e-3 (vs RMS(step)); `gediis_thresh` 1.0e-2 (vs RMS(force)); `gdiis_test_direction` True.
-  * Step model: `adapt_step_func` False.
+  - Trust region: `trust_radius` 0.30; `trust_update` True; bounds: `trust_min` 0.01, `trust_max` 0.30; `max_energy_incr` Optional[float].
+  - Hessian: `hessian_update` "bfgs" | "bofill"; `hessian_init` "calc"; `hessian_recalc` Optional[int] (e.g., 100); `hessian_recalc_adapt` 2.0.
+  - Numerics: `small_eigval_thresh` 1e-8; `line_search` True; `alpha0` 1.0; `max_micro_cycles` 25; `rfo_overlaps` False.
+  - DIIS helpers: `gdiis` True; `gediis` False; `gdiis_thresh` 2.5e-3 (vs RMS(step)); `gediis_thresh` 1.0e-2 (vs RMS(force)); `gdiis_test_direction` True.
+  - Step model: `adapt_step_func` False.
 
 Outputs (& Directory Layout)
 -----
 - `out_dir/` (default: `./result_opt/`)
-  * `final_geometry.xyz` — final optimized geometry (always).
-  * `final_geometry.pdb` — converted from XYZ when the input was a PDB.
-  * `optimization.trj` — trajectory (written when `--dump` or `opt.dump: true`).
-  * `optimization.pdb` — converted from TRJ when input was a PDB and dumping is enabled.
-  * `restart*.yml` — optional restart files every N cycles when `opt.dump_restart` is set (file names depend on optimizer).
+  - `final_geometry.xyz` — final optimized geometry (always).
+  - `final_geometry.pdb` — converted from XYZ when the input was a PDB.
+  - `optimization.trj` — trajectory (written when `--dump` or `opt.dump: true`).
+  - `optimization.pdb` — converted from TRJ when input was a PDB and dumping is enabled.
+  - `restart*.yml` — optional restart files every N cycles when `opt.dump_restart` is set (file names depend on optimizer).
 - The tool prints resolved configuration blocks (`geom`, `calc`, `opt`, and `lbfgs` or `rfo`), progress every `print_every` cycles, and a final wall-clock time summary.
 
 Notes:

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -48,13 +48,13 @@ Workflow:
 2) Localize barrier: find the highest‑energy image (HEI); optimize HEI±1 as single structures → two nearby minima,
    End1 and End2.
 3) Refine the step:
-   • If no covalent bond change between End1–End2 (a “kink”): insert `search.kink_max_nodes` linearly interpolated
+   - If no covalent bond change between End1–End2 (a “kink”): insert `search.kink_max_nodes` linearly interpolated
      nodes and optimize each; **skip** GSM.
-   • Otherwise: run a refinement GSM between End1 and End2.
+   - Otherwise: run a refinement GSM between End1 and End2.
 4) Recurse selectively: evaluate covalent changes for (A→End1) and (End2→B); recurse only on sides that change.
 5) Stitch subpaths: concatenate sub‑MEPs with duplicate removal via RMSD. If endpoints still mismatch beyond
-   `search.bridge_rmsd_thresh`, insert a *bridge* GSM. If the interface itself shows covalent changes, insert a
-   **new recursive segment** instead of a bridge.
+   `search.bridge_rmsd_thresh`, insert a *bridge* GSM.
+   - If the interface itself shows covalent changes, insert a **new recursive segment** instead of a bridge.
 6) Optional alignment & merge: after pre‑opt, when `--align` (default), rigidly co‑align all inputs and
    refine `freeze_atoms` to match the first input. If `--ref-pdb` is supplied, merge pocket trajectories
    into full templates and annotate segments.
@@ -85,22 +85,22 @@ out_dir/
 Notes:
 -----
 - Inputs:
-  • Provide ≥2 structures to `-i/--input` in reaction order. Either repeat `-i` or pass multiple paths after a single `-i`.
-  • Endpoint pre‑optimization runs by default (`--pre-opt True`). With `--align True`, all inputs are co‑aligned and
+  - Provide ≥2 structures to `-i/--input` in reaction order. Either repeat `-i` or pass multiple paths after a single `-i`.
+  - Endpoint pre‑optimization runs by default (`--pre-opt True`). With `--align True`, all inputs are co‑aligned and
     `freeze_atoms` are refined to the first input.
 - Bond‑change detection: uses `bond_changes.compare_structures` with `bond_factor`, `margin_fraction`,
   and `delta_fraction` thresholds.
 - Concatenation policy:
-  • Endpoint duplicate removal when RMSD ≤ `search.stitch_rmsd_thresh` (default 1e‑4 Å).
-  • Bridge GSM when gap RMSD > `search.bridge_rmsd_thresh` (default 1e‑4 Å).
-  • If an interface shows covalent changes, insert a **new recursive segment** instead of a bridge.
+  - Endpoint duplicate removal when RMSD ≤ `search.stitch_rmsd_thresh` (default 1e‑4 Å).
+  - Bridge GSM when gap RMSD > `search.bridge_rmsd_thresh` (default 1e‑4 Å).
+  - If an interface shows covalent changes, insert a **new recursive segment** instead of a bridge.
 - Nodes and recursion:
-  • Segment vs bridge nodes can differ via `search.max_nodes_segment` and `search.max_nodes_bridge` (segment defaults to `--max-nodes`).
-  • Kinks use `search.kink_max_nodes` (default 3) linear nodes, each optimized individually.
-  • Recursion depth is capped by `search.max_depth` (default 10).
+  - Segment vs bridge nodes can differ via `search.max_nodes_segment` and `search.max_nodes_bridge` (segment defaults to `--max-nodes`).
+  - Kinks use `search.kink_max_nodes` (default 3) linear nodes, each optimized individually.
+  - Recursion depth is capped by `search.max_depth` (default 10).
 - Calculators & optimizers:
-  • A single UMA calculator (`uma_pysis`, default model "uma-s-1p1") is shared serially across all stages.
-  • GSM employs pysisyphus `GrowingString` + `StringOptimizer`; single‑structure uses LBFGS or RFO.
+  - A single UMA calculator (`uma_pysis`, default model "uma-s-1p1") is shared serially across all stages.
+  - GSM employs pysisyphus `GrowingString` + `StringOptimizer`; single‑structure uses LBFGS or RFO.
 - Configuration precedence: **CLI > YAML > defaults** (`geom`, `calc`, `gs`, `opt`, `sopt`, `bond`, `search`).
 - Final merge rule with `--align True`: when `--ref-pdb` is provided, the **first** reference PDB is used for *all* pairs
   in the final merge (passing one file is sufficient). Without `--align`, supply one reference PDB per input.

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -45,23 +45,23 @@ specified atom pairs and the full structure is relaxed. This lean implementation
 the UMA calculator via `uma_pysis` and removes general-purpose handling to reduce overhead and speed.
 
 Scheduling
-  • For scan tuples [(i, j, target_Å)], compute the Å-space displacement Δ = target − current_distance_Å.
-  • Let d_max = max(|Δ|). With --max-step-size = h (Å), set N = ceil(d_max / h).
-  • Per-pair step width δ_k = Δ / N (Å).
-  • At step s (1..N), the temporary target is r_k(s) = r_k(0) + s · δ_k (Å).
-  • Relax the full structure under the harmonic wells for that step.
+  - For scan tuples [(i, j, target_Å)], compute the Å-space displacement Δ = target − current_distance_Å.
+  - Let d_max = max(|Δ|). With --max-step-size = h (Å), set N = ceil(d_max / h).
+  - Per-pair step width δ_k = Δ / N (Å).
+  - At step s (1..N), the temporary target is r_k(s) = r_k(0) + s · δ_k (Å).
+  - Relax the full structure under the harmonic wells for that step.
 
 Harmonic bias model
-  • E_bias = Σ ½ · k · (|r_i − r_j| − target_k)².
-  • k is provided in eV/Å² (CLI/YAML) and converted once to Hartree/Bohr² internally.
-  • Coordinates are in Bohr; the UMA base returns energies in Hartree and forces in Hartree/Bohr.
+  - E_bias = Σ ½ · k · (|r_i − r_j| − target_k)².
+  - k is provided in eV/Å² (CLI/YAML) and converted once to Hartree/Bohr² internally.
+  - Coordinates are in Bohr; the UMA base returns energies in Hartree and forces in Hartree/Bohr.
 
 Optional optimizations
-  • --preopt: Pre-optimize the initial structure **without bias** before the scan; writes
+  - --preopt: Pre-optimize the initial structure **without bias** before the scan; writes
     `preopt/result.xyz` (and `.pdb` if the input was PDB), then continues from that geometry.
-  • --endopt: After **each stage** completes its biased stepping, perform an additional **unbiased**
+  - --endopt: After **each stage** completes its biased stepping, perform an additional **unbiased**
     optimization of that stage’s final structure before writing outputs.
-  • For each stage, covalent-bond **formation/breaking** is reported between the stage’s first
+  - For each stage, covalent-bond **formation/breaking** is reported between the stage’s first
     structure and its final structure (the latter is the end-of-stage optimized result when
     `--endopt True`).
 
@@ -81,21 +81,21 @@ Base output directory (default `./result_scan/`):
 
 Notes:
 -----
-• UMA only: `uma_pysis` is the sole supported calculator.
-• Optimizers: `--opt-mode light|lbfgs` selects LBFGS; `--opt-mode heavy|rfo` selects RFOptimizer.
+- UMA only: `uma_pysis` is the sole supported calculator.
+- Optimizers: `--opt-mode light|lbfgs` selects LBFGS; `--opt-mode heavy|rfo` selects RFOptimizer.
   Step/trust radii are capped in Bohr based on `--max-step-size` (Å).
-• Indexing: (i, j) are 1-based by default; use `--zero-based` if your tuples are 0-based.
-• Units: Distances in CLI/YAML are Å; the bias is applied internally in a.u. (Hartree/Bohr) with
+- Indexing: (i, j) are 1-based by default; use `--zero-based` if your tuples are 0-based.
+- Units: Distances in CLI/YAML are Å; the bias is applied internally in a.u. (Hartree/Bohr) with
   k converted from eV/Å² to Hartree/Bohr².
-• Performance simplifications:
-  – Bias wrapper implements only the (elem, coords) two-argument API used by `pysisyphus.Geometry`
+- Performance simplifications:
+  - Bias wrapper implements only the (elem, coords) two-argument API used by `pysisyphus.Geometry`
     with `uma_pysis`; Geometry-style 1-arg fallbacks and broad shape inference are removed.
-  – Bias is computed directly in a.u. using a pre-converted k to avoid repeated unit conversions.
-  – Trajectories are accumulated only when `--dump` is True.
-  – Energy is not re-queried for per-frame annotation during the scan to avoid extra calls.
-• PDB convenience: With `--freeze-links` (default True for PDB), parent atoms of link hydrogens
+  - Bias is computed directly in a.u. using a pre-converted k to avoid repeated unit conversions.
+  - Trajectories are accumulated only when `--dump` is True.
+  - Energy is not re-queried for per-frame annotation during the scan to avoid extra calls.
+- PDB convenience: With `--freeze-links` (default True for PDB), parent atoms of link hydrogens
   are detected and frozen, and merged with any user-specified frozen atoms.
-• YAML: Additional arguments can be supplied via `--args-yaml` under sections:
+- YAML: Additional arguments can be supplied via `--args-yaml` under sections:
   `geom`, `calc`, `opt`, `lbfgs`, `rfo`, `bias`, and `bond`.
 """
 

--- a/pdb2reaction/trj2fig.py
+++ b/pdb2reaction/trj2fig.py
@@ -32,9 +32,9 @@ Description
       (uses the first floating-point number on that line).
     - Computes either ΔE (relative to a chosen reference) or absolute E; units: kcal/mol (default) or hartree.
       Reference specification:
-        * -r init  : use the initial frame (or the last frame if --reverse-x is set).
-        * -r None  : use absolute energies (no reference). Also accepts "none"/"null" (case-insensitive).
-        * -r <int> : use the given 0-based frame index as the reference.
+        - -r init  : use the initial frame (or the last frame if --reverse-x is set).
+        - -r None  : use absolute energies (no reference). Also accepts "none"/"null" (case-insensitive).
+        - -r <int> : use the given 0-based frame index as the reference.
     - Generates a polished Plotly figure (no title) with bold ticks, consistent fonts, markers,
       and a smoothed spline curve. Supported figure outputs: PNG (default), HTML, SVG, PDF.
     - Optionally writes a CSV table of the data.
@@ -46,11 +46,11 @@ Outputs (& Directory Layout)
     - Default output when no -o is provided: ./energy.png (current working directory).
     - You can provide multiple filenames to -o and/or repeat -o to emit several outputs at once.
       Supported formats:
-        * .png  : High-resolution raster figure (scale=2).
-        * .html : Standalone interactive Plotly figure.
-        * .svg  : Vector figure.
-        * .pdf  : Vector figure.
-        * .csv  : Tabular data with columns:
+        - .png  : High-resolution raster figure (scale=2).
+        - .html : Standalone interactive Plotly figure.
+        - .svg  : Vector figure.
+        - .pdf  : Vector figure.
+        - .csv  : Tabular data with columns:
                   frame (0-based), energy_hartree,
                   <delta_kcal|energy_kcal|delta_hartree|energy_hartree> depending on --unit and reference.
 

--- a/pdb2reaction/uma_pysis.py
+++ b/pdb2reaction/uma_pysis.py
@@ -8,12 +8,12 @@ Description
 -----
 - Provides energy, forces, and Hessian for molecular systems using FAIR‑Chem UMA pretrained ML potentials via ASE/AtomicData.
 - Two Hessian modes:
-  * "Analytical": second‑order autograd of the UMA energy on the GPU.
+  - "Analytical": second‑order autograd of the UMA energy on the GPU.
     Requires more VRAM/time than finite differences. During evaluation,
     model parameter gradients are disabled; dropout layers are force‑disabled;
     the model is temporarily toggled to train mode only to build the autograd
     graph and then restored to eval.
-  * "FiniteDifference": central differences of forces assembled on the GPU.
+  - "FiniteDifference": central differences of forces assembled on the GPU.
     Columns for frozen DOF are skipped; optionally return only the active‑DOF block.
     Default step: ε = 1.0e‑3 Å.
 - Device handling: device="auto" selects CUDA if available, else CPU; tensors use torch.float32.
@@ -33,24 +33,24 @@ PySisyphus calculator interface (`implemented_properties = ["energy", "forces", 
 
 - get_energy(elem, coords)
   Returns: {"energy": E}
-  • E: float, Hartree.
-  • coords: Bohr in, internally converted to Å.
+  - E: float, Hartree.
+  - coords: Bohr in, internally converted to Å.
 
 - get_forces(elem, coords)
   Returns: {"energy": E, "forces": F}
-  • F: shape (3N,), Hartree/Bohr.
-  • E: float, Hartree.
-  • coords: Bohr in, internally converted to Å.
+  - F: shape (3N,), Hartree/Bohr.
+  - E: float, Hartree.
+  - coords: Bohr in, internally converted to Å.
 
 - get_hessian(elem, coords)
   Returns: {"energy": E, "forces": F, "hessian": H}
-  • F: shape (3N,), Hartree/Bohr.
-  • H: shape (3N, 3N), Hartree/Bohr² (or (3N_active, 3N_active) if returning the
+  - F: shape (3N,), Hartree/Bohr.
+  - H: shape (3N, 3N), Hartree/Bohr² (or (3N_active, 3N_active) if returning the
     active‑DOF submatrix in FiniteDifference mode).
-  • If FiniteDifference + return_partial_hessian=True: H contains only the
+  - If FiniteDifference + return_partial_hessian=True: H contains only the
     active‑DOF block (non‑frozen atoms). Otherwise H is full sized and columns
     corresponding to frozen DOF remain zero.
-  • Type of H: NumPy (CPU) unless out_hess_torch=True, in which case a torch.Tensor
+  - Type of H: NumPy (CPU) unless out_hess_torch=True, in which case a torch.Tensor
     on the current device is returned.
 
 Notes:


### PR DESCRIPTION
## Summary
- standardize the bullet formatting in module-level docstrings to match the ts_opt style across the CLI and utility modules

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915c68c08cc832da08ee1f1d73bd036)