### PR TITLE
Rename freeze_links utility to detect_freeze_links

### DIFF
--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -95,7 +95,7 @@ from .uma_pysis import uma_pysis, GEOM_KW_DEFAULT, CALC_KW as _UMA_CALC_KW
 from .utils import (
     load_yaml_dict,
     apply_yaml_overrides,
-    freeze_links,
+    detect_freeze_links,
     convert_xyz_to_pdb as _convert_xyz_to_pdb,
     pretty_block,
     format_geom_for_echo,
@@ -616,7 +616,7 @@ def cli(
     # Freeze links (PDB only): merge with existing list
     if freeze_links and input_path.suffix.lower() == ".pdb":
         try:
-            detected = freeze_links(input_path)
+            detected = detect_freeze_links(input_path)
         except Exception as e:
             click.echo(f"[freeze-links] WARNING: Could not detect link parents: {e}", err=True)
             detected = []

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -105,7 +105,7 @@ from pdb2reaction.utils import (
     pretty_block,
     format_geom_for_echo,
     format_elapsed,
-    freeze_links,
+    detect_freeze_links,
     merge_freeze_atom_indices,
 )
 
@@ -260,7 +260,7 @@ def cli(
         merged_freeze = merge_freeze_atom_indices(geom_cfg)
         if freeze_links_flag and input_path.suffix.lower() == ".pdb":
             try:
-                detected = freeze_links(input_path)
+                detected = detect_freeze_links(input_path)
             except Exception as e:
                 click.echo(
                     f"[freeze-links] WARNING: Could not detect link parents: {e}",

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -101,7 +101,7 @@ from pysisyphus.optimizers.exceptions import OptimizationError, ZeroStepLength
 from .uma_pysis import uma_pysis, GEOM_KW_DEFAULT, CALC_KW as _UMA_CALC_KW
 from .utils import (
     convert_xyz_to_pdb,
-    freeze_links,
+    detect_freeze_links,
     load_yaml_dict,
     apply_yaml_overrides,
     pretty_block,
@@ -347,7 +347,7 @@ def cli(
         # Optionally infer "freeze_atoms" from link hydrogens in PDB
         if freeze_links and input_path.suffix.lower() == ".pdb":
             try:
-                detected = freeze_links(input_path)
+                detected = detect_freeze_links(input_path)
             except Exception as e:
                 click.echo(f"[freeze-links] WARNING: Could not detect link parents: {e}", err=True)
                 detected = []
@@ -450,7 +450,7 @@ def freeze_links_helper(pdb_path: Path):
     """
     Small shim to keep the intent readable.
     """
-    return freeze_links(pdb_path)
+    return detect_freeze_links(pdb_path)
 
 
 # Allow `python -m pdb2reaction.commands.opt` direct execution

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -71,7 +71,7 @@ from pysisyphus.optimizers.exceptions import OptimizationError
 from .uma_pysis import uma_pysis, GEOM_KW_DEFAULT, CALC_KW as _UMA_CALC_KW
 from .utils import (
     convert_xyz_to_pdb,
-    freeze_links,
+    detect_freeze_links,
     load_yaml_dict,
     apply_yaml_overrides,
     pretty_block,
@@ -130,7 +130,7 @@ def _freeze_links_for_pdb(pdb_path: Path) -> Sequence[int]:
     Detect the parent atoms of link hydrogens in a PDB and return 0‑based indices.
     """
     try:
-        return freeze_links(pdb_path)
+        return detect_freeze_links(pdb_path)
     except Exception as e:
         click.echo(f"[freeze-links] WARNING: Could not detect link parents for '{pdb_path.name}': {e}", err=True)
         return []
@@ -435,9 +435,9 @@ def cli(
 
 def freeze_links_helper(pdb_path: Path):
     """
-    Expose freeze_links for external callers/tests.
+    Expose detect_freeze_links for external callers/tests.
     """
-    return freeze_links(pdb_path)
+    return detect_freeze_links(pdb_path)
 
 
 if __name__ == "__main__":

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -147,7 +147,7 @@ from .opt import (
 )
 from .utils import (
     convert_xyz_to_pdb,
-    freeze_links,
+    detect_freeze_links,
     load_yaml_dict,
     apply_yaml_overrides,
     pretty_block,
@@ -229,7 +229,7 @@ def _freeze_links_for_pdb(pdb_path: Path) -> Sequence[int]:
     Detect parent atoms of link hydrogens in a PDB; return 0‑based indices. Silent on failure.
     """
     try:
-        return freeze_links(pdb_path)
+        return detect_freeze_links(pdb_path)
     except Exception as e:
         click.echo(f"[freeze-links] WARNING: Could not detect link parents for '{pdb_path.name}': {e}", err=True)
         return []

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -134,7 +134,7 @@ from .opt import (
 )
 from .utils import (
     convert_xyz_to_pdb,
-    freeze_links,
+    detect_freeze_links,
     load_yaml_dict,
     apply_yaml_overrides,
     pretty_block,
@@ -197,7 +197,7 @@ _OPT_MODE_ALIASES = (
 
 def _freeze_links_for_pdb(pdb_path: Path) -> List[int]:
     try:
-        return list(freeze_links(pdb_path))
+        return list(detect_freeze_links(pdb_path))
     except Exception as e:
         click.echo(f"[freeze-links] WARNING: Could not detect link parents for '{pdb_path.name}': {e}", err=True)
         return []

--- a/pdb2reaction/ts_opt.py
+++ b/pdb2reaction/ts_opt.py
@@ -136,7 +136,7 @@ from .opt import (
 )
 from .utils import (
     convert_xyz_to_pdb,
-    freeze_links,
+    detect_freeze_links,
     load_yaml_dict,
     apply_yaml_overrides,
     pretty_block,
@@ -1348,7 +1348,7 @@ def cli(
     # Freeze links (PDB only): merge with existing list
     if freeze_links and input_path.suffix.lower() == ".pdb":
         try:
-            detected = freeze_links(input_path)
+            detected = detect_freeze_links(input_path)
         except Exception as e:
             click.echo(f"[freeze-links] WARNING: Could not detect link parents: {e}", err=True)
             detected = []

--- a/pdb2reaction/utils.py
+++ b/pdb2reaction/utils.py
@@ -9,7 +9,7 @@ Usage (API)
     from pdb2reaction.utils import (
         build_energy_diagram,
         convert_xyz_to_pdb,
-        freeze_links,
+        detect_freeze_links,
         merge_freeze_atom_indices,
         normalize_choice,
         pretty_block,
@@ -19,7 +19,7 @@ Examples::
     >>> from pathlib import Path
     >>> block = pretty_block("Geometry", {"freeze_atoms": [0, 1, 5]})
     >>> diagram = build_energy_diagram([0.0, 12.3, 5.4], ["R", "TS", "P"])
-    >>> indices = freeze_links(Path("pocket.pdb"))
+    >>> indices = detect_freeze_links(Path("pocket.pdb"))
 
 Description
 -----
@@ -45,7 +45,7 @@ Description
 - **Link-freezing helpers**
   - `parse_pdb_coords(pdb_path)`: Parse `ATOM`/`HETATM` records, separating all atoms (as “others”) from link hydrogens `HL` in residue `LKH` (as “lkhs”). Coordinates are read from standard PDB columns (1‑based): X 31–38, Y 39–46, Z 47–54. Returns `(others, lkhs)` as lists of `(x, y, z, line)`.
   - `nearest_index(point, pool)`: Find the Euclidean nearest neighbor of a given `(x, y, z)` within `pool`; returns `(index, distance)` where `index` is 0‑based or `-1` if `pool` is empty (distance will be `inf` in that case).
-  - `freeze_links(pdb_path)`: For each `LKH`/`HL` atom, find the nearest atom among all other `ATOM`/`HETATM` records and return the corresponding 0‑based indices into the sequence of non‑`LKH` atoms (“others”). Returns an empty list if no link hydrogens are present.
+  - `detect_freeze_links(pdb_path)`: For each `LKH`/`HL` atom, find the nearest atom among all other `ATOM`/`HETATM` records and return the corresponding 0‑based indices into the sequence of non‑`LKH` atoms (“others”). Returns an empty list if no link hydrogens are present.
 
 Outputs (& Directory Layout)
 -----
@@ -517,7 +517,7 @@ def nearest_index(point, pool):
     return best_i, math.sqrt(best_d2)
 
 
-def freeze_links(pdb_path):
+def detect_freeze_links(pdb_path):
     """Identify link-parent atom indices for 'LKH'/'HL' link hydrogens.
 
     For each 'HL' atom in residue 'LKH', find the nearest atom among all other


### PR DESCRIPTION
## Summary
- rename the `freeze_links` helper in `pdb2reaction.utils` to `detect_freeze_links` and refresh the module documentation to match
- update CLI modules that detect link hydrogens to import and call `detect_freeze_links`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915ee862888832dbc297baa594f74d4)