### PR TITLE
Refactor duplicated timing output across CLI commands

### DIFF
--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -123,7 +123,7 @@ from . import freq as _freq_cli
 from . import dft as _dft_cli
 from .uma_pysis import uma_pysis
 from .trj2fig import run_trj2fig
-from .utils import build_energy_diagram
+from .utils import build_energy_diagram, format_elapsed
 
 
 # -----------------------------
@@ -818,11 +818,7 @@ def cli(
     # --------------------------
     if not (do_tsopt or do_thermo or do_dft):
         # Elapsed time
-        elapsed = time.perf_counter() - time_start
-        hh = int(elapsed // 3600)
-        mm = int((elapsed % 3600) // 60)
-        ss = elapsed - (hh * 3600 + mm * 60)
-        click.echo(f"[all] Total Elapsed: {hh:02d}:{mm:02d}:{ss:06.3f}")
+        click.echo(format_elapsed("[all] Total Elapsed", time_start))
         return
 
     click.echo("\n=== [all] Stage 4 — Post-processing per reactive segment ===\n")
@@ -832,22 +828,14 @@ def cli(
     segments = _read_summary(summary_yaml)
     if not segments:
         click.echo("[post] No segments found in summary; nothing to do.")
-        elapsed = time.perf_counter() - time_start
-        hh = int(elapsed // 3600)
-        mm = int((elapsed % 3600) // 60)
-        ss = elapsed - (hh * 3600 + mm * 60)
-        click.echo(f"[all] Total Elapsed: {hh:02d}:{mm:02d}:{ss:06.3f}")
+        click.echo(format_elapsed("[all] Total Elapsed", time_start))
         return
 
     # Iterate only bond-change segments (kind='seg' and bond_changes not empty and not '(no covalent...)')
     reactive = [s for s in segments if (s.get("kind", "seg") == "seg" and str(s.get("bond_changes", "")).strip() and str(s.get("bond_changes", "")).strip() != "(no covalent changes detected)")]
     if not reactive:
         click.echo("[post] No bond-change segments. Skipping TS/thermo/DFT.")
-        elapsed = time.perf_counter() - time_start
-        hh = int(elapsed // 3600)
-        mm = int((elapsed % 3600) // 60)
-        ss = elapsed - (hh * 3600 + mm * 60)
-        click.echo(f"[all] Total Elapsed: {hh:02d}:{mm:02d}:{ss:06.3f}")
+        click.echo(format_elapsed("[all] Total Elapsed", time_start))
         return
 
     # For each reactive segment

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -69,7 +69,7 @@ import numpy as np
 
 from pysisyphus.helpers import geom_loader
 
-from .utils import load_yaml_dict, apply_yaml_overrides, pretty_block
+from .utils import load_yaml_dict, apply_yaml_overrides, pretty_block, format_elapsed
 
 
 # -----------------------------------------------
@@ -428,11 +428,7 @@ def cli(
             click.echo("WARNING: SCF did not converge to the requested tolerance.", err=True)
             sys.exit(3)
         
-        elapsed = time.perf_counter() - time_start
-        hh = int(elapsed // 3600)
-        mm = int((elapsed % 3600) // 60)
-        ss = elapsed - (hh * 3600 + mm * 60)
-        click.echo(f"[time] Elapsed Time for DFT: {hh:02d}:{mm:02d}:{ss:06.3f}")
+        click.echo(format_elapsed("[time] Elapsed Time for DFT", time_start))
 
     except KeyboardInterrupt:
         click.echo("\nInterrupted by user.", err=True)

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -99,6 +99,7 @@ from .utils import (
     convert_xyz_to_pdb as _convert_xyz_to_pdb,
     pretty_block,
     format_geom_for_echo,
+    format_elapsed,
     merge_freeze_atom_indices,
 )
 def _torch_device(auto: str = "auto") -> torch.device:
@@ -827,11 +828,7 @@ def cli(
 
         click.echo(f"[DONE] Wrote modes and list → {out_dir_path}")
 
-        elapsed = time.perf_counter() - time_start
-        hh = int(elapsed // 3600)
-        mm = int((elapsed % 3600) // 60)
-        ss = elapsed - (hh * 3600 + mm * 60)
-        click.echo(f"[time] Elapsed Time for Freq: {hh:02d}:{mm:02d}:{ss:06.3f}")
+        click.echo(format_elapsed("[time] Elapsed Time for Freq", time_start))
 
     except KeyboardInterrupt:
         click.echo("\nInterrupted by user.", err=True)

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -102,6 +102,7 @@ from pdb2reaction.utils import (
     apply_yaml_overrides,
     pretty_block,
     format_geom_for_echo,
+    format_elapsed,
 )
 
 
@@ -305,11 +306,7 @@ def cli(
                 out_dir_path / f"{irc_cfg.get('prefix','')}{'backward_irc.pdb'}",
             )
 
-        elapsed = time.perf_counter() - time_start
-        hh = int(elapsed // 3600)
-        mm = int((elapsed % 3600) // 60)
-        ss = elapsed - (hh * 3600 + mm * 60)
-        click.echo(f"[time] Elapsed Time for IRC: {hh:02d}:{mm:02d}:{ss:06.3f}")
+        click.echo(format_elapsed("[time] Elapsed Time for IRC", time_start))
 
     except KeyboardInterrupt:
         click.echo("\nInterrupted by user.", err=True)

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -106,6 +106,7 @@ from .utils import (
     apply_yaml_overrides,
     pretty_block,
     format_geom_for_echo,
+    format_elapsed,
     merge_freeze_atom_indices,
     normalize_choice,
 )
@@ -427,11 +428,7 @@ def cli(
             final_xyz_path=final_xyz_path,
         )
 
-        elapsed = time.perf_counter() - time_start
-        hh = int(elapsed // 3600)
-        mm = int((elapsed % 3600) // 60)
-        ss = elapsed - (hh * 3600 + mm * 60)
-        click.echo(f"[time] Elapsed Time for Opt: {hh:02d}:{mm:02d}:{ss:06.3f}")
+        click.echo(format_elapsed("[time] Elapsed Time for Opt", time_start))
 
     except ZeroStepLength:
         click.echo("ERROR: Step length fell below the minimum allowed (ZeroStepLength).", err=True)

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -76,6 +76,7 @@ from .utils import (
     apply_yaml_overrides,
     pretty_block,
     format_geom_for_echo,
+    format_elapsed,
     merge_freeze_atom_indices,
 )
 from .align_freeze_atoms import align_and_refine_sequence_inplace
@@ -418,11 +419,7 @@ def cli(
             click.echo(f"[HEI] ERROR: Failed to dump HEI: {e}", err=True)
             sys.exit(5)
 
-        elapsed = time.perf_counter() - time_start
-        hh = int(elapsed // 3600)
-        mm = int((elapsed % 3600) // 60)
-        ss = elapsed - (hh * 3600 + mm * 60)
-        click.echo(f"[time] Elapsed Time for Path Opt: {hh:02d}:{mm:02d}:{ss:06.3f}")
+        click.echo(format_elapsed("[time] Elapsed Time for Path Opt", time_start))
 
     except OptimizationError as e:
         click.echo(f"ERROR: Path optimization failed — {e}", err=True)

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -152,6 +152,7 @@ from .utils import (
     apply_yaml_overrides,
     pretty_block,
     format_geom_for_echo,
+    format_elapsed,
     merge_freeze_atom_indices,
     build_energy_diagram,
 )
@@ -2044,11 +2045,7 @@ def cli(
         # --------------------------
         # 7) Elapsed time
         # --------------------------
-        elapsed = time.perf_counter() - time_start
-        hh = int(elapsed // 3600)
-        mm = int((elapsed % 3600) // 60)
-        ss = elapsed - (hh * 3600 + mm * 60)
-        click.echo(f"[time] Elapsed for Path Search: {hh:02d}:{mm:02d}:{ss:06.3f}")
+        click.echo(format_elapsed("[time] Elapsed for Path Search", time_start))
 
     except ZeroStepLength:
         click.echo("ERROR: Proposed step length dropped below the minimum allowed (ZeroStepLength).", err=True)

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -139,6 +139,7 @@ from .utils import (
     apply_yaml_overrides,
     pretty_block,
     format_geom_for_echo,
+    format_elapsed,
     merge_freeze_atom_indices,
     normalize_choice,
 )
@@ -874,11 +875,7 @@ def cli(
 
         click.echo("\n=== Scan finished ===\n")
 
-        elapsed = time.perf_counter() - time_start
-        hh = int(elapsed // 3600)
-        mm = int((elapsed % 3600) // 60)
-        ss = elapsed - (hh * 3600 + mm * 60)
-        click.echo(f"[time] Elapsed Time for Scan: {hh:02d}:{mm:02d}:{ss:06.3f}")
+        click.echo(format_elapsed("[time] Elapsed Time for Scan", time_start))
 
     except KeyboardInterrupt:
         click.echo("\nInterrupted by user.", err=True)

--- a/pdb2reaction/ts_opt.py
+++ b/pdb2reaction/ts_opt.py
@@ -141,6 +141,7 @@ from .utils import (
     apply_yaml_overrides,
     pretty_block,
     format_geom_for_echo,
+    format_elapsed,
     merge_freeze_atom_indices,
     normalize_choice,
 )
@@ -1548,11 +1549,7 @@ def cli(
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
 
-        elapsed = time.perf_counter() - time_start
-        hh = int(elapsed // 3600)
-        mm = int((elapsed % 3600) // 60)
-        ss = elapsed - (hh * 3600 + mm * 60)
-        click.echo(f"[time] Elapsed Time for TS Opt: {hh:02d}:{mm:02d}:{ss:06.3f}")
+        click.echo(format_elapsed("[time] Elapsed Time for TS Opt", time_start))
 
     except ZeroStepLength:
         click.echo("ERROR: Proposed step length dropped below the minimum allowed (ZeroStepLength).", err=True)

--- a/pdb2reaction/utils.py
+++ b/pdb2reaction/utils.py
@@ -26,6 +26,7 @@ Description
 - **Generic helpers**
   - `pretty_block(title, content)`: Return a YAML-formatted block with an underlined title. Uses `yaml.safe_dump` with `allow_unicode=True`, `sort_keys=False`. Renders `(empty)` when `content` is empty.
   - `format_geom_for_echo(geom_cfg)`: Normalize geometry configuration for CLI echo. If `"freeze_atoms"` is an iterable (but not a string), convert it to a comma-separated string; `None`/string/other types are left unchanged. Empty iterables become `""`.
+  - `format_elapsed(prefix, start_time, end_time=None)`: Format a wall-clock duration (HH:MM:SS.sss) given a start time and optional end time, using `time.perf_counter()` when the end time is omitted.
   - `merge_freeze_atom_indices(geom_cfg, *indices)`: Merge one or more iterables of atom indices into `geom_cfg["freeze_atoms"]`. Preserve existing entries, de-duplicate, sort numerically, and return the updated list (in place).
   - `normalize_choice(value, *, param, alias_groups, allowed_hint)`: Canonicalise CLI-style string options using alias groups. Returns the mapped value or raises `click.BadParameter` with the provided hint when no alias matches.
   - `deep_update(dst, src)`: Recursively update mapping `dst` with `src`. Nested dicts are merged, non-dicts overwrite; returns `dst`.
@@ -65,6 +66,7 @@ Notes:
 """
 
 import math
+import time
 from collections.abc import Iterable as _Iterable, Mapping, Sequence as _Sequence
 from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, List, Tuple
@@ -109,6 +111,16 @@ def format_geom_for_echo(geom_cfg: Dict[str, Any]) -> Dict[str, Any]:
 
     g["freeze_atoms"] = ",".join(map(str, items)) if items else ""
     return g
+
+
+def format_elapsed(prefix: str, start_time: float, end_time: Optional[float] = None) -> str:
+    """Return a formatted elapsed-time string with the provided ``prefix`` label."""
+
+    finish = end_time if end_time is not None else time.perf_counter()
+    elapsed = max(0.0, finish - start_time)
+    hours, rem = divmod(elapsed, 3600)
+    minutes, seconds = divmod(rem, 60)
+    return f"{prefix}: {int(hours):02d}:{int(minutes):02d}:{seconds:06.3f}"
 
 
 def merge_freeze_atom_indices(


### PR DESCRIPTION
## Summary
- add a shared `format_elapsed` helper in `pdb2reaction.utils` to format wall-clock durations
- reuse the helper across CLI entry points to eliminate repeated timing snippets

## Testing
- python -m compileall pdb2reaction

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915e5abf17c832d92ef74bb0d998275)