### PR TITLE
Fix boolean option docs to match CLI

### DIFF
--- a/docs/freq.md
+++ b/docs/freq.md
@@ -6,10 +6,10 @@ Computes vibrational frequencies using UMA, performs partial Hessian vibrational
 ## Usage
 ```bash
 pdb2reaction freq -i INPUT -q CHARGE [--spin 2S+1]
-                  [--freeze-links/--no-freeze-links]
+                  [--freeze-links BOOL]
                   [--max-write N] [--amplitude-ang Å] [--n-frames N]
                   [--sort value|abs] [--out-dir DIR]
-                  [--temperature K] [--pressure atm] [--dump/--no-dump]
+                  [--temperature K] [--pressure atm] [--dump BOOL]
                   [--hessian-calc-mode Analytical|FiniteDifference]
                   [--args-yaml FILE]
 ```
@@ -20,7 +20,7 @@ pdb2reaction freq -i INPUT -q CHARGE [--spin 2S+1]
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
 | `-q, --charge INT` | Total charge. | Required |
 | `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
-| `--freeze-links / --no-freeze-links` | For PDB inputs, freeze link-hydrogen parents (merged with `geom.freeze_atoms`). | `--freeze-links` |
+| `--freeze-links BOOL` | Explicit `True`/`False`. For PDB inputs, freeze link-hydrogen parents (merged with `geom.freeze_atoms`). | `True` |
 | `--max-write INT` | Number of modes to export. | `20` |
 | `--amplitude-ang FLOAT` | Animation amplitude (Å). | `0.8` |
 | `--n-frames INT` | Frames per mode animation. | `20` |
@@ -28,7 +28,7 @@ pdb2reaction freq -i INPUT -q CHARGE [--spin 2S+1]
 | `--out-dir TEXT` | Output directory. | `./result_freq/` |
 | `--temperature FLOAT` | Thermochemistry temperature (K). | `298.15` |
 | `--pressure FLOAT` | Thermochemistry pressure (atm). | `1.0` |
-| `--dump / --no-dump` | Write `thermoanalysis.yaml`. | `--no-dump` |
+| `--dump BOOL` | Explicit `True`/`False`. Write `thermoanalysis.yaml`. | `False` |
 | `--hessian-calc-mode CHOICE` | UMA Hessian mode (`Analytical` or `FiniteDifference`). | _None_ |
 | `--args-yaml FILE` | YAML overrides (see below). | _None_ |
 

--- a/docs/irc.md
+++ b/docs/irc.md
@@ -8,7 +8,7 @@ Runs Intrinsic Reaction Coordinate (IRC) integrations with the EulerPC predictor
 pdb2reaction irc -i INPUT -q CHARGE [--spin 2S+1]
                  [--max-cycles N] [--step-size Δs] [--root k]
                  [--forward BOOL] [--backward BOOL]
-                 [--freeze-links/--no-freeze-links]
+                 [--freeze-links BOOL]
                  [--out-dir DIR]
                  [--hessian-calc-mode Analytical|FiniteDifference]
                  [--args-yaml FILE]
@@ -25,7 +25,7 @@ pdb2reaction irc -i INPUT -q CHARGE [--spin 2S+1]
 | `--root INT` | Imaginary-mode index for the initial displacement (`irc.root`). | _None_ (default `0`) |
 | `--forward BOOL` | Run forward branch (`irc.forward`). Explicit `True` or `False`. | _None_ (default `True`) |
 | `--backward BOOL` | Run backward branch (`irc.backward`). Explicit `True` or `False`. | _None_ (default `True`) |
-| `--freeze-links / --no-freeze-links` | For PDB inputs, freeze link-hydrogen parents (merged with `geom.freeze_atoms`). | `--freeze-links` |
+| `--freeze-links BOOL` | Explicit `True`/`False`. For PDB inputs, freeze link-hydrogen parents (merged with `geom.freeze_atoms`). | `True` |
 | `--out-dir TEXT` | Output directory (`irc.out_dir`). | `./result_irc/` |
 | `--hessian-calc-mode CHOICE` | UMA Hessian mode. | _None_ |
 | `--args-yaml FILE` | YAML overrides (see below). | _None_ |

--- a/docs/opt.md
+++ b/docs/opt.md
@@ -6,7 +6,7 @@ Performs single-structure geometry optimizations with pysisyphus using either th
 ## Usage
 ```bash
 pdb2reaction opt -i INPUT -q CHARGE [--spin 2S+1] [--opt-mode light|lbfgs|heavy|rfo]
