### PR TITLE
Document default YAML configurations

### DIFF
--- a/docs/add_elem_info.md
+++ b/docs/add_elem_info.md
@@ -1,0 +1,28 @@
+# `add_elem_info` subcommand
+
+## Purpose
+Repairs or populates element-symbol columns (77–78) in PDB files using Biopython heuristics aligned with the extractor’s residue definitions.
+
+## Usage
+```bash
+pdb2reaction add_elem_info -i INPUT.pdb [-o OUTPUT.pdb] [--overwrite]
+```
+
+## CLI options
+| Option | Description | Default |
+| --- | --- | --- |
+| `-i, --input PATH` | Input PDB file. | Required |
+| `-o, --out PATH` | Output PDB file. If omitted, the input is overwritten. | _None_ |
+| `--overwrite` | Re-infer all element fields even when present. | `False` |
+
+## YAML configuration (`--args-yaml`)
+Not supported.
+
+## Outputs
+- A PDB file with element symbols filled (`--out` path or the original file when omitted).
+- Console summary including counts of assigned/kept/overwritten elements and up to 50 unresolved atoms.
+
+## Notes
+- Recognises standard protein, nucleic acid, water, ion, and common ligand nomenclature; deuterium (`D`) is mapped to hydrogen.
+- Depends on Biopython’s `PDBParser`/`PDBIO`; only ATOM/HETATM records are modified.
+- Keeps coordinates and other columns unchanged; only columns 77–78 are rewritten when assignments exist.

