### PR TITLE
Document JPEG support in trj2fig

### DIFF
--- a/docs/trj2fig.md
+++ b/docs/trj2fig.md
@@ -13,14 +13,14 @@ pdb2reaction trj2fig -i TRAJ.xyz [-o OUT ...] [--unit kcal|hartree]
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH` | XYZ trajectory file whose comment line (2nd line) contains the energy. | Required |
-| `-o, --out PATH` | Output filenames. Repeatable; supports .png/.html/.svg/.pdf/.csv. | _None_ → `energy.png` |
+| `-o, --out PATH` | Output filenames. Repeatable; supports .png/.jpg/.jpeg/.html/.svg/.pdf/.csv. | _None_ → `energy.png` |
 | `extra_outs` | Positional filenames after options; combined with `-o`. | _None_ |
 | `--unit CHOICE` | Energy unit for output values (`kcal` or `hartree`). | `kcal` |
 | `-r, --reference TEXT` | Reference specification: `init`, `None`, or integer frame index. | `init` |
 | `--reverse-x` | Reverse x-axis so the last frame appears on the left (also flips `init`). | `False` |
 
 ## Outputs
-- Figure files (`.png`, `.html`, `.svg`, `.pdf`) showing energy or ΔE versus frame.
+- Figure files (`.png`, `.jpg`, `.jpeg`, `.html`, `.svg`, `.pdf`) showing energy or ΔE versus frame.
 - Optional `.csv` with columns `frame`, `energy_hartree`, and either `delta_kcal`, `energy_kcal`, `delta_hartree`, or `energy_hartree` depending on mode.
 - Console warning/error messages when energies cannot be parsed or unsupported extensions are requested.
 

--- a/pdb2reaction/trj2fig.py
+++ b/pdb2reaction/trj2fig.py
@@ -36,7 +36,8 @@ Description
         - -r None  : use absolute energies (no reference). Also accepts "none"/"null" (case-insensitive).
         - -r <int> : use the given 0-based frame index as the reference.
     - Generates a polished Plotly figure (no title) with bold ticks, consistent fonts, markers,
-      and a smoothed spline curve. Supported figure outputs: PNG (default), HTML, SVG, PDF.
+      and a smoothed spline curve. Supported figure outputs: PNG (default), JPEG/JPG, HTML,
+      SVG, PDF.
     - Optionally writes a CSV table of the data.
     - --reverse-x flips the x-axis so the last frame appears on the left
       (and makes -r init point to that last frame).
@@ -47,6 +48,7 @@ Outputs (& Directory Layout)
     - You can provide multiple filenames to -o and/or repeat -o to emit several outputs at once.
       Supported formats:
         - .png  : High-resolution raster figure (scale=2).
+        - .jpg/.jpeg : Raster figure (same rendering path as PNG).
         - .html : Standalone interactive Plotly figure.
         - .svg  : Vector figure.
         - .pdf  : Vector figure.


### PR DESCRIPTION
## Summary
- update the `trj2fig` module docstring to mention that JPEG/JPG figures are fully supported alongside the other formats
- extend the public documentation in `docs/trj2fig.md` so the `-o/--out` table and outputs section describe JPEG/JPG options as well

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918ee8f3e28832dabc9366870d6b85c)