### PR TITLE
Clarify CLI docs and reuse opt-mode normalization

### DIFF
--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -24,7 +24,7 @@ Recommended/common:
     --ref-pdb PATH [...] Full template PDB(s) for final merge (see Notes).
     --out-dir PATH       Output directory; default ./result_path_search/
     --dump               Save optimizer dumps; default off.
-    --freeze-links/--no-freeze-links  Freeze parents of link hydrogens for PDB input; default on.
+    --freeze-links {True|False}  Freeze parents of link hydrogens for PDB input; default on.
 
 Examples::
     # Minimal (pocket-only MEP; writes mep.trj or mep.pdb if inputs are PDB)


### PR DESCRIPTION
## Summary
- clarify boolean CLI arguments in the opt, scan, and path-search docstrings
- add a shared `normalize_choice` helper for option alias resolution and apply it across opt/scan/ts-opt

## Testing
- python -m compileall pdb2reaction

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915e0a79270832d80145ed779fe3e86)