-                 [--freeze-links/--no-freeze-links] [--dump/--no-dump]
+                 [--freeze-links BOOL] [--dump BOOL]
                  [--out-dir DIR] [--max-cycles N] [--args-yaml FILE]
 ```
 
@@ -16,10 +16,10 @@ pdb2reaction opt -i INPUT -q CHARGE [--spin 2S+1] [--opt-mode light|lbfgs|heavy|
 | `-i, --input PATH` | Structure file accepted by `geom_loader` (`.pdb`, `.xyz`, `.trj`, …). | Required |
 | `-q, --charge INT` | Total charge passed to UMA. | Required |
 | `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
-| `--freeze-links / --no-freeze-links` | When the input is PDB, detect link hydrogens and freeze their parent atoms (merged with `geom.freeze_atoms`). | `--freeze-links` |
+| `--freeze-links BOOL` | Explicit `True`/`False`. When the input is PDB, detect link hydrogens and freeze their parent atoms (merged with `geom.freeze_atoms`). | `True` |
 | `--max-cycles INT` | Maximum optimization cycles (`opt.max_cycles`). | `10000` |
 | `--opt-mode TEXT` | Select optimizer: `light`/`lbfgs` → LBFGS, `heavy`/`rfo` → RFO. | `light` |
-| `--dump / --no-dump` | Emit `optimization.trj`. | `--no-dump` |
+| `--dump BOOL` | Explicit `True`/`False`. Emit `optimization.trj`. | `False` |
 | `--out-dir TEXT` | Output directory. | `./result_opt/` |
 | `--args-yaml FILE` | YAML overrides (see below). | _None_ |
 

--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -6,9 +6,9 @@ Optimizes a minimum-energy path between two endpoints using the pysisyphus Growi
 ## Usage
 ```bash
 pdb2reaction path_opt -i REACTANT PRODUCT -q CHARGE [--spin 2S+1]
-                      [--freeze-links/--no-freeze-links]
-                      [--max-nodes N] [--max-cycles N] [--climb/--no-climb]
-                      [--dump/--no-dump] [--out-dir DIR] [--args-yaml FILE]
+                      [--freeze-links BOOL]
+                      [--max-nodes N] [--max-cycles N] [--climb BOOL]
+                      [--dump BOOL] [--out-dir DIR] [--args-yaml FILE]
 ```
 
 ## CLI options
@@ -17,11 +17,11 @@ pdb2reaction path_opt -i REACTANT PRODUCT -q CHARGE [--spin 2S+1]
 | `-i, --input PATH PATH` | Two endpoint structures (reactant, product). | Required |
 | `-q, --charge INT` | Total charge. | Required |
 | `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
-| `--freeze-links / --no-freeze-links` | For PDB inputs, freeze link-hydrogen parents. | `--freeze-links` |
+| `--freeze-links BOOL` | Explicit `True`/`False`. For PDB inputs, freeze link-hydrogen parents. | `True` |
 | `--max-nodes INT` | Internal nodes in the string (total images = `max_nodes + 2`). | `30` |
 | `--max-cycles INT` | Maximum optimizer cycles. | `1000` |
-| `--climb / --no-climb` | Enable climbing-image refinement. | `--climb` |
-| `--dump / --no-dump` | Dump optimizer trajectories and restarts. | `--no-dump` |
+| `--climb BOOL` | Explicit `True`/`False`. Enable climbing-image refinement. | `True` |
+| `--dump BOOL` | Explicit `True`/`False`. Dump optimizer trajectories and restarts. | `False` |
 | `--out-dir TEXT` | Output directory. | `./result_path_opt/` |
 | `--args-yaml FILE` | YAML overrides (see below). | _None_ |
 

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -6,10 +6,10 @@ Runs a recursive Growing String (GSM) search across multiple structures (reactan
 ## Usage
 ```bash
 pdb2reaction path_search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--spin 2S+1]
-                         [--freeze-links/--no-freeze-links]
-                         [--max-nodes N] [--max-cycles N] [--climb/--no-climb]
-                         [--sopt-mode lbfgs|rfo|light|heavy] [--dump/--no-dump]
-                         [--out-dir DIR] [--pre-opt/--no-pre-opt]
+                         [--freeze-links BOOL]
+                         [--max-nodes N] [--max-cycles N] [--climb BOOL]
+                         [--sopt-mode lbfgs|rfo|light|heavy] [--dump BOOL]
+                         [--out-dir DIR] [--pre-opt BOOL]
                          [--align/--no-align] [--ref-pdb FILE ...]
                          [--args-yaml FILE]
 ```
@@ -20,16 +20,16 @@ pdb2reaction path_search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--spin 2S+1]
 | `-i, --input PATH...` | Two or more structures in reaction order (reactant → product). A single `-i` may be followed by multiple paths. | Required |
 | `-q, --charge INT` | Total charge. | Required |
 | `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
