### PR TITLE
Clarify DFT spin CLI docs

### DIFF
--- a/docs/dft.md
+++ b/docs/dft.md
@@ -5,7 +5,7 @@ Runs single-point DFT calculations using GPU4PySCF when available (falling back 
 
 ## Usage
 ```bash
-pdb2reaction dft -i INPUT -q CHARGE -s SPIN \
+pdb2reaction dft -i INPUT -q CHARGE [-s SPIN] \
                  [--func-basis "FUNC/BASIS"] \
                  [--max-cycle N] [--conv-tol Eh] [--grid-level L] \
                  [--out-dir DIR] [--args-yaml FILE]
@@ -16,7 +16,7 @@ pdb2reaction dft -i INPUT -q CHARGE -s SPIN \
 | --- | --- | --- |
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
 | `-q, --charge INT` | Total charge supplied to PySCF. | Required |
-| `-s, --spin INT` | Spin multiplicity (2S+1). Converted to `2S` for PySCF. | Required |
+| `-s, --spin INT` | Spin multiplicity (2S+1). Converted to `2S` for PySCF. | `1` |
 | `--func-basis TEXT` | Functional and basis in `FUNC/BASIS` form (quotes recommended when using `*`). | `wb97m-v/6-31g**` |
 | `--max-cycle INT` | Maximum SCF iterations (`dft.max_cycle`). | `100` |
 | `--conv-tol FLOAT` | SCF convergence tolerance in Hartree (`dft.conv_tol`). | `1e-9` |
@@ -31,7 +31,7 @@ pdb2reaction dft -i INPUT -q CHARGE -s SPIN \
 - `verbose` (`4`): PySCF verbosity (0–9).
 - `out_dir` (`"./result_dft/"`): Output directory.
 
-_Functional/basis selection and molecular charge/spin must be supplied on the CLI._
+_Functional/basis selection and molecular charge must be supplied on the CLI. Spin defaults to `1` (singlet) but should be set explicitly for other states._
 
 ## Outputs
 - `<out-dir>/input_geometry.xyz`: Geometry snapshot passed to PySCF (identical coordinates to the input file).
@@ -44,7 +44,7 @@ _Functional/basis selection and molecular charge/spin must be supplied on the CL
 ## Notes
 - GPU4PySCF is used when available; otherwise a CPU SCF object is built. Nonlocal VV10 is enabled automatically for functionals ending with `-v` or containing `vv10`.
 - The YAML file must contain a mapping root with top-level key `dft`; non-mapping roots raise an error via `load_yaml_dict`.
-- Both `-q/--charge` and `-s/--spin` **must** be provided explicitly; incorrect multiplicities lead to the wrong (RKS vs UKS) solver.
+- `-q/--charge` is required. `-s/--spin` defaults to `1` (RKS) but should be specified explicitly for non-singlet states to ensure the correct (RKS vs UKS) solver.
 - Exit codes: `0` (converged), `3` (not converged), `2` (PySCF import failure), `1` (other errors), `130` (interrupt).
 - IAO spin/charge analysis may fail for challenging systems; in that case the IAO column values in `result.yaml` are `null` and a warning is printed.
 

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -6,9 +6,9 @@ dft — Single-point DFT (GPU4PySCF with CPU PySCF fallback)
 
 Usage (CLI)
 -----
-    pdb2reaction dft -i INPUT -q CHARGE -s SPIN [--func-basis "FUNC/BASIS"] [--max-cycle N] [--conv-tol Eh] [--grid-level L] [--out-dir OUT_DIR] [--args-yaml YAML]
+    pdb2reaction dft -i INPUT -q CHARGE [-s SPIN] [--func-basis "FUNC/BASIS"] [--max-cycle N] [--conv-tol Eh] [--grid-level L] [--out-dir OUT_DIR] [--args-yaml YAML]
 
-    # Always include -q/-s explicitly to avoid wrong electronic states.
+    # -q/--charge is required; -s/--spin defaults to 1 (RKS) but should be set explicitly when the state is not singlet.
 
 Examples::
     pdb2reaction dft -i input.pdb -q 0 -s 1 --func-basis "wb97m-v/6-31g**"
@@ -49,7 +49,7 @@ Outputs (& Directory Layout)
 
 Notes:
 -----
-- Always set both -q/--charge and -s/--spin explicitly; incorrect values lead to the wrong electronic state (UKS for multiplicity > 1; RKS for multiplicity = 1).
+- Always supply -q/--charge (required) and prefer explicit -s/--spin to avoid unintentional multiplicities (defaults to 1 → RKS; multiplicity > 1 selects UKS).
 - YAML overrides: --args-yaml points to a file with top-level key "dft" (conv_tol, max_cycle, grid_level, verbose, out_dir).
 - Grids and checkpointing: sets `grids.level` when supported; disables SCF checkpoint files when possible.
 - Units: input coordinates are in Å. Functional/basis names are PySCF-style and case-insensitive for common sets.


### PR DESCRIPTION
## Summary
- clarify that `dft`'s `-s/--spin` option defaults to 1 (singlet) in both the module docstring and the CLI documentation
- update the docs to show the correct usage snippet, table default, and guidance on when to override the multiplicity

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918ee8f3e28832dabc9366870d6b85c)