### PR TITLE
Document verbose behaviour in extract

### DIFF
--- a/docs/extract.md
+++ b/docs/extract.md
@@ -17,14 +17,14 @@ pdb2reaction extract -i COMPLEX.pdb [COMPLEX2.pdb ...]
                      [--verbose true|false]
 ```
 
-_Subcommand `extract` is invoked via the Click wrapper in `pdb2reaction cli`, which forwards to the argparse-based implementation shown above._
+`--verbose true|false` mirrors the Click wrapper (`pdb2reaction cli extract`) and now behaves identically when the script is invoked directly via argparse.
 
 ## CLI options
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH...` | One or more full protein–ligand PDB files (identical atom ordering required). | Required |
 | `-c, --center SPEC` | Substrate specification: PDB path, residue-ID list (e.g. `123,124` or `A:123,B:456`), or residue-name list (e.g. `GPP,MMT`). | Required |
-| `-o, --output PATH...` | Pocket PDB output(s). Provide one path for a multi-MODEL file or N paths matching the number of inputs. | Auto-generated (`pocket.pdb` / `pocket_<input>.pdb`) |
+| `-o, --output PATH...` | Pocket PDB output(s). Provide one path for a single multi-MODEL file or N paths matching the number of inputs for per-structure outputs. | Auto-generated (`pocket.pdb` for single input / `pocket_<input>.pdb` per input) |
 | `-r, --radius FLOAT` | Atom–atom distance cutoff (Å) for inclusion. | `2.6` |
 | `--radius-het2het FLOAT` | Independent hetero–hetero cutoff (Å) for non-C/H pairs. | `0.0` (internally treated as 0.001 Å) |
 | `--include-H2O BOOL` | Include water residues (HOH/WAT/TIP3/SOL). | `true` |
@@ -32,13 +32,19 @@ _Subcommand `extract` is invoked via the Click wrapper in `pdb2reaction cli`, wh
 | `--add-linkH BOOL` | Add carbon-only link hydrogens at 1.09 Å along severed bonds. | `true` |
 | `--selected-resn TEXT` | Residue IDs to force-include (comma/space separated; chain/insertion codes supported). | `""` |
 | `--ligand-charge TEXT` | Either a total charge (number) or mapping like `GPP:-3,MMT:-1` to distribute across unknown residues. | `None` |
-| `-v, --verbose` | Enable INFO-level logging. | `true` |
+| `-v, --verbose` | Enable INFO-level logging (set `true` to emit INFO via `click.echo`, `false` keeps WARNING-only output). | `false` |
 
 ## Outputs
 - Pocket PDB(s) containing the extracted residues, with optional link hydrogens appended after a `TER` record.
-- Charge summary (protein/ligand/ion/total) printed to stdout when extraction succeeds.
+  - Single input: defaults to `pocket.pdb`.
+  - Multiple inputs + no `-o`: defaults to `pocket_<original_basename>.pdb` per structure.
+  - Supplying one `-o` path with multiple inputs writes a single multi-MODEL PDB.
+- Charge summary (protein/ligand/ion/total) is logged for model #1 when verbose mode is enabled (Click wrapper echoes INFO lines by default; the argparse script now follows the same behaviour via `--verbose true`).
 
 ## Notes
-- Multi-structure mode (`-i` with multiple files) produces a pocket per input; atom ordering must match across inputs.
+- Multi-structure mode (`-i` with multiple files) unions the selected residues across all inputs (after verifying identical atom ordering). That union is applied consistently to every structure, and the outputs can be written either as a single multi-MODEL PDB or one file per input.
+- `--radius` defines the standard cutoff around substrate atoms; `--radius-het2het` independently includes residues whose hetero atoms approach substrate hetero atoms (non-C/H) within the specified Å.
+- Waters (HOH/WAT/H2O/DOD/TIP/TIP3/SOL) are included by default. `--include-H2O false` removes them from the pocket.
+- Backbone trimming removes N/H*/CA/HA*/C/O from non-substrate amino acids when `--exclude-backbone true` (default); PRO/HYP safeguards keep the atoms needed to retain the pyrrolidine ring and neighbouring peptide bond.
 - Substrate residue lists support insertion codes (e.g. `123A`, `A:123A`). When residue-name mode yields duplicates, all matches are included and a warning is logged.
-- Water selection recognises HOH/WAT/TIP3/SOL residues; backbone trimming skips PRO/HYP nitrogen atoms.
+- Link-hydrogen placement (`--add-linkH true`) adds 1.09 Å C–H vectors for severed bonds and appends them as contiguous `HL` atoms in residue `LKH` after a `TER`.

--- a/pdb2reaction/extract.py
+++ b/pdb2reaction/extract.py
@@ -13,7 +13,8 @@ Single structure:
                          [-r 2.6] [--radius-het2het 2.6]
                          [--include-H2O true|false] [--exclude-backbone true|false]
                          [--add-linkH true|false] [--selected-resn "A:123,456"]
-                         [--ligand-charge <Q> | --ligand-charge "RES1:Q1,RES2:Q2"] [-v]
+                         [--ligand-charge <Q> | --ligand-charge "RES1:Q1,RES2:Q2"]
+                         [--verbose true|false]
 
 Multiple structures → single multi‑MODEL PDB:
     pdb2reaction extract -i complex1.pdb complex2.pdb [...] -c <substrate_spec>
@@ -37,7 +38,7 @@ Examples::
 
     # Multi‑structure → single multi‑MODEL output, with hetero‑hetero proximity enabled
     pdb2reaction extract -i complex1.pdb complex2.pdb -c A:123 \
-                         -o pocket_multi.pdb --radius-het2het 2.6 --ligand-charge -3
+                         -o pocket_multi.pdb --radius-het2het 2.6 --ligand-charge -3 --verbose true
 
 Description
 -----
@@ -374,8 +375,9 @@ def parse_args() -> argparse.Namespace:
               "'GPP:-3,MMT:-1'. In mapping mode, any other unknown residues remain 0.")
     )
     p.add_argument(
-        "-v", "--verbose", action="store_true", default=True,
-        help="Enable INFO logging (default WARNING)."
+        "-v", "--verbose", type=str2bool, default=False,
+        help=("Enable INFO-level logging (set true to emit INFO; false keeps WARNING-level output)."
+              " Default: false.")
     )
     return p.parse_args()
 


### PR DESCRIPTION
## Summary
- align the argparse implementation of `pdb2reaction extract` with the documented `--verbose true|false` toggle by switching the parser to a boolean flag (defaulting to false) and refreshing the module docstring usage example
- expand `docs/extract.md` to describe the new verbose behaviour, clarify the default outputs for single vs multi-structure runs, and document the multi-structure union semantics and link-H details

## Testing
- Not run (missing optional numpy dependency prevents `python -m pdb2reaction.extract -h`)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691903921180832d83b08469a1b3ef92)