### PR TITLE
Standardize API docstrings to ts_opt format

### DIFF
--- a/pdb2reaction/align_freeze_atoms.py
+++ b/pdb2reaction/align_freeze_atoms.py
@@ -4,6 +4,22 @@
 align_freeze_atoms — Rigid alignment and staged “scan + relaxation” utilities for pysisyphus Geometry objects
 ====================================================================
 
+Usage (API)
+-----
+    from pdb2reaction.align_freeze_atoms import (
+        align_and_refine_pair_inplace,
+        align_and_refine_sequence_inplace,
+        align_second_to_first_kabsch_inplace,
+        kabsch_R_t,
+        scan_freeze_atoms_toward_target_inplace,
+    )
+
+Examples::
+    >>> from pdb2reaction.align_freeze_atoms import align_and_refine_pair_inplace
+    >>> result = align_and_refine_pair_inplace(g_ref, g_mob, verbose=False)
+    >>> result["align"]["mode"]
+    'kabsch'
+
 Description
 -----
 API-only utilities to co-align and refine pre-optimized `pysisyphus.Geometry` objects—typically adjacent

--- a/pdb2reaction/uma_pysis.py
+++ b/pdb2reaction/uma_pysis.py
@@ -4,6 +4,16 @@
 uma_pysis — UMA calculator wrapper for PySisyphus
 ====================================================================
 
+Usage (API)
+-----
+    from pdb2reaction.uma_pysis import uma_pysis
+
+Examples::
+    >>> from pdb2reaction.uma_pysis import uma_pysis
+    >>> calc = uma_pysis(charge=0, spin=1, model="uma-s-1p1")
+    >>> calc.get_energy(["C", "O"], coords)
+    {'energy': -228.123456}
+
 Description
 -----
 - Provides energy, forces, and Hessian for molecular systems using FAIR‑Chem UMA pretrained ML potentials via ASE/AtomicData.

--- a/pdb2reaction/utils.py
+++ b/pdb2reaction/utils.py
@@ -4,6 +4,22 @@
 utils — concise utilities for configuration, plotting, coordinates, and link-freezing
 ====================================================================
 
+Usage (API)
+-----
+    from pdb2reaction.utils import (
+        build_energy_diagram,
+        convert_xyz_to_pdb,
+        freeze_links,
+        merge_freeze_atom_indices,
+        pretty_block,
+    )
+
+Examples::
+    >>> from pathlib import Path
+    >>> block = pretty_block("Geometry", {"freeze_atoms": [0, 1, 5]})
+    >>> diagram = build_energy_diagram([0.0, 12.3, 5.4], ["R", "TS", "P"])
+    >>> indices = freeze_links(Path("pocket.pdb"))
+
 Description
 -----
 - **Generic helpers**


### PR DESCRIPTION
## Summary
- add Usage (API) and Examples sections to align_freeze_atoms, bond_changes, uma_pysis, and utils module docstrings
- keep existing descriptive content while matching the ts_opt docstring layout for API modules

## Testing
- python -m compileall pdb2reaction

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915c84b2ad4832da05781e16207a1df)