--- a/docs/all.md
+++ b/docs/all.md
@@ -1,0 +1,60 @@
+# `all` subcommand
+
+## Purpose
+Runs the full pipeline: pocket extraction across multiple full PDBs, minimum-energy-path search on the pockets, automatic merge back into the originals, and optional per-segment post-processing (TS optimisation, thermochemistry, DFT).
+
+## Usage
+```bash
+pdb2reaction all -i R.pdb [I.pdb ...] P.pdb -c SUBSTRATE_SPEC
+                 [--ligand-charge MAP_OR_NUMBER]
+                 [--spin 2S+1]
+                 [--freeze-links/--no-freeze-links]
+                 [--max-nodes N] [--max-cycles N] [--climb/--no-climb]
+                 [--sopt-mode lbfgs|rfo|light|heavy]
+                 [--dump/--no-dump] [--out-dir DIR]
+                 [--pre-opt/--no-pre-opt]
+                 [--args-yaml FILE]
+                 [--tsopt/--no-tsopt] [--thermo/--no-thermo] [--dft/--no-dft]
+```
+
+## CLI options
+| Option | Description | Default |
+| --- | --- | --- |
+| `-i, --input PATH...` | Two or more full PDBs in reaction order. A single `-i` may be followed by multiple files. | Required |
+| `-c, --center TEXT` | Substrate specification (PDB path, residue IDs, or residue names) passed to the extractor. | Required |
+| `--out-dir PATH` | Top-level output directory. | `./result_all/` |
+| `-r, --radius FLOAT` | Pocket inclusion cutoff (Å). | `2.6` |
+| `--radius-het2het FLOAT` | Independent hetero–hetero cutoff (Å). | `0.0` |
+| `--include-H2O / --no-include-H2O` | Include waters. | `--include-H2O` |
+| `--exclude-backbone / --no-exclude-backbone` | Remove backbone atoms on non-substrate residues. | `--exclude-backbone` |
+| `--add-linkH / --no-add-linkH` | Add carbon-only link hydrogens. | `--add-linkH` |
+| `--selected-resn TEXT` | Residues to force include. | `""` |
+| `--ligand-charge TEXT` | Total charge or mapping for unknown residues (recommended). | `None` |
+| `--verbose / --no-verbose` | Extractor logging. | `--verbose` |
+| `-s, --spin INT` | Spin multiplicity forwarded to path search and post-processing. | `1` |
+| `--freeze-links / --no-freeze-links` | Freeze link parents in pocket PDBs. | `--freeze-links` |
+| `--max-nodes INT` | GSM internal nodes per segment. | `10` |
+| `--max-cycles INT` | GSM max cycles. | `100` |
+| `--climb / --no-climb` | Enable climbing image for the first segment per pair. | `--climb` |
+| `--sopt-mode TEXT` | Single-structure optimiser for HEI±1/kink nodes. | `lbfgs` |
+| `--dump / --no-dump` | Dump GSM and single-structure trajectories. | `--no-dump` |
+| `--args-yaml FILE` | YAML forwarded to `path_search` (see below). | _None_ |
+| `--pre-opt / --no-pre-opt` | Pre-optimise pocket endpoints before GSM. | `--pre-opt` |
+| `--tsopt / --no-tsopt` | Run TS optimisation and pseudo-IRC per reactive segment. | `--no-tsopt` |
+| `--thermo / --no-thermo` | Run vibrational analysis (freq) on R/TS/P and build Gibbs diagram. | `--no-thermo` |
+| `--dft / --no-dft` | Run single-point DFT on R/TS/P and build DFT energy diagram. | `--no-dft` |
+
+## YAML configuration (`--args-yaml`)
+The YAML file is forwarded unchanged to `path_search`. See [`path_search`](path_search.md#yaml-configuration-args-yaml) for accepted sections (`geom`, `calc`, `gs`, `opt`, `sopt`, `bond`, `search`).
+
+## Outputs
+- `<out-dir>/pockets/`: Pocket PDBs for each input.
+- `<out-dir>/path_search/`: GSM results (trajectory, merged full-system PDBs, energy diagrams, `summary.yaml`, segment folders).
+- Optional `<out-dir>/path_search/tsopt_seg_XX/` subtrees with TS optimisation, pseudo-IRC, frequency, and DFT results depending on toggles.
+- Console logs covering pocket charge summary, resolved configuration blocks, and per-stage timing.
+
+## Notes
+- The total pocket charge from the extractor (first model) is rounded to the nearest integer and used as the GSM charge.
+- Reference PDB templates for merging are taken automatically from the original inputs; the explicit `--ref-pdb` option of `path_search` is intentionally hidden in this wrapper.
+- When both `--thermo` and `--dft` are enabled, the post-processing stage also produces a DFT//UMA Gibbs diagram (DFT energy + UMA thermal correction).
+- Always provide `--ligand-charge` when formal charges are not inferable to ensure the correct total charge propagates through the pipeline.

--- a/docs/dft.md
+++ b/docs/dft.md
@@ -1,0 +1,56 @@
+# `dft` subcommand
+
+## Purpose
+Runs single-point DFT calculations using GPU4PySCF when available (falling back to CPU PySCF), reporting total energies and atomic charges.
+
+## Usage
+```bash
+pdb2reaction dft -i INPUT -q CHARGE -s SPIN
+                 [--func-basis FUNC/BASIS]
+                 [--max-cycle N] [--conv-tol Eh] [--grid-level L]
+                 [--out-dir DIR] [--args-yaml FILE]
+```
+
+## CLI options
+| Option | Description | Default |
+| --- | --- | --- |
+| `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
+| `-q, --charge INT` | Total charge supplied to PySCF. | Required |
+| `-s, --spin INT` | Spin multiplicity (2S+1). Converted to `2S` for PySCF. | Required |
+| `--func-basis TEXT` | Functional and basis in `FUNC/BASIS` form. | `wb97m-v/6-31g**` |
+| `--max-cycle INT` | Maximum SCF iterations (`dft.max_cycle`). | `100` |
+| `--conv-tol FLOAT` | SCF convergence tolerance in Hartree (`dft.conv_tol`). | `1e-9` |
+| `--grid-level INT` | PySCF numerical integration grid level (`dft.grid_level`). | `3` |
+| `--out-dir TEXT` | Output directory. | `./result_dft/` |
+| `--args-yaml FILE` | YAML overrides (see below). | _None_ |
+
+## YAML configuration (`--args-yaml`)
+Accepts a mapping with top-level key `dft`. CLI overrides YAML values.
+
+```yaml
+dft:
+  conv_tol: 1.0e-09
+  max_cycle: 100
+  grid_level: 3
+  verbose: 4
+  out_dir: ./result_dft/
+```
+
+### Section `dft`
+- `conv_tol` (`1e-9`): SCF convergence threshold (Hartree).
+- `max_cycle` (`100`): Maximum SCF iterations.
+- `grid_level` (`3`): PySCF `grids.level`.
+- `verbose` (`4`): PySCF verbosity (0–9).
+- `out_dir` (`"./result_dft/"`): Output directory.
+
+_Functional/basis selection and molecular charge/spin must be supplied on the CLI._
+
+## Outputs
+- `<out-dir>/input_geometry.xyz`: Geometry snapshot passed to PySCF.
+- `<out-dir>/result.yaml`: Total energy (Hartree and kcal·mol⁻¹), convergence status, engine metadata, SCF wall time, and Mulliken/Löwdin/IAO charges.
+- Console pretty block summarising charge, multiplicity, functional, basis, convergence settings, and output directory.
+
+## Notes
+- GPU4PySCF is used when available; otherwise a CPU SCF object is built. Nonlocal VV10 is enabled automatically for `-v` functionals.
+- The YAML file must contain a mapping root; non-mapping roots raise an error via `load_yaml_dict`.
+- Exit codes: `0` (converged), `3` (not converged), `2` (PySCF import failure), `1` (other errors), `130` (interrupt).

--- a/docs/extract.md
+++ b/docs/extract.md
@@ -1,0 +1,47 @@
+# `extract` subcommand
+
+## Purpose
+Extracts binding pockets from protein–substrate complexes by selecting residues within distance cutoffs, optionally pruning backbone atoms, and adding link hydrogens.
+
+## Usage
+```bash
+pdb2reaction extract -i COMPLEX.pdb [COMPLEX2.pdb ...]
+                     -c SUBSTRATE_SPEC
+                     [-o POCKET.pdb [POCKET2.pdb ...]]
+                     [--radius Å] [--radius-het2het Å]
+                     [--include-H2O true|false]
+                     [--exclude-backbone true|false]
+                     [--add-linkH true|false]
+                     [--selected-resn LIST]
+                     [--ligand-charge MAP_OR_NUMBER]
+                     [--verbose true|false]
+```
+
+_Subcommand `extract` is invoked via the Click wrapper in `pdb2reaction cli`, which forwards to the argparse-based implementation shown above._
+
+## CLI options
+| Option | Description | Default |
+| --- | --- | --- |
+| `-i, --input PATH...` | One or more full protein–ligand PDB files (identical atom ordering required). | Required |
+| `-c, --center SPEC` | Substrate specification: PDB path, residue-ID list (e.g. `123,124` or `A:123,B:456`), or residue-name list (e.g. `GPP,MMT`). | Required |
+| `-o, --output PATH...` | Pocket PDB output(s). Provide one path for a multi-MODEL file or N paths matching the number of inputs. | Auto-generated (`pocket.pdb` / `pocket_<input>.pdb`) |
+| `-r, --radius FLOAT` | Atom–atom distance cutoff (Å) for inclusion. | `2.6` |
+| `--radius-het2het FLOAT` | Independent hetero–hetero cutoff (Å) for non-C/H pairs. | `0.0` (internally treated as 0.001 Å) |
+| `--include-H2O BOOL` | Include water residues (HOH/WAT/TIP3/SOL). | `true` |
+| `--exclude-backbone BOOL` | Remove backbone atoms (N/H*/CA/HA*/C/O) on non-substrate amino acids (PRO/HYP safeguards). | `true` |
+| `--add-linkH BOOL` | Add carbon-only link hydrogens at 1.09 Å along severed bonds. | `true` |
+| `--selected-resn TEXT` | Residue IDs to force-include (comma/space separated; chain/insertion codes supported). | `""` |
+| `--ligand-charge TEXT` | Either a total charge (number) or mapping like `GPP:-3,MMT:-1` to distribute across unknown residues. | `None` |
+| `-v, --verbose` | Enable INFO-level logging. | `true` |
+
+## YAML configuration (`--args-yaml`)
+Not supported.
+
+## Outputs
+- Pocket PDB(s) containing the extracted residues, with optional link hydrogens appended after a `TER` record.
+- Charge summary (protein/ligand/ion/total) printed to stdout when extraction succeeds.
+
+## Notes
+- Multi-structure mode (`-i` with multiple files) produces a pocket per input; atom ordering must match across inputs.
+- Substrate residue lists support insertion codes (e.g. `123A`, `A:123A`). When residue-name mode yields duplicates, all matches are included and a warning is logged.
+- Water selection recognises HOH/WAT/TIP3/SOL residues; backbone trimming skips PRO/HYP nitrogen atoms.

--- a/docs/freq.md
+++ b/docs/freq.md
@@ -1,0 +1,84 @@
+# `freq` subcommand
+
+## Purpose
+Computes vibrational frequencies using UMA, performs partial Hessian vibrational analysis (PHVA) when atoms are frozen, exports animated modes, and prints a thermochemistry summary.
+
+## Usage
+```bash
+pdb2reaction freq -i INPUT -q CHARGE [--spin 2S+1]
+                  [--freeze-links/--no-freeze-links]
+                  [--max-write N] [--amplitude-ang Å] [--n-frames N]
+                  [--sort value|abs] [--out-dir DIR]
+                  [--temperature K] [--pressure atm] [--dump/--no-dump]
+                  [--hessian-calc-mode Analytical|FiniteDifference]
+                  [--args-yaml FILE]
+```
+
+## CLI options
+| Option | Description | Default |
+| --- | --- | --- |
+| `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
+| `-q, --charge INT` | Total charge. | Required |
+| `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
+| `--freeze-links / --no-freeze-links` | For PDB inputs, freeze link-hydrogen parents (merged with `geom.freeze_atoms`). | `--freeze-links` |
+| `--max-write INT` | Number of modes to export. | `20` |
+| `--amplitude-ang FLOAT` | Animation amplitude (Å). | `0.8` |
+| `--n-frames INT` | Frames per mode animation. | `20` |
+| `--sort CHOICE` | Mode ordering: `value` (cm⁻¹) or `abs`. | `value` |
+| `--out-dir TEXT` | Output directory. | `./result_freq/` |
+| `--temperature FLOAT` | Thermochemistry temperature (K). | `298.15` |
+| `--pressure FLOAT` | Thermochemistry pressure (atm). | `1.0` |
+| `--dump / --no-dump` | Write `thermoanalysis.yaml`. | `--no-dump` |
+| `--hessian-calc-mode CHOICE` | UMA Hessian mode (`Analytical` or `FiniteDifference`). | _None_ |
+| `--args-yaml FILE` | YAML overrides (see below). | _None_ |
+
+## YAML configuration (`--args-yaml`)
+Accepts a mapping; CLI overrides YAML. Shared sections reuse [`opt`](opt.md#yaml-configuration-args-yaml).
+
+```yaml
+geom:
+  coord_type: cart
+  freeze_atoms: []
+calc:
+  charge: 0            # overridden by -q/--charge
+  spin: 1              # overridden by -s/--spin
+  model: uma-s-1p1
+  task_name: omol
+  device: auto
+  max_neigh: null
+  radius: null
+  r_edges: false
+  out_hess_torch: true
+  freeze_atoms: null
+  hessian_calc_mode: Analytical
+  return_partial_hessian: true
+freq:
+  amplitude_ang: 0.8
+  n_frames: 20
+  max_write: 20
+  sort: value
+```
+
+### Shared sections
+- `geom`, `calc`: same keys as [`opt`](opt.md#yaml-configuration-args-yaml). `--freeze-links` augments `geom.freeze_atoms`, which are also forwarded to UMA for Hessian calculations.
+
+### Section `freq`
+Controls mode export.
+
+- `amplitude_ang` (`0.8`): Animation amplitude (Å).
+- `n_frames` (`20`): Frames per vibrational animation.
+- `max_write` (`20`): Number of modes to export.
+- `sort` (`"value"`): Ordering (`"value"` ascending or `"abs"` for absolute value).
+
+_The thermochemistry parameters (`temperature`, `pressure_atm`, `dump`) are currently CLI-only and not read from YAML._
+
+## Outputs
+- `<out-dir>/mode_XXXX_±freqcm-1.(trj|pdb)` animations for exported modes.
+- `<out-dir>/frequencies_cm-1.txt` sorted list of frequencies.
+- Optional `<out-dir>/thermoanalysis.yaml` when `--dump` is enabled.
+- Console blocks summarising resolved `geom`, `calc`, `freq`, and thermochemistry settings.
+
+## Notes
+- Imaginary modes are reported as negative frequencies; PHVA restricts the Hessian to active degrees of freedom when atoms are frozen.
+- `--hessian-calc-mode` overrides `calc.hessian_calc_mode`; Analytical mode may require more GPU memory than finite differences.
+- Mode animations use sinusoidal displacements; PDB animations employ MODEL/ENDMDL records for multi-model files.

--- a/docs/irc.md
+++ b/docs/irc.md
@@ -1,0 +1,108 @@
+# `irc` subcommand
+
+## Purpose
+Runs Intrinsic Reaction Coordinate (IRC) integrations with the EulerPC predictor–corrector method using UMA, writing forward/backward trajectories and optional HDF5 dumps.
+
+## Usage
+```bash
+pdb2reaction irc -i INPUT -q CHARGE [--spin 2S+1]
+                 [--max-cycles N] [--step-size Δs] [--root k]
+                 [--forward BOOL] [--backward BOOL]
+                 [--freeze-links/--no-freeze-links]
+                 [--out-dir DIR]
+                 [--hessian-calc-mode Analytical|FiniteDifference]
+                 [--args-yaml FILE]
+```
+
+## CLI options
+| Option | Description | Default |
+| --- | --- | --- |
+| `-i, --input PATH` | Transition-state structure accepted by `geom_loader`. | Required |
+| `-q, --charge INT` | Total charge. | Required |
+| `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
+| `--max-cycles INT` | Maximum IRC steps (overrides `irc.max_cycles`). | _None_ (use YAML/default `125`) |
+| `--step-size FLOAT` | Step length in mass-weighted coordinates (overrides `irc.step_length`). | _None_ (default `0.10`) |
+| `--root INT` | Imaginary-mode index for the initial displacement (`irc.root`). | _None_ (default `0`) |
+| `--forward BOOL` | Run forward branch (`irc.forward`). Explicit `True` or `False`. | _None_ (default `True`) |
+| `--backward BOOL` | Run backward branch (`irc.backward`). Explicit `True` or `False`. | _None_ (default `True`) |
+| `--freeze-links / --no-freeze-links` | For PDB inputs, freeze link-hydrogen parents (merged with `geom.freeze_atoms`). | `--freeze-links` |
+| `--out-dir TEXT` | Output directory (`irc.out_dir`). | `./result_irc/` |
+| `--hessian-calc-mode CHOICE` | UMA Hessian mode. | _None_ |
+| `--args-yaml FILE` | YAML overrides (see below). | _None_ |
+
+## YAML configuration (`--args-yaml`)
+Provide a mapping; CLI overrides YAML. Shared sections reuse [`opt`](opt.md#yaml-configuration-args-yaml) for geometry/calculator keys.
+
+```yaml
+geom:
+  coord_type: cart
+  freeze_atoms: []
+calc:
+  charge: 0            # overridden by -q/--charge
+  spin: 1              # overridden by -s/--spin
+  model: uma-s-1p1
+  task_name: omol
+  device: auto
+  max_neigh: null
+  radius: null
+  r_edges: false
+  out_hess_torch: true
+  freeze_atoms: null
+  hessian_calc_mode: Analytical
+  return_partial_hessian: true
+irc:
+  step_length: 0.1
+  max_cycles: 125
+  downhill: false
+  forward: true
+  backward: true
+  root: 0
+  hessian_init: calc
+  displ: energy
+  displ_energy: 0.001
+  displ_length: 0.1
+  rms_grad_thresh: 0.001
+  hard_rms_grad_thresh: null
+  energy_thresh: 1.0e-06
+  imag_below: 0.0
+  force_inflection: true
+  check_bonds: false
+  out_dir: ./result_irc/
+  prefix: ""
+  dump_fn: irc_data.h5
+  dump_every: 5
+  hessian_update: bofill
+  hessian_recalc: null
+  max_pred_steps: 500
+  loose_cycles: 3
+  corr_func: mbs
+```
+
+### Shared sections
+- `geom`: same keys as [`opt`](opt.md#section-geom). `--freeze-links` augments `geom.freeze_atoms`.
+- `calc`: same keys as [`opt`](opt.md#section-calc). `--hessian-calc-mode` overrides `calc.hessian_calc_mode` after merging.
+
+### Section `irc`
+EulerPC / IRC controls (defaults in parentheses).
+
+- `step_length` (`0.10`): Step length in mass-weighted coordinates (overridden by `--step-size`).
+- `max_cycles` (`125`): Maximum IRC steps (overridden by `--max-cycles`).
+- `downhill` (`False`): Follow downhill potential energy.
+- `forward` (`True`), `backward` (`True`): Integrate forward/backward branches.
+- `root` (`0`): Imaginary-mode index for initial displacement.
+- `hessian_init` (`"calc"`): Source for initial Hessian.
+- `displ` (`"energy"`), `displ_energy` (`1.0e-3`), `displ_length` (`0.10`): Displacement control.
+- Convergence thresholds: `rms_grad_thresh` (`1.0e-3`), `hard_rms_grad_thresh` (`null`), `energy_thresh` (`1.0e-6`), `imag_below` (`0.0`).
+- Termination flags: `force_inflection` (`True`), `check_bonds` (`False`).
+- Output: `out_dir` (`"./result_irc/"`), `prefix` (`""`), `dump_fn` (`"irc_data.h5"`), `dump_every` (`5`).
+- EulerPC specifics: `hessian_update` (`"bofill"`), `hessian_recalc` (`null`), `max_pred_steps` (`500`), `loose_cycles` (`3`), `corr_func` (`"mbs"`).
+
+## Outputs
+- `<out-dir>/irc_data.h5` (written every `dump_every` steps).
+- `<out-dir>/<prefix>finished_irc.trj` plus optional forward/backward `.trj` and `.pdb` files when the input was PDB.
+- Console summaries of resolved `geom`, `calc`, and `irc` configurations plus timing.
+
+## Notes
+- CLI boolean options `--forward` and `--backward` require explicit `True` or `False` (e.g., `--forward True`).
+- When the input is PDB, trajectory files are converted to PDB using the input topology.
+- IRC calculations reuse the UMA calculator across steps; large `step_length` values may destabilise the integration.

--- a/docs/opt.md
+++ b/docs/opt.md
@@ -1,0 +1,183 @@
+# `opt` subcommand
+
+## Purpose
+Performs single-structure geometry optimizations with pysisyphus using either the LBFGS ("light") or RFOptimizer ("heavy") algorithms backed by the UMA machine-learning calculator.
+
+## Usage
+```bash
+pdb2reaction opt -i INPUT -q CHARGE [--spin 2S+1] [--opt-mode light|lbfgs|heavy|rfo]
+                 [--freeze-links/--no-freeze-links] [--dump/--no-dump]
+                 [--out-dir DIR] [--max-cycles N] [--args-yaml FILE]
+```
+
+## CLI options
+| Option | Description | Default |
+| --- | --- | --- |
+| `-i, --input PATH` | Structure file accepted by `geom_loader` (`.pdb`, `.xyz`, `.trj`, …). | Required |
+| `-q, --charge INT` | Total charge passed to UMA. | Required |
+| `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
+| `--freeze-links / --no-freeze-links` | When the input is PDB, detect link hydrogens and freeze their parent atoms (merged with `geom.freeze_atoms`). | `--freeze-links` |
+| `--max-cycles INT` | Maximum optimization cycles (`opt.max_cycles`). | `10000` |
+| `--opt-mode TEXT` | Select optimizer: `light`/`lbfgs` → LBFGS, `heavy`/`rfo` → RFO. | `light` |
+| `--dump / --no-dump` | Emit `optimization.trj`. | `--no-dump` |
+| `--out-dir TEXT` | Output directory. | `./result_opt/` |
+| `--args-yaml FILE` | YAML overrides (see below). | _None_ |
+
+## YAML configuration (`--args-yaml`)
+Pass a YAML mapping; CLI values override YAML, which override the defaults below.
+
+```yaml
+geom:
+  coord_type: cart
+  freeze_atoms: []
+calc:
+  charge: 0            # overridden by -q/--charge
+  spin: 1              # overridden by -s/--spin
+  model: uma-s-1p1
+  task_name: omol
+  device: auto
+  max_neigh: null
+  radius: null
+  r_edges: false
+  out_hess_torch: true
+  freeze_atoms: null
+  hessian_calc_mode: Analytical
+  return_partial_hessian: true
+opt:
+  thresh: gau
+  max_cycles: 10000
+  print_every: 1
+  min_step_norm: 1.0e-08
+  assert_min_step: true
+  rms_force: null
+  rms_force_only: false
+  max_force_only: false
+  force_only: false
+  converge_to_geom_rms_thresh: 0.05
+  overachieve_factor: 0.0
+  check_eigval_structure: false
+  line_search: true
+  dump: false
+  dump_restart: false
+  prefix: ""
+  out_dir: ./result_opt/
+lbfgs:
+  thresh: gau
+  max_cycles: 10000
+  print_every: 1
+  min_step_norm: 1.0e-08
+  assert_min_step: true
+  rms_force: null
+  rms_force_only: false
+  max_force_only: false
+  force_only: false
+  converge_to_geom_rms_thresh: 0.05
+  overachieve_factor: 0.0
+  check_eigval_structure: false
+  line_search: true
+  dump: false
+  dump_restart: false
+  prefix: ""
+  out_dir: ./result_opt/
+  keep_last: 7
+  beta: 1.0
+  gamma_mult: false
+  max_step: 0.3
+  control_step: true
+  double_damp: true
+  mu_reg: null
+  max_mu_reg_adaptions: 10
+rfo:
+  thresh: gau
+  max_cycles: 10000
+  print_every: 1
+  min_step_norm: 1.0e-08
+  assert_min_step: true
+  rms_force: null
+  rms_force_only: false
+  max_force_only: false
+  force_only: false
+  converge_to_geom_rms_thresh: 0.05
+  overachieve_factor: 0.0
+  check_eigval_structure: false
+  line_search: true
+  dump: false
+  dump_restart: false
+  prefix: ""
+  out_dir: ./result_opt/
+  trust_radius: 0.3
+  trust_update: true
+  trust_min: 0.01
+  trust_max: 0.3
+  max_energy_incr: null
+  hessian_update: bfgs
+  hessian_init: calc
+  hessian_recalc: 100
+  hessian_recalc_adapt: 2.0
+  small_eigval_thresh: 1.0e-08
+  alpha0: 1.0
+  max_micro_cycles: 25
+  rfo_overlaps: false
+  gdiis: true
+  gediis: false
+  gdiis_thresh: 0.0025
+  gediis_thresh: 0.01
+  gdiis_test_direction: true
+  adapt_step_func: false
+```
+
+### Section `geom`
+Geometry loader options (see also `pdb2reaction.uma_pysis.GEOM_KW_DEFAULT`).
+
+- `coord_type` (`"cart"`): Coordinate representation for `geom_loader` (`"cart"` or `"dlc"`).
+- `freeze_atoms` (`[]`): 0-based indices to freeze; merged with link parents when `--freeze-links`.
+
+### Section `calc`
+UMA calculator options (see also `pdb2reaction/uma_pysis.py`).
+
+- `charge` / `spin`: Overridden by `-q/-s`.
+- `model` (`"uma-s-1p1"`) and `task_name` (`"omol"`): UMA checkpoint and dataset tag.
+- `device` (`"auto"`), `max_neigh`, `radius`, `r_edges`: Graph/device controls.
+- `out_hess_torch` (`True`): Request a Torch Hessian (GPU-friendly).
+- `freeze_atoms`: Auto-filled from `geom.freeze_atoms`.
+- `hessian_calc_mode` (`"Analytical"`) and `return_partial_hessian` (`True`): UMA Hessian controls.
+
+### Section `opt`
+Shared optimizer controls.
+
+- `thresh` (`"gau"`): Convergence preset (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`).
+- `max_cycles` (`10000`), `print_every` (`1`), `dump` (`False`), `dump_restart` (`False`), `prefix` (`""`), `out_dir` (`"./result_opt/"`).
+- Safeguards: `min_step_norm` (`1e-8`), `assert_min_step` (`True`).
+- Convergence flags: `rms_force`, `rms_force_only`, `max_force_only`, `force_only`.
+- Extras: `converge_to_geom_rms_thresh`, `overachieve_factor`, `check_eigval_structure`, `line_search`.
+
+### Section `lbfgs`
+Specific to the LBFGS optimizer (`--opt-mode light|lbfgs`).
+
+- `keep_last` (`7`): Memory depth.
+- `beta` (`1.0`), `gamma_mult` (`False`): Initial scaling.
+- Step control: `max_step` (`0.30`), `control_step` (`True`).
+- Safeguards: `double_damp` (`True`).
+- Regularization: `mu_reg` (`None`), `max_mu_reg_adaptions` (`10`).
+
+### Section `rfo`
+Specific to RFOptimizer (`--opt-mode heavy|rfo`).
+
+- Trust region: `trust_radius` (`0.30`), `trust_min` (`0.01`), `trust_max` (`0.30`), `trust_update` (`True`).
+- Energy guard: `max_energy_incr` (`None`).
+- Hessian management: `hessian_update` (`"bfgs"`), `hessian_init` (`"calc"`), `hessian_recalc` (`100`), `hessian_recalc_adapt` (`2.0`).
+- Numerics: `small_eigval_thresh` (`1e-8`), `line_search` (`True`), `alpha0` (`1.0`), `max_micro_cycles` (`25`), `rfo_overlaps` (`False`).
+- DIIS controls: `gdiis` (`True`), `gediis` (`False`), `gdiis_thresh` (`2.5e-3`), `gediis_thresh` (`1.0e-2`), `gdiis_test_direction` (`True`).
+- `adapt_step_func` (`False`).
+
+## Outputs
+- `final_geometry.xyz` (+ `.pdb` when the input was PDB).
+- Optional `optimization.trj` (+ `.pdb` when dumping and PDB input).
+- Optional restart YAML files when `opt.dump_restart` is set.
+- Console blocks summarising resolved `geom`, `calc`, `opt`, and LBFGS/RFO settings.
+
+## Notes
+- Always provide the chemically correct charge and multiplicity.
+- `--freeze-links` is PDB-only and merges link parents into `geom.freeze_atoms`.
+- CLI precedence: CLI > YAML > built-in defaults.
+- Exit codes: `0` success, `2` zero-step error, `3` optimizer failure, `130` interrupt, `1` unexpected error.

--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -1,0 +1,114 @@
+# `path_opt` subcommand
+
+## Purpose
+Optimizes a minimum-energy path between two endpoints using the pysisyphus Growing String method with UMA providing energies, gradients, and Hessians.
+
+## Usage
+```bash
+pdb2reaction path_opt -i REACTANT PRODUCT -q CHARGE [--spin 2S+1]
+                      [--freeze-links/--no-freeze-links]
+                      [--max-nodes N] [--max-cycles N] [--climb/--no-climb]
+                      [--dump/--no-dump] [--out-dir DIR] [--args-yaml FILE]
+```
+
+## CLI options
+| Option | Description | Default |
+| --- | --- | --- |
+| `-i, --input PATH PATH` | Two endpoint structures (reactant, product). | Required |
+| `-q, --charge INT` | Total charge. | Required |
+| `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
+| `--freeze-links / --no-freeze-links` | For PDB inputs, freeze link-hydrogen parents. | `--freeze-links` |
+| `--max-nodes INT` | Internal nodes in the string (total images = `max_nodes + 2`). | `30` |
+| `--max-cycles INT` | Maximum optimizer cycles. | `1000` |
+| `--climb / --no-climb` | Enable climbing-image refinement. | `--climb` |
+| `--dump / --no-dump` | Dump optimizer trajectories and restarts. | `--no-dump` |
+| `--out-dir TEXT` | Output directory. | `./result_path_opt/` |
+| `--args-yaml FILE` | YAML overrides (see below). | _None_ |
+
+## YAML configuration (`--args-yaml`)
+The YAML root must be a mapping. CLI values override YAML. Shared sections reuse [`opt`](opt.md#yaml-configuration-args-yaml).
+
+```yaml
+geom:
+  coord_type: cart
+  freeze_atoms: []
+calc:
+  charge: 0            # overridden by -q/--charge
+  spin: 1              # overridden by -s/--spin
+  model: uma-s-1p1
+  task_name: omol
+  device: auto
+  max_neigh: null
+  radius: null
+  r_edges: false
+  out_hess_torch: true
+  freeze_atoms: null
+  hessian_calc_mode: Analytical
+  return_partial_hessian: true
+gs:
+  max_nodes: 30
+  perp_thresh: 0.005
+  reparam_check: rms
+  reparam_every: 1
+  reparam_every_full: 1
+  param: equi
+  max_micro_cycles: 10
+  reset_dlc: true
+  climb: true
+  climb_rms: 0.0005
+  climb_lanczos: true
+  climb_lanczos_rms: 0.0005
+  climb_fixed: false
+  scheduler: null
+opt:
+  type: string
+  stop_in_when_full: 100
+  align: false
+  scale_step: global
+  max_cycles: 100
+  dump: false
+  dump_restart: false
+  reparam_thresh: 0.001
+  coord_diff_thresh: 0.0
+  out_dir: ./result_path_opt/
+  print_every: 1
+```
+
+### Shared sections
+- `geom`, `calc`: same keys as [`opt`](opt.md#yaml-configuration-args-yaml). `--freeze-links` augments `geom.freeze_atoms` for PDB inputs.
+
+### Section `gs`
+Growing String controls (defaults shown in parentheses).
+
+- `max_nodes` (`30`): Internal nodes (overridden by `--max-nodes`).
+- `perp_thresh` (`5e-3`): Growth convergence threshold on perpendicular forces.
+- `reparam_check` (`"rms"`), `reparam_every` (`1`), `reparam_every_full` (`1`): Reparametrisation cadence and metric.
+- `param` (`"equi"`): Node spacing (`"equi"` or `"energy"`).
+- `max_micro_cycles` (`10`): Micro-iterations per macro step.
+- `reset_dlc` (`True`): Reset DLC coordinates when appropriate.
+- `climb` (`True`), `climb_rms` (`5e-4`), `climb_lanczos` (`True`), `climb_lanczos_rms` (`5e-4`), `climb_fixed` (`False`): Climbing image controls (overridden by `--climb`).
+- `scheduler` (`None`): Execution scheduler (normally left `None` for shared calculator use).
+
+### Section `opt`
+StringOptimizer controls (defaults in parentheses).
+
+- `type` (`"string"`): Label for bookkeeping.
+- `stop_in_when_full` (`100`): Extra cycles allowed after full growth (overridden by `--max-cycles`).
+- `align` (`False`): Internal alignment disabled (external Kabsch alignment is used).
+- `scale_step` (`"global"`): Step scaling policy.
+- `max_cycles` (`100`): Macro-iteration cap (overridden by `--max-cycles`).
+- `dump` (`False`), `dump_restart` (`False`): Trajectory/restart dumping (dump toggled by CLI).
+- `reparam_thresh` (`1e-3`), `coord_diff_thresh` (`0.0`): Reparametrisation and pruning thresholds.
+- `out_dir` (`"./result_path_opt/"`), `print_every` (`1`): Output location and logging cadence.
+
+## Outputs
+- `<out-dir>/final_geometries.trj` (+ `.pdb` when a PDB reference is available).
+- `<out-dir>/gsm_hei.xyz` (+ `.pdb` for PDB inputs) for the highest-energy image.
+- `<out-dir>/align_refine/` alignment diagnostics.
+- Optional optimizer dumps/restarts when `--dump` or YAML toggles them.
+
+## Notes
+- Inputs are rigidly aligned via Kabsch before optimisation; if freeze atoms are present, only those atoms guide the fit.
+- UMA calculator instances are shared across all images for efficiency.
+- When the input is PDB, link-hydrogen parents are merged into `geom.freeze_atoms` before loading.
+- Exit codes: `0` success, `3` optimization failure, `4`/`5` write failures, `130` interrupt, `1` unexpected error.

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -1,0 +1,211 @@
+# `path_search` subcommand
+
+## Purpose
+Runs a recursive Growing String (GSM) search across multiple structures (reactant → intermediates → product), stitches segment paths, and optionally merges pocket trajectories back into full PDB templates.
+
+## Usage
+```bash
+pdb2reaction path_search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--spin 2S+1]
+                         [--freeze-links/--no-freeze-links]
+                         [--max-nodes N] [--max-cycles N] [--climb/--no-climb]
+                         [--sopt-mode lbfgs|rfo|light|heavy] [--dump/--no-dump]
+                         [--out-dir DIR] [--pre-opt/--no-pre-opt]
+                         [--align/--no-align] [--ref-pdb FILE ...]
+                         [--args-yaml FILE]
+```
+
+## CLI options
+| Option | Description | Default |
+| --- | --- | --- |
+| `-i, --input PATH...` | Two or more structures in reaction order (reactant → product). A single `-i` may be followed by multiple paths. | Required |
+| `-q, --charge INT` | Total charge. | Required |
+| `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
+| `--freeze-links / --no-freeze-links` | For PDB inputs, freeze link-hydrogen parents when building pockets. | `--freeze-links` |
+| `--max-nodes INT` | Internal nodes for GSM segments (`String` has `max_nodes + 2` images). | `10` |
+| `--max-cycles INT` | Maximum GSM optimization cycles. | `100` |
+| `--climb / --no-climb` | Enable climbing image for the first segment in each pair. | `--climb` |
+| `--sopt-mode TEXT` | Single-structure optimizer for HEI±1/kink nodes (`light|lbfgs` or `heavy|rfo`). | `lbfgs` |
+| `--dump / --no-dump` | Dump GSM and single-structure trajectories. | `--no-dump` |
+| `--out-dir TEXT` | Output directory. | `./result_path_search/` |
+| `--args-yaml FILE` | YAML overrides (see below). | _None_ |
+| `--pre-opt / --no-pre-opt` | Pre-optimise each endpoint before the GSM search. | `--pre-opt` |
+| `--align / --no-align` | Align all inputs to the first structure before searching. | `--align` |
+| `--ref-pdb PATH...` | Full-size template PDBs (one per input, unless `--align` lets you reuse the first). | _None_ |
+
+## YAML configuration (`--args-yaml`)
+The YAML root must be a mapping. CLI parameters override YAML values. Shared sections reuse [`opt`](opt.md#yaml-configuration-args-yaml).
+
+```yaml
+geom:
+  coord_type: cart
+  freeze_atoms: []
+calc:
+  charge: 0            # overridden by -q/--charge
+  spin: 1              # overridden by -s/--spin
+  model: uma-s-1p1
+  task_name: omol
+  device: auto
+  max_neigh: null
+  radius: null
+  r_edges: false
+  out_hess_torch: true
+  freeze_atoms: null
+  hessian_calc_mode: Analytical
+  return_partial_hessian: true
+gs:
+  max_nodes: 10
+  perp_thresh: 0.005
+  reparam_check: rms
+  reparam_every: 1
+  reparam_every_full: 1
+  param: equi
+  max_micro_cycles: 10
+  reset_dlc: true
+  climb: true
+  climb_rms: 0.0005
+  climb_lanczos: true
+  climb_lanczos_rms: 0.0005
+  climb_fixed: false
+  scheduler: null
+opt:
+  type: string
+  stop_in_when_full: 1000
+  align: false
+  scale_step: global
+  max_cycles: 1000
+  dump: false
+  dump_restart: false
+  reparam_thresh: 0.001
+  coord_diff_thresh: 0.0
+  out_dir: ./result_path_search/
+  print_every: 1
+sopt:
+  lbfgs:
+    thresh: gau
+    max_cycles: 10000
+    print_every: 1
+    min_step_norm: 1.0e-08
+    assert_min_step: true
+    rms_force: null
+    rms_force_only: false
+    max_force_only: false
+    force_only: false
+    converge_to_geom_rms_thresh: 0.05
+    overachieve_factor: 0.0
+    check_eigval_structure: false
+    line_search: true
+    dump: false
+    dump_restart: false
+    prefix: ""
+    out_dir: ./result_path_search/
+    keep_last: 7
+    beta: 1.0
+    gamma_mult: false
+    max_step: 0.3
+    control_step: true
+    double_damp: true
+    mu_reg: null
+    max_mu_reg_adaptions: 10
+  rfo:
+    thresh: gau
+    max_cycles: 10000
+    print_every: 1
+    min_step_norm: 1.0e-08
+    assert_min_step: true
+    rms_force: null
+    rms_force_only: false
+    max_force_only: false
+    force_only: false
+    converge_to_geom_rms_thresh: 0.05
+    overachieve_factor: 0.0
+    check_eigval_structure: false
+    line_search: true
+    dump: false
+    dump_restart: false
+    prefix: ""
+    out_dir: ./result_path_search/
+    trust_radius: 0.3
+    trust_update: true
+    trust_min: 0.01
+    trust_max: 0.3
+    max_energy_incr: null
+    hessian_update: bfgs
+    hessian_init: calc
+    hessian_recalc: 100
+    hessian_recalc_adapt: 2.0
+    small_eigval_thresh: 1.0e-08
+    alpha0: 1.0
+    max_micro_cycles: 25
+    rfo_overlaps: false
+    gdiis: true
+    gediis: false
+    gdiis_thresh: 0.0025
+    gediis_thresh: 0.01
+    gdiis_test_direction: true
+    adapt_step_func: false
+bond:
+  device: cuda
+  bond_factor: 1.2
+  margin_fraction: 0.05
+  delta_fraction: 0.05
+search:
+  max_depth: 10
+  stitch_rmsd_thresh: 0.0001
+  bridge_rmsd_thresh: 0.0001
+  rmsd_align: true
+  max_nodes_segment: 10
+  max_nodes_bridge: 5
+  kink_max_nodes: 3
+```
+
+### Shared sections
+- `geom`, `calc`: same keys as [`opt`](opt.md#yaml-configuration-args-yaml). `--freeze-links` augments `geom.freeze_atoms` when inputs are PDB.
+
+### Section `gs`
+Growing String controls for main segments. Defaults derive from `pdb2reaction.path_opt.GS_KW` with overrides:
+
+- `max_nodes` (`10`): Internal nodes per GSM segment (CLI override).
+- `reparam_every_full` (`1`), `climb_rms` (`5e-4`), `climb_fixed` (`False`): Growth/climb behaviour.
+- Additional keys match [`path_opt`](path_opt.md#section-gs).
+
+### Section `opt`
+StringOptimizer controls for GSM (defaults in parentheses).
+
+- `stop_in_when_full` (`1000`) and `max_cycles` (`1000`): Cycle caps (CLI overrides `--max-cycles`).
+- `dump` (`False`), `dump_restart` (`False`), `out_dir` (`"./result_path_search/"`), `print_every` (`1`), `align` (`False`).
+- Other keys mirror [`path_opt`](path_opt.md#section-opt).
+
+### Section `sopt`
+Single-structure optimization defaults for HEI±1 and kink nodes. Split into `lbfgs` and `rfo` subsections.
+
+- `sopt.lbfgs`: Same keys as [`opt`](opt.md#section-lbfgs) but with defaults adapted for path search (`out_dir: ./result_path_search/`, `dump: False`).
+- `sopt.rfo`: Same keys as [`opt`](opt.md#section-rfo) with analogous defaults.
+
+### Section `bond`
+Bond-change detection parameters (identical to [`scan`](scan.md#section-bond)).
+
+- `device` (`"cuda"`), `bond_factor` (`1.20`), `margin_fraction` (`0.05`), `delta_fraction` (`0.05`).
+
+### Section `search`
+Recursive path-building controls.
+
+- `max_depth` (`10`): Recursion depth for segment refinement.
+- `stitch_rmsd_thresh` (`1.0e-4`): Maximum RMSD to consider endpoints duplicates during stitching.
+- `bridge_rmsd_thresh` (`1.0e-4`): RMSD threshold to trigger insertion of bridge GSMs.
+- `rmsd_align` (`True`): Retained for compatibility (ignored internally).
+- `max_nodes_segment` (`10`): Max nodes per recursive segment (defaults to `--max-nodes` if unspecified).
+- `max_nodes_bridge` (`5`): Nodes for bridge GSMs.
+- `kink_max_nodes` (`3`): Linear interpolation nodes for skipped GSM at kinks.
+
+## Outputs
+- `<out-dir>/mep.trj` (+ `.pdb` when pockets were PDB inputs).
+- `<out-dir>/mep_w_ref.pdb` merged full-system trajectory (requires `--ref-pdb` or auto-supplied templates).
+- `<out-dir>/summary.yaml` summarising segment barriers and classification.
+- Per-segment folders containing GSM dumps, merged structures, and diagnostic energy plots.
+- Console reports covering resolved configuration blocks (`geom`, `calc`, `gs`, `opt`, `sopt.*`, `bond`, `search`).
+
+## Notes
+- Provide at least two inputs; `click.BadParameter` is raised otherwise.
+- `--ref-pdb` can be given once followed by multiple filenames; with `--align`, only the first template is reused for merges.
+- All UMA calculators are shared across structures for efficiency.
+- When `--dump` is set, GSM and single-structure optimizations emit trajectories and restart YAML files.

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -1,0 +1,171 @@
+# `scan` subcommand
+
+## Purpose
+Performs staged bond-length scans with harmonic restraints and single-structure relaxations after each step, using UMA plus pysisyphus optimizers.
+
+## Usage
+```bash
+pdb2reaction scan -i INPUT -q CHARGE --scan-lists "[(i,j,target), ...]" [...]
+                  [--one-based/--zero-based] [--max-step-size ΔÅ] [--bias-k k]
+                  [--relax-max-cycles N] [--opt-mode light|lbfgs|heavy|rfo]
+                  [--freeze-links/--no-freeze-links] [--dump/--no-dump]
+                  [--out-dir DIR] [--preopt/--no-preopt] [--endopt/--no-endopt]
+                  [--args-yaml FILE]
+```
+
+## CLI options
+| Option | Description | Default |
+| --- | --- | --- |
+| `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
+| `-q, --charge INT` | Total charge. | Required |
+| `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
+| `--scan-lists TEXT` | Repeatable Python-like list literal of `(i, j, targetÅ)` triples defining each scan stage. | Required |
+| `--one-based / --zero-based` | Interpret `(i, j)` indices as 1-based (default) or 0-based. | `--one-based` |
+| `--max-step-size FLOAT` | Maximum change in any scanned bond per integration step (Å). | `0.20` |
+| `--bias-k FLOAT` | Harmonic bias strength `k` (eV·Å⁻²). Overrides `bias.k`. | `100` |
+| `--relax-max-cycles INT` | Maximum optimizer cycles per step (overrides `opt.max_cycles`). | `10000` |
+| `--opt-mode TEXT` | Relaxation optimizer (`light|lbfgs` or `heavy|rfo`). | `light` |
+| `--freeze-links / --no-freeze-links` | Freeze link-hydrogen parents for PDB inputs. | `--freeze-links` |
+| `--dump / --no-dump` | Dump stage trajectories. | `--no-dump` |
+| `--out-dir TEXT` | Output directory. | `./result_scan/` |
+| `--args-yaml FILE` | YAML overrides (see below). | _None_ |
+| `--preopt / --no-preopt` | Pre-optimize the initial structure before scanning. | `--preopt` |
+| `--endopt / --no-endopt` | Unbiased relaxation after each stage. | `--endopt` |
+
+## YAML configuration (`--args-yaml`)
+The YAML root must be a mapping. CLI parameters override YAML. Shared sections reuse the definitions documented for [`opt`](opt.md#yaml-configuration-args-yaml).
+
+```yaml
+geom:
+  coord_type: cart
+  freeze_atoms: []
+calc:
+  charge: 0            # overridden by -q/--charge
+  spin: 1              # overridden by -s/--spin
+  model: uma-s-1p1
+  task_name: omol
+  device: auto
+  max_neigh: null
+  radius: null
+  r_edges: false
+  out_hess_torch: true
+  freeze_atoms: null
+  hessian_calc_mode: Analytical
+  return_partial_hessian: true
+opt:
+  thresh: gau
+  max_cycles: 100
+  print_every: 1
+  min_step_norm: 1.0e-08
+  assert_min_step: true
+  rms_force: null
+  rms_force_only: false
+  max_force_only: false
+  force_only: false
+  converge_to_geom_rms_thresh: 0.05
+  overachieve_factor: 0.0
+  check_eigval_structure: false
+  line_search: true
+  dump: false
+  dump_restart: false
+  prefix: ""
+  out_dir: ./result_scan/
+lbfgs:
+  thresh: gau
+  max_cycles: 10000
+  print_every: 1
+  min_step_norm: 1.0e-08
+  assert_min_step: true
+  rms_force: null
+  rms_force_only: false
+  max_force_only: false
+  force_only: false
+  converge_to_geom_rms_thresh: 0.05
+  overachieve_factor: 0.0
+  check_eigval_structure: false
+  line_search: true
+  dump: false
+  dump_restart: false
+  prefix: ""
+  out_dir: ./result_scan/
+  keep_last: 7
+  beta: 1.0
+  gamma_mult: false
+  max_step: 0.3
+  control_step: true
+  double_damp: true
+  mu_reg: null
+  max_mu_reg_adaptions: 10
+rfo:
+  thresh: gau
+  max_cycles: 10000
+  print_every: 1
+  min_step_norm: 1.0e-08
+  assert_min_step: true
+  rms_force: null
+  rms_force_only: false
+  max_force_only: false
+  force_only: false
+  converge_to_geom_rms_thresh: 0.05
+  overachieve_factor: 0.0
+  check_eigval_structure: false
+  line_search: true
+  dump: false
+  dump_restart: false
+  prefix: ""
+  out_dir: ./result_scan/
+  trust_radius: 0.3
+  trust_update: true
+  trust_min: 0.01
+  trust_max: 0.3
+  max_energy_incr: null
+  hessian_update: bfgs
+  hessian_init: calc
+  hessian_recalc: 100
+  hessian_recalc_adapt: 2.0
+  small_eigval_thresh: 1.0e-08
+  alpha0: 1.0
+  max_micro_cycles: 25
+  rfo_overlaps: false
+  gdiis: true
+  gediis: false
+  gdiis_thresh: 0.0025
+  gediis_thresh: 0.01
+  gdiis_test_direction: true
+  adapt_step_func: false
+bias:
+  k: 100
+bond:
+  device: cuda
+  bond_factor: 1.2
+  margin_fraction: 0.05
+  delta_fraction: 0.05
+```
+
+### Shared sections
+- `geom`, `calc`, `opt`, `lbfgs`, `rfo`: see [`opt`](opt.md#yaml-configuration-args-yaml) for all keys and defaults. `opt.dump` is internally forced to `False`; dumping is controlled by `--dump`.
+
+### Section `bias`
+Controls the harmonic restraint applied during each scan stage.
+
+- `k` (`100`): Harmonic strength in eV·Å⁻².
+
+### Section `bond`
+Parameters for UMA-based bond-change detection (mirrors `path_search`).
+
+- `device` (`"cuda"`): UMA device for bond analysis.
+- `bond_factor` (`1.20`): Covalent-radius scale factor for bond cutoff.
+- `margin_fraction` (`0.05`): Fractional tolerance when comparing bond lengths.
+- `delta_fraction` (`0.05`): Minimum fractional change to classify a bond as forming/breaking.
+
+## Outputs
+- `<out-dir>/stage_XX/scan.trj` (and `.pdb` when the input was PDB and dumping is enabled).
+- `<out-dir>/stage_XX/scan_summary.yaml` with per-step metadata.
+- Final unbiased geometries after `--endopt` stored per stage.
+- Console summaries of resolved `geom`, `calc`, `opt`, `bias`, `bond`, and optimizer blocks.
+
+## Notes
+- `--scan-lists` accepts multiple literals; each defines one stage, and tuple indices are normalized to 0-based internally.
+- When `--one-based` is used (default), indices follow PDB conventions; invalid indices or non-positive target distances raise `click.BadParameter`.
+- Pre- and end-of-stage optimizations share UMA calculator instances for efficiency.
+- Stage dumping writes one trajectory per stage; `--dump` also triggers `.pdb` conversion for PDB inputs.

--- a/docs/trj2fig.md
+++ b/docs/trj2fig.md
@@ -1,0 +1,33 @@
+# `trj2fig` subcommand
+
+## Purpose
+Extracts energies from XYZ trajectory comments, computes either absolute energies or ΔE relative to a reference frame, and exports figures and/or CSV tables.
+
+## Usage
+```bash
+pdb2reaction trj2fig -i TRAJ.xyz [-o OUT ...] [--unit kcal|hartree]
+                     [-r init|None|INDEX] [--reverse-x]
+```
+
+## CLI options
+| Option | Description | Default |
+| --- | --- | --- |
+| `-i, --input PATH` | XYZ trajectory file whose comment line (2nd line) contains the energy. | Required |
+| `-o, --out PATH` | Output filenames. Repeatable; supports .png/.html/.svg/.pdf/.csv. | _None_ → `energy.png` |
+| `extra_outs` | Positional filenames after options; combined with `-o`. | _None_ |
+| `--unit CHOICE` | Energy unit for output values (`kcal` or `hartree`). | `kcal` |
+| `-r, --reference TEXT` | Reference specification: `init`, `None`, or integer frame index. | `init` |
+| `--reverse-x` | Reverse x-axis so the last frame appears on the left (also flips `init`). | `False` |
+
+## YAML configuration (`--args-yaml`)
+Not supported.
+
+## Outputs
+- Figure files (`.png`, `.html`, `.svg`, `.pdf`) showing energy or ΔE versus frame.
+- Optional `.csv` with columns `frame`, `energy_hartree`, and either `delta_kcal`, `energy_kcal`, `delta_hartree`, or `energy_hartree` depending on mode.
+- Console warning/error messages when energies cannot be parsed or unsupported extensions are requested.
+
+## Notes
+- Energies are parsed as the first floating-point number on each comment line; malformed comments raise an error.
+- The CSV/figure data respect `--unit` and whether a reference is used.
+- `--reverse-x` swaps the interpretation of `-r init` to use the last frame as the reference.

--- a/docs/ts_opt.md
+++ b/docs/ts_opt.md
@@ -1,0 +1,199 @@
+# `ts_opt` subcommand
+
+## Purpose
+Optimizes transition states using either the Hessian Dimer method ("light") or RS-I-RFO ("heavy"), leveraging UMA for energies, gradients, and Hessians, and exporting the final imaginary mode.
+
+## Usage
+```bash
+pdb2reaction ts_opt -i INPUT -q CHARGE [--spin 2S+1]
+                    [--freeze-links/--no-freeze-links]
+                    [--max-cycles N] [--opt-mode light|heavy]
+                    [--dump/--no-dump] [--out-dir DIR]
+                    [--hessian-calc-mode Analytical|FiniteDifference]
+                    [--args-yaml FILE]
+```
+
+## CLI options
+| Option | Description | Default |
+| --- | --- | --- |
+| `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
+| `-q, --charge INT` | Total charge. | Required |
+| `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
+| `--freeze-links / --no-freeze-links` | For PDB inputs, freeze link-hydrogen parents (propagated to UMA). | `--freeze-links` |
+| `--max-cycles INT` | Maximum macro cycles (forwarded to `opt.max_cycles`). | `10000` |
+| `--opt-mode TEXT` | `light` → Hessian Dimer, `heavy` → RS-I-RFO. | `light` |
+| `--dump / --no-dump` | Dump optimization trajectories. | `--no-dump` |
+| `--out-dir TEXT` | Output directory. | `./result_ts_opt/` |
+| `--hessian-calc-mode CHOICE` | UMA Hessian mode (`Analytical` or `FiniteDifference`). | _None_ (use YAML/default) |
+| `--args-yaml FILE` | YAML overrides (see below). | _None_ |
+
+## YAML configuration (`--args-yaml`)
+Provide a mapping; CLI overrides YAML. Shared sections reuse [`opt`](opt.md#yaml-configuration-args-yaml).
+
+```yaml
+geom:
+  coord_type: cart
+  freeze_atoms: []
+calc:
+  charge: 0            # overridden by -q/--charge
+  spin: 1              # overridden by -s/--spin
+  model: uma-s-1p1
+  task_name: omol
+  device: auto
+  max_neigh: null
+  radius: null
+  r_edges: false
+  out_hess_torch: true
+  freeze_atoms: null
+  hessian_calc_mode: Analytical
+  return_partial_hessian: true
+opt:
+  thresh: gau
+  max_cycles: 10000
+  print_every: 1
+  min_step_norm: 1.0e-08
+  assert_min_step: true
+  rms_force: null
+  rms_force_only: false
+  max_force_only: false
+  force_only: false
+  converge_to_geom_rms_thresh: 0.05
+  overachieve_factor: 0.0
+  check_eigval_structure: false
+  line_search: true
+  dump: false
+  dump_restart: false
+  prefix: ""
+  out_dir: ./result_ts_opt/
+hessian_dimer:
+  thresh_loose: gau_loose
+  thresh: gau
+  update_interval_hessian: 1000
+  neg_freq_thresh_cm: 5.0
+  flatten_amp_ang: 0.1
+  flatten_max_iter: 20
+  mem: 100000
+  use_lobpcg: true
+  device: auto
+  root: 0
+  dimer:
+    length: 0.0189
+    rotation_max_cycles: 15
+    rotation_method: fourier
+    rotation_thresh: 0.0001
+    rotation_tol: 1
+    rotation_max_element: 0.001
+    rotation_interpolate: true
+    rotation_disable: false
+    rotation_disable_pos_curv: true
+    rotation_remove_trans: true
+    trans_force_f_perp: true
+    bonds: null
+    N_hessian: null
+    bias_rotation: false
+    bias_translation: false
+    bias_gaussian_dot: 0.1
+    seed: null
+    write_orientations: true
+    forward_hessian: true
+  lbfgs:
+    thresh: gau
+    max_cycles: 10000
+    print_every: 1
+    min_step_norm: 1.0e-08
+    assert_min_step: true
+    rms_force: null
+    rms_force_only: false
+    max_force_only: false
+    force_only: false
+    converge_to_geom_rms_thresh: 0.05
+    overachieve_factor: 0.0
+    check_eigval_structure: false
+    line_search: true
+    dump: false
+    dump_restart: false
+    prefix: ""
+    out_dir: ./result_opt/
+    keep_last: 7
+    beta: 1.0
+    gamma_mult: false
+    max_step: 0.3
+    control_step: true
+    double_damp: true
+    mu_reg: null
+    max_mu_reg_adaptions: 10
+rsirfo:
+  thresh: gau
+  max_cycles: 10000
+  print_every: 1
+  min_step_norm: 1.0e-08
+  assert_min_step: true
+  rms_force: null
+  rms_force_only: false
+  max_force_only: false
+  force_only: false
+  converge_to_geom_rms_thresh: 0.05
+  overachieve_factor: 0.0
+  check_eigval_structure: false
+  line_search: true
+  dump: false
+  dump_restart: false
+  prefix: ""
+  out_dir: ./result_ts_opt/
+  roots: [0]
+  hessian_ref: null
+  rx_modes: null
+  prim_coord: null
+  rx_coords: null
+  hessian_update: bofill
+  hessian_recalc_reset: true
+  max_micro_cycles: 50
+  augment_bonds: false
+  min_line_search: true
+  max_line_search: true
+  assert_neg_eigval: false
+```
+
+### Shared sections
+- `geom`, `calc`, `opt`: same keys as [`opt`](opt.md#yaml-configuration-args-yaml). `--freeze-links` augments `geom.freeze_atoms` and pushes the list into `calc.freeze_atoms`.
+
+### Section `hessian_dimer`
+Controls the light-mode TS workflow. Top-level keys:
+
+- `thresh_loose` (`"gau_loose"`): First-pass convergence preset.
+- `thresh` (`"gau"`): Main convergence preset.
+- `update_interval_hessian` (`1000`): LBFGS cycles between exact Hessian refreshes.
+- `neg_freq_thresh_cm` (`5.0`): Threshold (cm⁻¹) below which a frequency counts as imaginary.
+- `flatten_amp_ang` (`0.10` Å), `flatten_max_iter` (`20`): Flattening displacement and iteration cap.
+- `mem` (`100000`): Scratch memory forwarded to UMA during Hessian evaluations.
+- `use_lobpcg` (`True`): Attempt LOBPCG for the most negative eigenpair.
+- `device` (`"auto"`): Torch device for Hessian/mode algebra.
+- `root` (`0`): Imaginary mode index to follow.
+- `dimer`: Nested dictionary forwarded to the pysisyphus `Dimer` calculator. Key highlights (defaults in parentheses):
+  - `length` (`0.0189` Bohr), rotation controls (`rotation_max_cycles: 15`, `rotation_method: "fourier"`, `rotation_thresh: 1e-4`, etc.).
+  - Bias flags: `bias_rotation` (`False`), `bias_translation` (`False`), `bias_gaussian_dot` (`0.1`).
+  - Optional initial guesses: `bonds`, `N_hessian`.
+- `lbfgs`: Nested dictionary for the inner LBFGS pass; defaults align with [`opt`](opt.md#section-lbfgs) but tuned for TS search (e.g., `keep_last`, `max_step`, `double_damp`).
+
+### Section `rsirfo`
+Controls the heavy-mode RS-I-RFO optimizer. Defaults derive from [`opt`](opt.md#section-rfo) with TS-specific additions:
+
+- `roots` (`[0]`): Mode indices to follow uphill.
+- `hessian_ref` (`null`): Optional reference Hessian path.
+- `rx_modes`, `prim_coord`, `rx_coords`: Optional monitoring definitions.
+- `hessian_update` (`"bofill"`), `hessian_recalc_reset` (`True`), `max_micro_cycles` (`50`).
+- Step safeguards: `augment_bonds` (`False`), `min_line_search` (`True`), `max_line_search` (`True`).
+- `assert_neg_eigval` (`False`): Require a negative eigenvalue at convergence.
+- Other trust-region parameters inherit from [`opt`](opt.md#section-rfo).
+
+## Outputs
+- `<out-dir>/final_geometry.xyz` (+ `.pdb` when the input was PDB).
+- `<out-dir>/optimization.trj` or `optimization_all.trj` (mode-dependent) and PDB conversions when applicable.
+- `<out-dir>/vib/final_imag_mode_±XXXX.Xcm-1.(trj|pdb)` for the converged imaginary mode.
+- Optional `.dimer_mode.dat` (light mode) and dump files when `--dump` is enabled.
+
+## Notes
+- Always provide accurate charge and multiplicity; they are propagated to UMA.
+- `--hessian-calc-mode` overrides `calc.hessian_calc_mode` after YAML merging.
+- In light mode, the flattened active-subspace Hessian is maintained and updated between LBFGS passes.
+- Imaginary-mode analysis uses PHVA and translation/rotation projection consistent with the frequency module.


### PR DESCRIPTION
## Summary
- add default `--args-yaml` YAML examples to each CLI subcommand guide
- document default values for geometry, UMA calculator, and workflow-specific sections using fenced code blocks

## Testing
- not run (documentation only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915f5add3e0832daac893286119dfa8)