### PR TITLE
Fix docs for YAML sections and freeze-links description

### DIFF
--- a/docs/all.md
+++ b/docs/all.md
@@ -98,7 +98,7 @@ The same YAML file is forwarded unchanged to **every** invoked subcommand. Each 
 - [`freq`](freq.md#yaml-configuration-args-yaml): `geom`, `calc`, `freq`, `thermo`.
 - [`dft`](dft.md#yaml-configuration-args-yaml): `dft`.
 
-Include whichever sections you need at the YAML root; overlapping names such as `geom`, `calc`, or `opt` will be shared across modules, while module-specific blocks (for example `freq.freq` or `dft`) apply only where supported. CLI values always take precedence over the YAML contents.
+Include whichever sections you need at the YAML root; overlapping names such as `geom`, `calc`, or `opt` will be shared across modules, while module-specific blocks (for example `freq` or `dft`) apply only where supported. CLI values always take precedence over the YAML contents.
 
 Example snippet combining shared and module-specific sections:
 
@@ -111,11 +111,9 @@ calc:
 gs:
   max_nodes: 12
 freq:
-  freq:
-    max_write: 8
+  max_write: 8
 dft:
-  dft:
-    grid_level: 6
+  grid_level: 6
 ```
 
 ```yaml

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -20,7 +20,7 @@ pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--spin 2S+1]
 | `-i, --input PATH...` | Two or more structures in reaction order (reactant → product). A single `-i` may be followed by multiple paths. | Required |
 | `-q, --charge INT` | Total charge. | Required |
 | `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
-| `--freeze-links BOOL` | Explicit `True`/`False`. For PDB inputs, freeze link-hydrogen parents when building pockets. | `True` |
+| `--freeze-links BOOL` | Explicit `True`/`False`. When loading PDB pockets, freeze the parent atoms of link hydrogens. | `True` |
 | `--max-nodes INT` | Internal nodes for GSM segments (`String` has `max_nodes + 2` images). | `10` |
 | `--max-cycles INT` | Maximum GSM optimization cycles. | `100` |
 | `--climb BOOL` | Explicit `True`/`False`. Enable climbing image for the first segment in each pair. | `True` |


### PR DESCRIPTION
## Summary
- clarify that module-specific YAML sections forwarded by `all` should live directly under `freq` and `dft`, and fix the accompanying example snippet
- correct the `path-search` documentation to describe what the `--freeze-links` flag actually does when loading PDB inputs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691903921180832d83b08469a1b3ef92)