### PR TITLE
Update CLI docs to match hyphenated subcommand names and defaults

### DIFF
--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -1,11 +1,11 @@
-# `path_opt` subcommand
+# `path-opt` subcommand
 
 ## Purpose
 Optimizes a minimum-energy path between two endpoints using the pysisyphus Growing String method with UMA providing energies, gradients, and Hessians.
 
 ## Usage
 ```bash
-pdb2reaction path_opt -i REACTANT PRODUCT -q CHARGE [--spin 2S+1]
+pdb2reaction path-opt -i REACTANT PRODUCT -q CHARGE [--spin 2S+1]
                       [--freeze-links BOOL]
                       [--max-nodes N] [--max-cycles N] [--climb BOOL]
                       [--dump BOOL] [--out-dir DIR] [--args-yaml FILE]
@@ -44,10 +44,10 @@ Growing String controls (defaults shown in parentheses).
 StringOptimizer controls (defaults in parentheses).
 
 - `type` (`"string"`): Label for bookkeeping.
-- `stop_in_when_full` (`100`): Extra cycles allowed after full growth (overridden by `--max-cycles`).
+- `stop_in_when_full` (`1000`): Extra cycles allowed after full growth (overridden by `--max-cycles`).
 - `align` (`False`): Internal alignment disabled (external Kabsch alignment is used).
 - `scale_step` (`"global"`): Step scaling policy.
-- `max_cycles` (`100`): Macro-iteration cap (overridden by `--max-cycles`).
+- `max_cycles` (`1000`): Macro-iteration cap (overridden by `--max-cycles`).
 - `dump` (`False`), `dump_restart` (`False`): Trajectory/restart dumping (dump toggled by CLI).
 - `reparam_thresh` (`1e-3`), `coord_diff_thresh` (`0.0`): Reparametrisation and pruning thresholds.
 - `out_dir` (`"./result_path_opt/"`), `print_every` (`1`): Output location and logging cadence.
@@ -101,10 +101,10 @@ gs:
   scheduler: null
 opt:
   type: string
-  stop_in_when_full: 100
+  stop_in_when_full: 1000
   align: false
   scale_step: global
-  max_cycles: 100
+  max_cycles: 1000
   dump: false
   dump_restart: false
   reparam_thresh: 0.001

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -1,11 +1,11 @@
-# `path_search` subcommand
+# `path-search` subcommand
 
 ## Purpose
 Runs a recursive Growing String (GSM) search across multiple structures (reactant → intermediates → product), stitches segment paths, and optionally merges pocket trajectories back into full PDB templates.
 
 ## Usage
 ```bash
-pdb2reaction path_search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--spin 2S+1]
+pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--spin 2S+1]
                          [--freeze-links BOOL]
                          [--max-nodes N] [--max-cycles N] [--climb BOOL]
                          [--sopt-mode lbfgs|rfo|light|heavy] [--dump BOOL]
@@ -22,7 +22,7 @@ pdb2reaction path_search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--spin 2S+1]
 | `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
 | `--freeze-links BOOL` | Explicit `True`/`False`. For PDB inputs, freeze link-hydrogen parents when building pockets. | `True` |
 | `--max-nodes INT` | Internal nodes for GSM segments (`String` has `max_nodes + 2` images). | `10` |
-| `--max-cycles INT` | Maximum GSM optimization cycles. | `100` |
+| `--max-cycles INT` | Maximum GSM optimization cycles. | `1000` |
 | `--climb BOOL` | Explicit `True`/`False`. Enable climbing image for the first segment in each pair. | `True` |
 | `--sopt-mode TEXT` | Single-structure optimizer for HEI±1/kink nodes (`light|lbfgs` or `heavy|rfo`). | `lbfgs` |
 | `--dump BOOL` | Explicit `True`/`False`. Dump GSM and single-structure trajectories. | `False` |

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -50,9 +50,9 @@ Parameters for UMA-based bond-change detection (mirrors `path_search`).
 
 ## Outputs
 - `<out-dir>/stage_XX/scan.trj` (and `.pdb` when the input was PDB and dumping is enabled).
-- `<out-dir>/stage_XX/scan_summary.yaml` with per-step metadata.
 - Final unbiased geometries after `--endopt` stored per stage.
 - Console summaries of resolved `geom`, `calc`, `opt`, `bias`, `bond`, and optimizer blocks.
+- Final human-readable stage summary printed to the terminal (no separate YAML file).
 
 ## Notes
 - `--scan-lists` accepts multiple literals; each defines one stage, and tuple indices are normalized to 0-based internally.
@@ -82,7 +82,7 @@ calc:
   return_partial_hessian: true
 opt:
   thresh: gau
-  max_cycles: 100
+  max_cycles: 10000
   print_every: 1
   min_step_norm: 1.0e-08
   assert_min_step: true
@@ -100,7 +100,7 @@ opt:
   out_dir: ./result_scan/
 lbfgs:
   thresh: gau
-  max_cycles: 100
+  max_cycles: 10000
   print_every: 1
   min_step_norm: 1.0e-08
   assert_min_step: true
@@ -126,7 +126,7 @@ lbfgs:
   max_mu_reg_adaptions: 10
 rfo:
   thresh: gau
-  max_cycles: 100
+  max_cycles: 10000
   print_every: 1
   min_step_norm: 1.0e-08
   assert_min_step: true

--- a/docs/ts_opt.md
+++ b/docs/ts_opt.md
@@ -1,11 +1,11 @@
-# `ts_opt` subcommand
+# `ts-opt` subcommand
 
 ## Purpose
 Optimizes transition states using either the Hessian Dimer method ("light") or RS-I-RFO ("heavy"), leveraging UMA for energies, gradients, and Hessians, and exporting the final imaginary mode.
 
 ## Usage
 ```bash
