### PR TITLE
Map all scan indices to original PDB ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Key options:
 - `-i, --input PATH...`: Reaction-ordered PDB files (≥2 for GSM mode, 1 when combined with `--scan-lists` or `--tsopt True`).
 - `-c, --center TEXT`: Substrate specification (residue IDs or names) used to carve the binding pocket.
 - `--ligand-charge TEXT`: Total or per-residue charge assignment propagated through scan/GSM/TSOPT.
+- `--scan-lists TEXT...`: Define staged scans for single-input runs. Atom indices are taken from the **original** PDB supplied to
+  `pdb2reaction all` (1-based) and are automatically remapped onto the extracted pocket before invoking `scan`.
 - `--tsopt/--thermo/--dft BOOLEAN`: Enable TS optimisation, vibrational analysis, and DFT single-point post-processing.
 - `--args-yaml FILE`: Shared YAML file that forwards UMA/GSM configuration blocks to every invoked subcommand
   (see [`docs/all.md`](docs/all.md)).

--- a/docs/all.md
+++ b/docs/all.md
@@ -65,7 +65,7 @@ pdb2reaction all -i SINGLE.pdb -c SUBSTRATE_SPEC --tsopt True [other toggles]
 | `--dft-max-cycle INT` | Override `dft --max-cycle`. | _None_ |
 | `--dft-conv-tol FLOAT` | Override `dft --conv-tol`. | _None_ |
 | `--dft-grid-level INT` | Override `dft --grid-level`. | _None_ |
-| `--scan-lists TEXT...` | One or more Python-like lists describing staged scans on the extracted pocket (single-input runs only). Each list element is `(i,j,target\_Å)` (values are parsed from a Python-like literal). | _None_ |
+| `--scan-lists TEXT...` | One or more Python-like lists describing staged scans on the extracted pocket (single-input runs only). Each list element is `(i,j,target\_Å)` (values are parsed from a Python-like literal). Atom indices come from the original `all` input PDB (1-based) and are remapped internally to the pocket ordering. | _None_ |
 | `--scan-out-dir PATH` | Override the scan output directory (`<out-dir>/scan` by default). | _None_ |
 | `--scan-one-based BOOLEAN` | Force 1-based (`True`) or 0-based (`False`) scan indexing; `None` keeps the scan default (1-based). | _None_ |
 | `--scan-max-step-size FLOAT` | Override scan `--max-step-size` (Å). | _None_ |


### PR DESCRIPTION
## Summary
- convert the single-structure scan pipeline in `pdb2reaction all` so that `--scan-lists` atom indices are interpreted in terms of the original full-system PDB and remapped onto the extracted pocket before invoking `scan`
- add helper utilities and logging for the remapping plus documentation updates in the CLI help, README, and docs/all.md that describe the new behaviour

## Testing
- `python -m compileall pdb2reaction` *(fails: pre-existing `IndentationError` in `pdb2reaction/path_search.py`)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a491731a0832d932f7078992c3cb3)