### PR TITLE
Document path-search output products

### DIFF
--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -72,10 +72,13 @@ Recursive path-building controls.
 - `kink_max_nodes` (`3`): Linear interpolation nodes for skipped GSM at kinks.
 
 ## Outputs
-- `<out-dir>/mep.trj` (+ `.pdb` when pockets were PDB inputs).
-- `<out-dir>/mep_w_ref.pdb` merged full-system trajectory (requires `--ref-pdb` or auto-supplied templates).
-- `<out-dir>/summary.yaml` summarising segment barriers and classification.
-- Per-segment folders containing GSM dumps, merged structures, and diagnostic energy plots.
+- `<out-dir>/mep.trj` (and `.pdb` when the inputs were PDB pockets).
+- `<out-dir>/mep_w_ref.pdb` merged full-system MEP (requires `--ref-pdb` or auto-provided templates).
+- `<out-dir>/mep_w_ref_seg_XX.pdb` merged per-segment paths for segments with covalent changes (requires `--ref-pdb`).
+- `<out-dir>/summary.yaml` summarising barriers and classification for every recursive segment.
+- `<out-dir>/mep_plot.png` ΔE profile generated via `trj2fig` (`kcal/mol`, reference = reactant).
+- `<out-dir>/energy_diagram.html` and `.png` Plotly diagrams of state energies (relative to reactant, kcal/mol).
+- Per-segment folders (`segments/seg_000_*`) containing GSM dumps, HEI snapshots, merged HEI files, linear kink optimisations, and diagnostic energy plots.
 - Console reports covering resolved configuration blocks (`geom`, `calc`, `gs`, `opt`, `sopt.*`, `bond`, `search`).
 
 ## Notes


### PR DESCRIPTION
## Summary
- Update the `docs/path_search.md` output section so it lists every artifact the implementation actually writes, including `mep_plot.png`, energy diagrams, and merged per-segment files.

## Testing
- Not run (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691908f295f0832d882db1b6c43335c7)