### PR TITLE
Fix freq CLI pressure option binding

### DIFF
--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -551,7 +551,8 @@ THERMO_KW = {
 # ---- Thermochemistry options (added) ----
 @click.option("--temperature", type=float, default=THERMO_KW["temperature"], show_default=True,
               help="Temperature (K) for thermochemistry summary.")
-@click.option("--pressure", type=float, default=THERMO_KW["pressure_atm"], show_default=True,
+@click.option("--pressure", "pressure_atm",
+              type=float, default=THERMO_KW["pressure_atm"], show_default=True,
               help="Pressure (atm) for thermochemistry summary.")
 @click.option("--dump", type=click.BOOL, default=THERMO_KW["dump"], show_default=True,
               help="When True, write 'thermoanalysis.yaml' under out-dir.")


### PR DESCRIPTION
## Summary
- ensure the freq CLI `--pressure` option maps to the correct parameter name so Click can pass the argument successfully

## Testing
- `python -m pdb2reaction.cli freq --help | head` *(fails: missing numpy dependency in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69191a1cc594832d9897fe2c5f078508)