### PR TITLE
Fix path_search documentation defaults and clean comments

### DIFF
--- a/docs/all.md
+++ b/docs/all.md
@@ -152,10 +152,10 @@ gs:
   scheduler: null
 opt:
   type: string
-  stop_in_when_full: 1000
+  stop_in_when_full: 100
   align: false
   scale_step: global
-  max_cycles: 1000
+  max_cycles: 100
   dump: false
   dump_restart: false
   reparam_thresh: 0.001

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -45,7 +45,7 @@ Growing String controls for main segments. Defaults derive from `pdb2reaction.pa
 ### Section `opt`
 StringOptimizer controls for GSM (defaults in parentheses).
 
-- `stop_in_when_full` (`1000`) and `max_cycles` (`1000`): Cycle caps (CLI overrides `--max-cycles`).
+- `stop_in_when_full` (`100`) and `max_cycles` (`100`): Cycle caps (CLI overrides `--max-cycles`).
 - `dump` (`False`), `dump_restart` (`False`), `out_dir` (`"./result_path_search/"`), `print_every` (`1`), `align` (`False`).
 - Other keys mirror [`path_opt`](path_opt.md#section-opt).
 

--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -205,8 +205,8 @@ from . import dft as _dft_cli
 from .uma_pysis import uma_pysis
 from .trj2fig import run_trj2fig
 from .utils import build_energy_diagram, format_elapsed
-from . import scan as _scan_cli  # <-- NEW: use scan CLI when --scan-lists is provided (single-structure)
-from .add_elem_info import assign_elements as _assign_elem_info  # <-- NEW: add_elem_info preflight
+from . import scan as _scan_cli
+from .add_elem_info import assign_elements as _assign_elem_info
 
 # -----------------------------
 # Helpers

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -16,7 +16,7 @@ Recommended/common:
     -s/--spin            Spin multiplicity (2S+1); default 1.
     --sopt-mode          Single-structure optimizer: lbfgs|rfo|light|heavy; default lbfgs.
     --max-nodes          Internal nodes for segment GSM; default 10.
-    --max-cycles         Max optimization cycles; default 1000.
+    --max-cycles         Max optimization cycles; default 100.
     --climb {True|False}        Enable TS search for the first segment; default True.
     --pre-opt {True|False}      Pre-optimize endpoints; default True.
     --align/--no-align          Rigidly co‑align all inputs after pre‑opt; default on.
@@ -1487,7 +1487,7 @@ def cli(
     out_dir: str,
     args_yaml: Optional[Path],
     pre_opt: bool,
-    align: bool,                # <-- added
+    align: bool,
     ref_pdb_paths: Optional[Sequence[Path]],
 ) -> None:
     # --- Robustly accept both styles for -i/--input and --ref-pdb ---

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -506,7 +506,7 @@ def cli(
         lbfgs_cfg = dict(LBFGS_KW)
         rfo_cfg   = dict(RFO_KW)
         bias_cfg  = dict(BIAS_KW)
-        bond_cfg  = dict(BOND_KW)  # <-- added
+        bond_cfg  = dict(BOND_KW)
 
         apply_yaml_overrides(
             yaml_cfg,
@@ -544,13 +544,13 @@ def cli(
         echo_calc = dict(calc_cfg)
         echo_opt  = dict(opt_cfg); echo_opt["out_dir"] = str(out_dir_path)
         echo_bias = dict(bias_cfg)
-        echo_bond = dict(bond_cfg)  # <-- added
+        echo_bond = dict(bond_cfg)
         click.echo(pretty_block("geom", echo_geom))
         click.echo(pretty_block("calc", echo_calc))
         click.echo(pretty_block("opt",  echo_opt))
         click.echo(pretty_block("lbfgs" if kind == "lbfgs" else "rfo", (lbfgs_cfg if kind == "lbfgs" else rfo_cfg)))
         click.echo(pretty_block("bias", echo_bias))
-        click.echo(pretty_block("bond", echo_bond))  # <-- added
+        click.echo(pretty_block("bond", echo_bond))
 
         # ------------------------------------------------------------------
         # 2) Parse scan lists


### PR DESCRIPTION
## Summary
- correct the documented default for `--max-cycles` in the `path_search` docstring and both the `path_search`/`all` markdown guides
- drop stray inline comment markers that crept into the `scan`, `path_search`, and `all` modules so the CLI code reads cleanly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918fb5ca57c832db1e510415f0b0aca)