### PR TITLE
Add default args-yaml snippets to CLI docs

### DIFF
--- a/docs/all.md
+++ b/docs/all.md
@@ -47,6 +47,147 @@ pdb2reaction all -i R.pdb [I.pdb ...] P.pdb -c SUBSTRATE_SPEC
 ## YAML configuration (`--args-yaml`)
 The YAML file is forwarded unchanged to `path_search`. See [`path_search`](path_search.md#yaml-configuration-args-yaml) for accepted sections (`geom`, `calc`, `gs`, `opt`, `sopt`, `bond`, `search`).
 
+```yaml
+geom:
+  coord_type: cart
+  freeze_atoms: []
+calc:
+  charge: 0
+  spin: 1
+  model: uma-s-1p1
+  task_name: omol
+  device: auto
+  max_neigh: null
+  radius: null
+  r_edges: false
+  out_hess_torch: true
+  freeze_atoms: null
+  hessian_calc_mode: Analytical
+  return_partial_hessian: true
+gs:
+  max_nodes: 10
+  perp_thresh: 0.005
+  reparam_check: rms
+  reparam_every: 1
+  reparam_every_full: 1
+  param: equi
+  max_micro_cycles: 10
+  reset_dlc: true
+  climb: true
+  climb_rms: 0.0005
+  climb_lanczos: true
+  climb_lanczos_rms: 0.0005
+  climb_fixed: false
+  scheduler: null
+opt:
+  type: string
+  stop_in_when_full: 1000
+  align: false
+  scale_step: global
+  max_cycles: 1000
+  dump: false
+  dump_restart: false
+  reparam_thresh: 0.001
+  coord_diff_thresh: 0.0
+  out_dir: ./result_path_search/
+  print_every: 1
+sopt:
+  base:
+    thresh: gau
+    max_cycles: 10000
+    print_every: 1
+    min_step_norm: 1.0e-08
+    assert_min_step: true
+    rms_force: null
+    rms_force_only: false
+    max_force_only: false
+    force_only: false
+    converge_to_geom_rms_thresh: 0.05
+    overachieve_factor: 0.0
+    check_eigval_structure: false
+    line_search: true
+    dump: false
+    dump_restart: false
+    prefix: ""
+    out_dir: ./result_path_search/
+  lbfgs:
+    thresh: gau
+    max_cycles: 10000
+    print_every: 1
+    min_step_norm: 1.0e-08
+    assert_min_step: true
+    rms_force: null
+    rms_force_only: false
+    max_force_only: false
+    force_only: false
+    converge_to_geom_rms_thresh: 0.05
+    overachieve_factor: 0.0
+    check_eigval_structure: false
+    line_search: true
+    dump: false
+    dump_restart: false
+    prefix: ""
+    out_dir: ./result_path_search/
+    keep_last: 7
+    beta: 1.0
+    gamma_mult: false
+    max_step: 0.3
+    control_step: true
+    double_damp: true
+    mu_reg: null
+    max_mu_reg_adaptions: 10
+  rfo:
+    thresh: gau
+    max_cycles: 10000
+    print_every: 1
+    min_step_norm: 1.0e-08
+    assert_min_step: true
+    rms_force: null
+    rms_force_only: false
+    max_force_only: false
+    force_only: false
+    converge_to_geom_rms_thresh: 0.05
+    overachieve_factor: 0.0
+    check_eigval_structure: false
+    line_search: true
+    dump: false
+    dump_restart: false
+    prefix: ""
+    out_dir: ./result_path_search/
+    trust_radius: 0.3
+    trust_update: true
+    trust_min: 0.01
+    trust_max: 0.3
+    max_energy_incr: null
+    hessian_update: bfgs
+    hessian_init: calc
+    hessian_recalc: 100
+    hessian_recalc_adapt: 2.0
+    small_eigval_thresh: 1.0e-08
+    alpha0: 1.0
+    max_micro_cycles: 25
+    rfo_overlaps: false
+    gediis: false
+    gdiis: true
+    gdiis_thresh: 0.0025
+    gediis_thresh: 0.01
+    gdiis_test_direction: true
+    adapt_step_func: false
+bond:
+  device: cuda
+  bond_factor: 1.2
+  margin_fraction: 0.05
+  delta_fraction: 0.05
+search:
+  max_depth: 10
+  stitch_rmsd_thresh: 0.0001
+  bridge_rmsd_thresh: 0.0001
+  rmsd_align: true
+  max_nodes_segment: 10
+  max_nodes_bridge: 5
+  kink_max_nodes: 3
+```
+
 ## Outputs
 - `<out-dir>/pockets/`: Pocket PDBs for each input.
 - `<out-dir>/path_search/`: GSM results (trajectory, merged full-system PDBs, energy diagrams, `summary.yaml`, segment folders).

--- a/docs/dft.md
+++ b/docs/dft.md
@@ -27,6 +27,15 @@ pdb2reaction dft -i INPUT -q CHARGE -s SPIN
 ## YAML configuration (`--args-yaml`)
 Accepts a mapping with top-level key `dft`. CLI overrides YAML values.
 
+```yaml
+dft:
+  conv_tol: 1.0e-09
+  max_cycle: 100
+  grid_level: 3
+  verbose: 4
+  out_dir: ./result_dft/
+```
+
 ### Section `dft`
 - `conv_tol` (`1e-9`): SCF convergence threshold (Hartree).
 - `max_cycle` (`100`): Maximum SCF iterations.

--- a/docs/freq.md
+++ b/docs/freq.md
@@ -35,6 +35,30 @@ pdb2reaction freq -i INPUT -q CHARGE [--spin 2S+1]
 ## YAML configuration (`--args-yaml`)
 Accepts a mapping; CLI overrides YAML. Shared sections reuse [`opt`](opt.md#yaml-configuration-args-yaml).
 
+```yaml
+geom:
+  coord_type: cart
+  freeze_atoms: []
+calc:
+  charge: 0
+  spin: 1
+  model: uma-s-1p1
+  task_name: omol
+  device: auto
+  max_neigh: null
+  radius: null
+  r_edges: false
+  out_hess_torch: true
+  freeze_atoms: null
+  hessian_calc_mode: Analytical
+  return_partial_hessian: true
+freq:
+  amplitude_ang: 0.8
+  n_frames: 20
+  max_write: 20
+  sort: value
+```
+
 ### Shared sections
 - `geom`, `calc`: same keys as [`opt`](opt.md#yaml-configuration-args-yaml). `--freeze-links` augments `geom.freeze_atoms`, which are also forwarded to UMA for Hessian calculations.
 

--- a/docs/irc.md
+++ b/docs/irc.md
@@ -33,6 +33,51 @@ pdb2reaction irc -i INPUT -q CHARGE [--spin 2S+1]
 ## YAML configuration (`--args-yaml`)
 Provide a mapping; CLI overrides YAML. Shared sections reuse [`opt`](opt.md#yaml-configuration-args-yaml) for geometry/calculator keys.
 
+```yaml
+geom:
+  coord_type: cart
+  freeze_atoms: []
+calc:
+  charge: 0
+  spin: 1
+  model: uma-s-1p1
+  task_name: omol
+  device: auto
+  max_neigh: null
+  radius: null
+  r_edges: false
+  out_hess_torch: true
+  freeze_atoms: null
+  hessian_calc_mode: Analytical
+  return_partial_hessian: true
+irc:
+  step_length: 0.1
+  max_cycles: 125
+  downhill: false
+  forward: true
+  backward: true
+  root: 0
+  hessian_init: calc
+  displ: energy
+  displ_energy: 0.001
+  displ_length: 0.1
+  rms_grad_thresh: 0.001
+  hard_rms_grad_thresh: null
+  energy_thresh: 0.000001
+  imag_below: 0.0
+  force_inflection: true
+  check_bonds: false
+  out_dir: ./result_irc/
+  prefix: ""
+  dump_fn: irc_data.h5
+  dump_every: 5
+  hessian_update: bofill
+  hessian_recalc: null
+  max_pred_steps: 500
+  loose_cycles: 3
+  corr_func: mbs
+```
+
 ### Shared sections
 - `geom`: same keys as [`opt`](opt.md#section-geom). `--freeze-links` augments `geom.freeze_atoms`.
 - `calc`: same keys as [`opt`](opt.md#section-calc). `--hessian-calc-mode` overrides `calc.hessian_calc_mode` after merging.

--- a/docs/opt.md
+++ b/docs/opt.md
@@ -26,6 +26,106 @@ pdb2reaction opt -i INPUT -q CHARGE [--spin 2S+1] [--opt-mode light|lbfgs|heavy|
 ## YAML configuration (`--args-yaml`)
 Pass a YAML mapping; CLI values override YAML, which override the defaults below.
 
+```yaml
+geom:
+  coord_type: cart
+  freeze_atoms: []
+calc:
+  charge: 0
+  spin: 1
+  model: uma-s-1p1
+  task_name: omol
+  device: auto
+  max_neigh: null
+  radius: null
+  r_edges: false
+  out_hess_torch: true
+  freeze_atoms: null
+  hessian_calc_mode: Analytical
+  return_partial_hessian: true
+opt:
+  thresh: gau
+  max_cycles: 10000
+  print_every: 1
+  min_step_norm: 1.0e-08
+  assert_min_step: true
+  rms_force: null
+  rms_force_only: false
+  max_force_only: false
+  force_only: false
+  converge_to_geom_rms_thresh: 0.05
+  overachieve_factor: 0.0
+  check_eigval_structure: false
+  line_search: true
+  dump: false
+  dump_restart: false
+  prefix: ""
+  out_dir: ./result_opt/
+lbfgs:
+  thresh: gau
+  max_cycles: 10000
+  print_every: 1
+  min_step_norm: 1.0e-08
+  assert_min_step: true
+  rms_force: null
+  rms_force_only: false
+  max_force_only: false
+  force_only: false
+  converge_to_geom_rms_thresh: 0.05
+  overachieve_factor: 0.0
+  check_eigval_structure: false
+  line_search: true
+  dump: false
+  dump_restart: false
+  prefix: ""
+  out_dir: ./result_opt/
+  keep_last: 7
+  beta: 1.0
+  gamma_mult: false
+  max_step: 0.3
+  control_step: true
+  double_damp: true
+  mu_reg: null
+  max_mu_reg_adaptions: 10
+rfo:
+  thresh: gau
+  max_cycles: 10000
+  print_every: 1
+  min_step_norm: 1.0e-08
+  assert_min_step: true
+  rms_force: null
+  rms_force_only: false
+  max_force_only: false
+  force_only: false
+  converge_to_geom_rms_thresh: 0.05
+  overachieve_factor: 0.0
+  check_eigval_structure: false
+  line_search: true
+  dump: false
+  dump_restart: false
+  prefix: ""
+  out_dir: ./result_opt/
+  trust_radius: 0.3
+  trust_update: true
+  trust_min: 0.01
+  trust_max: 0.3
+  max_energy_incr: null
+  hessian_update: bfgs
+  hessian_init: calc
+  hessian_recalc: 100
+  hessian_recalc_adapt: 2.0
+  small_eigval_thresh: 1.0e-08
+  alpha0: 1.0
+  max_micro_cycles: 25
+  rfo_overlaps: false
+  gediis: false
+  gdiis: true
+  gdiis_thresh: 0.0025
+  gediis_thresh: 0.01
+  gdiis_test_direction: true
+  adapt_step_func: false
+```
+
 ### Section `geom`
 Geometry loader options (see also `pdb2reaction.uma_pysis.GEOM_KW_DEFAULT`).
 

--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -28,6 +28,52 @@ pdb2reaction path_opt -i REACTANT PRODUCT -q CHARGE [--spin 2S+1]
 ## YAML configuration (`--args-yaml`)
 The YAML root must be a mapping. CLI values override YAML. Shared sections reuse [`opt`](opt.md#yaml-configuration-args-yaml).
 
+```yaml
+geom:
+  coord_type: cart
+  freeze_atoms: []
+calc:
+  charge: 0
+  spin: 1
+  model: uma-s-1p1
+  task_name: omol
+  device: auto
+  max_neigh: null
+  radius: null
+  r_edges: false
+  out_hess_torch: true
+  freeze_atoms: null
+  hessian_calc_mode: Analytical
+  return_partial_hessian: true
+gs:
+  max_nodes: 30
+  perp_thresh: 0.005
+  reparam_check: rms
+  reparam_every: 1
+  reparam_every_full: 1
+  param: equi
+  max_micro_cycles: 10
+  reset_dlc: true
+  climb: true
+  climb_rms: 0.0005
+  climb_lanczos: true
+  climb_lanczos_rms: 0.0005
+  climb_fixed: false
+  scheduler: null
+opt:
+  type: string
+  stop_in_when_full: 100
+  align: false
+  scale_step: global
+  max_cycles: 100
+  dump: false
+  dump_restart: false
+  reparam_thresh: 0.001
+  coord_diff_thresh: 0.0
+  out_dir: ./result_path_opt/
+  print_every: 1
+```
+
 ### Shared sections
 - `geom`, `calc`: same keys as [`opt`](opt.md#yaml-configuration-args-yaml). `--freeze-links` augments `geom.freeze_atoms` for PDB inputs.
 

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -35,6 +35,147 @@ pdb2reaction path_search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--spin 2S+1]
 ## YAML configuration (`--args-yaml`)
 The YAML root must be a mapping. CLI parameters override YAML values. Shared sections reuse [`opt`](opt.md#yaml-configuration-args-yaml).
 
+```yaml
+geom:
+  coord_type: cart
+  freeze_atoms: []
+calc:
+  charge: 0
+  spin: 1
+  model: uma-s-1p1
+  task_name: omol
+  device: auto
+  max_neigh: null
+  radius: null
+  r_edges: false
+  out_hess_torch: true
+  freeze_atoms: null
+  hessian_calc_mode: Analytical
+  return_partial_hessian: true
+gs:
+  max_nodes: 10
+  perp_thresh: 0.005
+  reparam_check: rms
+  reparam_every: 1
+  reparam_every_full: 1
+  param: equi
+  max_micro_cycles: 10
+  reset_dlc: true
+  climb: true
+  climb_rms: 0.0005
+  climb_lanczos: true
+  climb_lanczos_rms: 0.0005
+  climb_fixed: false
+  scheduler: null
+opt:
+  type: string
+  stop_in_when_full: 1000
+  align: false
+  scale_step: global
+  max_cycles: 1000
+  dump: false
+  dump_restart: false
+  reparam_thresh: 0.001
+  coord_diff_thresh: 0.0
+  out_dir: ./result_path_search/
+  print_every: 1
+sopt:
+  base:
+    thresh: gau
+    max_cycles: 10000
+    print_every: 1
+    min_step_norm: 1.0e-08
+    assert_min_step: true
+    rms_force: null
+    rms_force_only: false
+    max_force_only: false
+    force_only: false
+    converge_to_geom_rms_thresh: 0.05
+    overachieve_factor: 0.0
+    check_eigval_structure: false
+    line_search: true
+    dump: false
+    dump_restart: false
+    prefix: ""
+    out_dir: ./result_path_search/
+  lbfgs:
+    thresh: gau
+    max_cycles: 10000
+    print_every: 1
+    min_step_norm: 1.0e-08
+    assert_min_step: true
+    rms_force: null
+    rms_force_only: false
+    max_force_only: false
+    force_only: false
+    converge_to_geom_rms_thresh: 0.05
+    overachieve_factor: 0.0
+    check_eigval_structure: false
+    line_search: true
+    dump: false
+    dump_restart: false
+    prefix: ""
+    out_dir: ./result_path_search/
+    keep_last: 7
+    beta: 1.0
+    gamma_mult: false
+    max_step: 0.3
+    control_step: true
+    double_damp: true
+    mu_reg: null
+    max_mu_reg_adaptions: 10
+  rfo:
+    thresh: gau
+    max_cycles: 10000
+    print_every: 1
+    min_step_norm: 1.0e-08
+    assert_min_step: true
+    rms_force: null
+    rms_force_only: false
+    max_force_only: false
+    force_only: false
+    converge_to_geom_rms_thresh: 0.05
+    overachieve_factor: 0.0
+    check_eigval_structure: false
+    line_search: true
+    dump: false
+    dump_restart: false
+    prefix: ""
+    out_dir: ./result_path_search/
+    trust_radius: 0.3
+    trust_update: true
+    trust_min: 0.01
+    trust_max: 0.3
+    max_energy_incr: null
+    hessian_update: bfgs
+    hessian_init: calc
+    hessian_recalc: 100
+    hessian_recalc_adapt: 2.0
+    small_eigval_thresh: 1.0e-08
+    alpha0: 1.0
+    max_micro_cycles: 25
+    rfo_overlaps: false
+    gediis: false
+    gdiis: true
+    gdiis_thresh: 0.0025
+    gediis_thresh: 0.01
+    gdiis_test_direction: true
+    adapt_step_func: false
+bond:
+  device: cuda
+  bond_factor: 1.2
+  margin_fraction: 0.05
+  delta_fraction: 0.05
+search:
+  max_depth: 10
+  stitch_rmsd_thresh: 0.0001
+  bridge_rmsd_thresh: 0.0001
+  rmsd_align: true
+  max_nodes_segment: 10
+  max_nodes_bridge: 5
+  kink_max_nodes: 3
+```
+
 ### Shared sections
 - `geom`, `calc`: same keys as [`opt`](opt.md#yaml-configuration-args-yaml). `--freeze-links` augments `geom.freeze_atoms` when inputs are PDB.
 

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -35,6 +35,113 @@ pdb2reaction scan -i INPUT -q CHARGE --scan-lists "[(i,j,target), ...]" [...]
 ## YAML configuration (`--args-yaml`)
 The YAML root must be a mapping. CLI parameters override YAML. Shared sections reuse the definitions documented for [`opt`](opt.md#yaml-configuration-args-yaml).
 
+```yaml
+geom:
+  coord_type: cart
+  freeze_atoms: []
+calc:
+  charge: 0
+  spin: 1
+  model: uma-s-1p1
+  task_name: omol
+  device: auto
+  max_neigh: null
+  radius: null
+  r_edges: false
+  out_hess_torch: true
+  freeze_atoms: null
+  hessian_calc_mode: Analytical
+  return_partial_hessian: true
+opt:
+  thresh: gau
+  max_cycles: 100
+  print_every: 1
+  min_step_norm: 1.0e-08
+  assert_min_step: true
+  rms_force: null
+  rms_force_only: false
+  max_force_only: false
+  force_only: false
+  converge_to_geom_rms_thresh: 0.05
+  overachieve_factor: 0.0
+  check_eigval_structure: false
+  line_search: true
+  dump: false
+  dump_restart: false
+  prefix: ""
+  out_dir: ./result_scan/
+lbfgs:
+  thresh: gau
+  max_cycles: 100
+  print_every: 1
+  min_step_norm: 1.0e-08
+  assert_min_step: true
+  rms_force: null
+  rms_force_only: false
+  max_force_only: false
+  force_only: false
+  converge_to_geom_rms_thresh: 0.05
+  overachieve_factor: 0.0
+  check_eigval_structure: false
+  line_search: true
+  dump: false
+  dump_restart: false
+  prefix: ""
+  out_dir: ./result_scan/
+  keep_last: 7
+  beta: 1.0
+  gamma_mult: false
+  max_step: 0.3
+  control_step: true
+  double_damp: true
+  mu_reg: null
+  max_mu_reg_adaptions: 10
+rfo:
+  thresh: gau
+  max_cycles: 100
+  print_every: 1
+  min_step_norm: 1.0e-08
+  assert_min_step: true
+  rms_force: null
+  rms_force_only: false
+  max_force_only: false
+  force_only: false
+  converge_to_geom_rms_thresh: 0.05
+  overachieve_factor: 0.0
+  check_eigval_structure: false
+  line_search: true
+  dump: false
+  dump_restart: false
+  prefix: ""
+  out_dir: ./result_scan/
+  trust_radius: 0.3
+  trust_update: true
+  trust_min: 0.01
+  trust_max: 0.3
+  max_energy_incr: null
+  hessian_update: bfgs
+  hessian_init: calc
+  hessian_recalc: 100
+  hessian_recalc_adapt: 2.0
+  small_eigval_thresh: 1.0e-08
+  alpha0: 1.0
+  max_micro_cycles: 25
+  rfo_overlaps: false
+  gediis: false
+  gdiis: true
+  gdiis_thresh: 0.0025
+  gediis_thresh: 0.01
+  gdiis_test_direction: true
+  adapt_step_func: false
+bias:
+  k: 100
+bond:
+  device: cuda
+  bond_factor: 1.2
+  margin_fraction: 0.05
+  delta_fraction: 0.05
+```
+
 ### Shared sections
 - `geom`, `calc`, `opt`, `lbfgs`, `rfo`: see [`opt`](opt.md#yaml-configuration-args-yaml) for all keys and defaults. `opt.dump` is internally forced to `False`; dumping is controlled by `--dump`.
 

--- a/docs/ts_opt.md
+++ b/docs/ts_opt.md
@@ -30,6 +30,130 @@ pdb2reaction ts_opt -i INPUT -q CHARGE [--spin 2S+1]
 ## YAML configuration (`--args-yaml`)
 Provide a mapping; CLI overrides YAML. Shared sections reuse [`opt`](opt.md#yaml-configuration-args-yaml).
 
+```yaml
+geom:
+  coord_type: cart
+  freeze_atoms: []
+calc:
+  charge: 0
+  spin: 1
+  model: uma-s-1p1
+  task_name: omol
+  device: auto
+  max_neigh: null
+  radius: null
+  r_edges: false
+  out_hess_torch: true
+  freeze_atoms: null
+  hessian_calc_mode: Analytical
+  return_partial_hessian: true
+opt:
+  thresh: gau
+  max_cycles: 10000
+  print_every: 1
+  min_step_norm: 1.0e-08
+  assert_min_step: true
+  rms_force: null
+  rms_force_only: false
+  max_force_only: false
+  force_only: false
+  converge_to_geom_rms_thresh: 0.05
+  overachieve_factor: 0.0
+  check_eigval_structure: false
+  line_search: true
+  dump: false
+  dump_restart: false
+  prefix: ""
+  out_dir: ./result_ts_opt/
+hessian_dimer:
+  thresh_loose: gau_loose
+  thresh: gau
+  update_interval_hessian: 1000
+  neg_freq_thresh_cm: 5.0
+  flatten_amp_ang: 0.1
+  flatten_max_iter: 20
+  mem: 100000
+  use_lobpcg: true
+  device: auto
+  root: 0
+  dimer:
+    length: 0.0189
+    rotation_max_cycles: 15
+    rotation_method: fourier
+    rotation_thresh: 0.0001
+    rotation_tol: 1
+    rotation_max_element: 0.001
+    rotation_interpolate: true
+    rotation_disable: false
+    rotation_disable_pos_curv: true
+    rotation_remove_trans: true
+    trans_force_f_perp: true
+    bonds: null
+    N_hessian: null
+    bias_rotation: false
+    bias_translation: false
+    bias_gaussian_dot: 0.1
+    seed: null
+    write_orientations: true
+    forward_hessian: true
+  lbfgs:
+    thresh: gau
+    max_cycles: 10000
+    print_every: 1
+    min_step_norm: 1.0e-08
+    assert_min_step: true
+    rms_force: null
+    rms_force_only: false
+    max_force_only: false
+    force_only: false
+    converge_to_geom_rms_thresh: 0.05
+    overachieve_factor: 0.0
+    check_eigval_structure: false
+    line_search: true
+    dump: false
+    dump_restart: false
+    prefix: ""
+    out_dir: ./result_opt/
+    keep_last: 7
+    beta: 1.0
+    gamma_mult: false
+    max_step: 0.3
+    control_step: true
+    double_damp: true
+    mu_reg: null
+    max_mu_reg_adaptions: 10
+rsirfo:
+  thresh: gau
+  max_cycles: 10000
+  print_every: 1
+  min_step_norm: 1.0e-08
+  assert_min_step: true
+  rms_force: null
+  rms_force_only: false
+  max_force_only: false
+  force_only: false
+  converge_to_geom_rms_thresh: 0.05
+  overachieve_factor: 0.0
+  check_eigval_structure: false
+  line_search: true
+  dump: false
+  dump_restart: false
+  prefix: ""
+  out_dir: ./result_opt/
+  roots: [0]
+  hessian_ref: null
+  rx_modes: null
+  prim_coord: null
+  rx_coords: null
+  hessian_update: bofill
+  hessian_recalc_reset: true
+  max_micro_cycles: 50
+  augment_bonds: false
+  min_line_search: true
+  max_line_search: true
+  assert_neg_eigval: false
+```
+
 ### Shared sections
 - `geom`, `calc`, `opt`: same keys as [`opt`](opt.md#yaml-configuration-args-yaml). `--freeze-links` augments `geom.freeze_atoms` and pushes the list into `calc.freeze_atoms`.
 


### PR DESCRIPTION
## Summary
- add explicit default `--args-yaml` configuration examples across CLI documentation pages that accept YAML overrides

## Testing
- not run (docs only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69160157be38832d876a46a82d16cb4d)