-| `--freeze-links / --no-freeze-links` | For PDB inputs, freeze link-hydrogen parents when building pockets. | `--freeze-links` |
+| `--freeze-links BOOL` | Explicit `True`/`False`. For PDB inputs, freeze link-hydrogen parents when building pockets. | `True` |
 | `--max-nodes INT` | Internal nodes for GSM segments (`String` has `max_nodes + 2` images). | `10` |
 | `--max-cycles INT` | Maximum GSM optimization cycles. | `100` |
-| `--climb / --no-climb` | Enable climbing image for the first segment in each pair. | `--climb` |
+| `--climb BOOL` | Explicit `True`/`False`. Enable climbing image for the first segment in each pair. | `True` |
 | `--sopt-mode TEXT` | Single-structure optimizer for HEI±1/kink nodes (`light|lbfgs` or `heavy|rfo`). | `lbfgs` |
-| `--dump / --no-dump` | Dump GSM and single-structure trajectories. | `--no-dump` |
+| `--dump BOOL` | Explicit `True`/`False`. Dump GSM and single-structure trajectories. | `False` |
 | `--out-dir TEXT` | Output directory. | `./result_path_search/` |
 | `--args-yaml FILE` | YAML overrides (see below). | _None_ |
-| `--pre-opt / --no-pre-opt` | Pre-optimise each endpoint before the GSM search. | `--pre-opt` |
-| `--align / --no-align` | Align all inputs to the first structure before searching. | `--align` |
+| `--pre-opt BOOL` | Explicit `True`/`False`. Pre-optimise each endpoint before the GSM search. | `True` |
+| `--align / --no-align` | Flag toggle. Align all inputs to the first structure before searching. | `--align` |
 | `--ref-pdb PATH...` | Full-size template PDBs (one per input, unless `--align` lets you reuse the first). | _None_ |
 
 ### Shared sections

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -8,8 +8,8 @@ Performs staged bond-length scans with harmonic restraints and single-structure 
 pdb2reaction scan -i INPUT -q CHARGE --scan-lists "[(i,j,target), ...]" [...]
                   [--one-based/--zero-based] [--max-step-size ΔÅ] [--bias-k k]
                   [--relax-max-cycles N] [--opt-mode light|lbfgs|heavy|rfo]
-                  [--freeze-links/--no-freeze-links] [--dump/--no-dump]
-                  [--out-dir DIR] [--preopt/--no-preopt] [--endopt/--no-endopt]
+                  [--freeze-links BOOL] [--dump BOOL]
+                  [--out-dir DIR] [--preopt BOOL] [--endopt BOOL]
                   [--args-yaml FILE]
 ```
 
@@ -25,12 +25,12 @@ pdb2reaction scan -i INPUT -q CHARGE --scan-lists "[(i,j,target), ...]" [...]
 | `--bias-k FLOAT` | Harmonic bias strength `k` (eV·Å⁻²). Overrides `bias.k`. | `100` |
 | `--relax-max-cycles INT` | Maximum optimizer cycles per step (overrides `opt.max_cycles`). | `10000` |
 | `--opt-mode TEXT` | Relaxation optimizer (`light|lbfgs` or `heavy|rfo`). | `light` |
-| `--freeze-links / --no-freeze-links` | Freeze link-hydrogen parents for PDB inputs. | `--freeze-links` |
-| `--dump / --no-dump` | Dump stage trajectories. | `--no-dump` |
+| `--freeze-links BOOL` | Explicit `True`/`False`. Freeze link-hydrogen parents for PDB inputs. | `True` |
+| `--dump BOOL` | Explicit `True`/`False`. Dump stage trajectories. | `False` |
 | `--out-dir TEXT` | Output directory. | `./result_scan/` |
 | `--args-yaml FILE` | YAML overrides (see below). | _None_ |
-| `--preopt / --no-preopt` | Pre-optimize the initial structure before scanning. | `--preopt` |
-| `--endopt / --no-endopt` | Unbiased relaxation after each stage. | `--endopt` |
+| `--preopt BOOL` | Explicit `True`/`False`. Pre-optimize the initial structure before scanning. | `True` |
+| `--endopt BOOL` | Explicit `True`/`False`. Unbiased relaxation after each stage. | `True` |
 
 ### Shared sections
 - `geom`, `calc`, `opt`, `lbfgs`, `rfo`: see [`opt`](opt.md#yaml-configuration-args-yaml) for all keys and defaults. `opt.dump` is internally forced to `False`; dumping is controlled by `--dump`.

--- a/docs/ts_opt.md
+++ b/docs/ts_opt.md
@@ -6,9 +6,9 @@ Optimizes transition states using either the Hessian Dimer method ("light") or R
 ## Usage
 ```bash
 pdb2reaction ts_opt -i INPUT -q CHARGE [--spin 2S+1]