-pdb2reaction ts_opt -i INPUT -q CHARGE [--spin 2S+1]
+pdb2reaction ts-opt -i INPUT -q CHARGE [--spin 2S+1]
                     [--freeze-links BOOL]
                     [--max-cycles N] [--opt-mode light|heavy]
                     [--dump BOOL] [--out-dir DIR]

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -6,17 +6,17 @@ path_opt — Minimum-energy path (MEP) optimization via the Growing String metho
 
 Usage (CLI)
 -----
-    pdb2reaction path_opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} \
+    pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} \
         -q <charge> [-s <multiplicity>] [--freeze-links {True|False}] \
         [--max-nodes <int>] [--max-cycles <int>] [--climb {True|False}] \
         [--dump {True|False}] [--out-dir <dir>] [--args-yaml <file>]
 
 Examples::
     # Minimal: two endpoints, neutral singlet
-    pdb2reaction path_opt -i reac.pdb prod.pdb -q 0 -s 1
+    pdb2reaction path-opt -i reac.pdb prod.pdb -q 0 -s 1
 
     # Typical full run with YAML overrides and dumps
-    pdb2reaction path_opt -i reac.pdb prod.pdb -q 0 -s 1 \
+    pdb2reaction path-opt -i reac.pdb prod.pdb -q 0 -s 1 \
       --freeze-links True --max-nodes 10 --max-cycles 100 \
       --dump True --out-dir ./result_path_opt/ --args-yaml ./args.yaml
 

--- a/pdb2reaction/ts_opt.py
+++ b/pdb2reaction/ts_opt.py
@@ -6,7 +6,7 @@ ts_opt — Transition-state optimization CLI
 
 Usage (CLI)
 -----
-    pdb2reaction ts_opt -i INPUT.(pdb|xyz|trj) -q CHARGE -s SPIN
+    pdb2reaction ts-opt -i INPUT.(pdb|xyz|trj) -q CHARGE -s SPIN
                         [--opt-mode light|heavy]
                         [--freeze-links True|False]
                         [--max-cycles N]
@@ -17,16 +17,16 @@ Usage (CLI)
 
 Examples::
     # Minimal (recommended to always specify charge and spin)
-    pdb2reaction ts_opt -i ts_cand.pdb -q 0 -s 1 --opt-mode light --out-dir ./result_ts_opt/
+    pdb2reaction ts-opt -i ts_cand.pdb -q 0 -s 1 --opt-mode light --out-dir ./result_ts_opt/
 
     # Light mode (HessianDimer) with YAML overrides and finite-difference Hessian
-    pdb2reaction ts_opt -i ts_cand.pdb -q 0 -s 1 \
+    pdb2reaction ts-opt -i ts_cand.pdb -q 0 -s 1 \
       --freeze-links True --opt-mode light --max-cycles 10000 --dump False \
       --out-dir ./result_ts_opt/ --args-yaml ./args.yaml \
       --hessian-calc-mode FiniteDifference
 
     # Heavy mode (RS-I-RFO) using YAML
-    pdb2reaction ts_opt -i ts_cand.pdb -q 0 -s 1 --opt-mode heavy \
+    pdb2reaction ts-opt -i ts_cand.pdb -q 0 -s 1 --opt-mode heavy \
       --args-yaml ./args.yaml --out-dir ./result_ts_opt/
 
 


### PR DESCRIPTION
## Summary
- align the path-opt and ts-opt docstrings and docs with the hyphenated CLI command names
- correct documented defaults and outputs in the path-opt, path-search, and scan guides to reflect current behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916dec541e4832d81cbb850112e68f0)