### PR TITLE
Document opt distance restraints and share freeze-link helper

### DIFF
--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -207,6 +207,7 @@ from .uma_pysis import uma_pysis
 from .trj2fig import run_trj2fig
 from .utils import (
     build_energy_diagram,
+    detect_freeze_links_safe,
     format_elapsed,
     prepare_input_structure,
     maybe_convert_xyz_to_gjf,
@@ -649,12 +650,9 @@ def _pseudo_irc_and_match(seg_idx: int,
     Returns dict with paths/energies/geoms for {left, ts, right}, and small IRC plots.
     """
     # Freeze parents of link-H if requested
-    freeze_atoms = []
+    freeze_atoms: List[int] = []
     if freeze_links_flag and seg_pocket_pdb.suffix.lower() == ".pdb":
-        try:
-            freeze_atoms = list(_path_search._freeze_links_for_pdb(seg_pocket_pdb))
-        except Exception:
-            freeze_atoms = []
+        freeze_atoms = detect_freeze_links_safe(seg_pocket_pdb)
 
     # Mode direction
     uma_kwargs = dict(charge=int(q_int), spin=int(spin), model="uma-s-1p1", task_name="omol", device="auto")

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -9,7 +9,8 @@ Usage (CLI)
     pdb2reaction opt -i INPUT -q CHARGE [-s SPIN]
         [--opt-mode {light|lbfgs|heavy|rfo}] [--freeze-links {True|False}]
         [--dist-freeze "[(I,J,TARGET_A), ...]"] [--one-based|--zero-based] [--bias-k FLOAT]
-        [--dump {True|False}] [--out-dir DIR] [--max-cycles N] [--args-yaml FILE]
+        [--dump {True|False}] [--out-dir DIR] [--max-cycles N] [--thresh PRESET]
+        [--args-yaml FILE]
 
 Examples::
     pdb2reaction opt -i input.pdb -q 0
@@ -66,6 +67,7 @@ Outputs (& Directory Layout)
 - `out_dir/` (default: `./result_opt/`)
   - `final_geometry.xyz` — final optimized geometry (always).
   - `final_geometry.pdb` — converted from XYZ when the input was a PDB.
+  - `final_geometry.gjf` — emitted when the input provided a Gaussian template (GJF) to reuse headers/basis.
   - `optimization.trj` — trajectory (written when `--dump` or `opt.dump: true`).
   - `optimization.pdb` — converted from TRJ when input was a PDB and dumping is enabled.
   - `restart*.yml` — optional restart files every N cycles when `opt.dump_restart` is set (file names depend on optimizer).

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -132,7 +132,7 @@ from .opt import (
 )
 from .utils import (
     convert_xyz_to_pdb,
-    detect_freeze_links,
+    detect_freeze_links_safe,
     load_yaml_dict,
     apply_yaml_overrides,
     pretty_block,
@@ -194,14 +194,6 @@ _OPT_MODE_ALIASES = (
     (("light", "lbfgs"), "lbfgs"),
     (("heavy", "rfo"), "rfo"),
 )
-
-
-def _freeze_links_for_pdb(pdb_path: Path) -> List[int]:
-    try:
-        return list(detect_freeze_links(pdb_path))
-    except Exception as e:
-        click.echo(f"[freeze-links] WARNING: Could not detect link parents for '{pdb_path.name}': {e}", err=True)
-        return []
 
 
 def _ensure_stage_dir(base: Path, k: int) -> Path:
@@ -508,7 +500,7 @@ def cli(
         # Merge freeze_atoms with link parents (PDB)
         freeze = merge_freeze_atom_indices(geom_cfg)
         if freeze_links and input_path.suffix.lower() == ".pdb":
-            detected = _freeze_links_for_pdb(input_path)
+            detected = detect_freeze_links_safe(input_path)
             if detected:
                 freeze = merge_freeze_atom_indices(geom_cfg, detected)
                 if freeze:

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -95,6 +95,7 @@ from .opt import (
     RFO_KW as _RFO_KW,
 )
 from .utils import (
+    detect_freeze_links_safe,
     pretty_block,
     format_geom_for_echo,
     format_elapsed,
@@ -135,15 +136,6 @@ HARTREE_TO_KCAL_MOL = 627.50961
 
 
 # ---- 小物ユーティリティ ----
-
-def _freeze_links_for_pdb(pdb_path: Path) -> List[int]:
-    from .utils import detect_freeze_links
-    try:
-        return list(detect_freeze_links(pdb_path))
-    except Exception as e:
-        click.echo(f"[freeze-links] WARNING: Could not detect link parents for '{pdb_path.name}': {e}", err=True)
-        return []
-
 
 def _ensure_dir(path: Path) -> None:
     path.mkdir(parents=True, exist_ok=True)
@@ -460,7 +452,7 @@ def cli(
         # freeze-atoms（PDB のリンク親の凍結をマージ）
         freeze = merge_freeze_atom_indices(geom_cfg)
         if freeze_links and input_path.suffix.lower() == ".pdb":
-            detected = _freeze_links_for_pdb(input_path)
+            detected = detect_freeze_links_safe(input_path)
             if detected:
                 freeze = merge_freeze_atom_indices(geom_cfg, detected)
                 if freeze:


### PR DESCRIPTION
## Summary
- document the opt CLI distance-restraint options, fix outdated defaults, and mention the optional GJF export so the docs match the implementation
- add a reusable `detect_freeze_links_safe` helper in `utils` and switch the opt/path-opt/path-search/scan/scan2d/all modules to use it instead of duplicating wrappers

## Testing
- `python -m compileall pdb2reaction`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a625f8724832d9ebf3c28c5aaa1d3)