-                    [--freeze-links/--no-freeze-links]
+                    [--freeze-links BOOL]
                     [--max-cycles N] [--opt-mode light|heavy]
-                    [--dump/--no-dump] [--out-dir DIR]
+                    [--dump BOOL] [--out-dir DIR]
                     [--hessian-calc-mode Analytical|FiniteDifference]
                     [--args-yaml FILE]
 ```
@@ -19,10 +19,10 @@ pdb2reaction ts_opt -i INPUT -q CHARGE [--spin 2S+1]
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
 | `-q, --charge INT` | Total charge. | Required |
 | `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
-| `--freeze-links / --no-freeze-links` | For PDB inputs, freeze link-hydrogen parents (propagated to UMA). | `--freeze-links` |
+| `--freeze-links BOOL` | Explicit `True`/`False`. For PDB inputs, freeze link-hydrogen parents (propagated to UMA). | `True` |
 | `--max-cycles INT` | Maximum macro cycles (forwarded to `opt.max_cycles`). | `10000` |
 | `--opt-mode TEXT` | `light` → Hessian Dimer, `heavy` → RS-I-RFO. | `light` |
-| `--dump / --no-dump` | Dump optimization trajectories. | `--no-dump` |
+| `--dump BOOL` | Explicit `True`/`False`. Dump optimization trajectories. | `False` |
 | `--out-dir TEXT` | Output directory. | `./result_ts_opt/` |
 | `--hessian-calc-mode CHOICE` | UMA Hessian mode (`Analytical` or `FiniteDifference`). | _None_ (use YAML/default) |
 | `--args-yaml FILE` | YAML overrides (see below). | _None_ |

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -17,14 +17,14 @@ Recommended/common:
     --sopt-mode          Single-structure optimizer: lbfgs|rfo|light|heavy; default lbfgs.
     --max-nodes          Internal nodes for segment GSM; default 10.
     --max-cycles         Max optimization cycles; default 1000.
-    --climb/--no-climb   Enable TS search for the first segment; default on.
-    --pre-opt/--no-pre-opt  Pre-optimize endpoints; default on.
-    --align/--no-align   Rigidly co‑align all inputs after pre‑opt; default on.
-    --args-yaml PATH     YAML with overrides (sections: geom, calc, gs, opt, sopt, bond, search).
-    --ref-pdb PATH [...] Full template PDB(s) for final merge (see Notes).
-    --out-dir PATH       Output directory; default ./result_path_search/
-    --dump               Save optimizer dumps; default off.
-    --freeze-links {True|False}  Freeze parents of link hydrogens for PDB input; default on.
+    --climb {True|False}        Enable TS search for the first segment; default True.
+    --pre-opt {True|False}      Pre-optimize endpoints; default True.
+    --align/--no-align          Rigidly co‑align all inputs after pre‑opt; default on.
+    --args-yaml PATH            YAML with overrides (sections: geom, calc, gs, opt, sopt, bond, search).
+    --ref-pdb PATH [...]        Full template PDB(s) for final merge (see Notes).
+    --out-dir PATH              Output directory; default ./result_path_search/
+    --dump {True|False}         Save optimizer dumps; default False.
+    --freeze-links {True|False} Freeze parents of link hydrogens for PDB input; default True.
 
 Examples::
     # Minimal (pocket-only MEP; writes mep.trj or mep.pdb if inputs are PDB)

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -23,8 +23,8 @@ Usage (CLI)
         --dump {True|False} \
         --out-dir PATH \
         [--args-yaml FILE] \
-        [--preopt/--no-preopt] \
-        [--endopt/--no-endopt]
+        [--preopt {True|False}] \
+        [--endopt {True|False}]
 
 Examples::
     # Single-stage, minimal inputs (PDB)


### PR DESCRIPTION
## Summary
- clarify the scan and path_search module docstrings so boolean options show the required True/False values
- update command documentation to describe boolean click options as explicit True/False switches instead of --flag/--no-flag pairs

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69162581d3b8832db5b50d9fcea3247a)