### PR TITLE
Document charge defaults and unify CLI options

### DIFF
--- a/docs/dft.md
+++ b/docs/dft.md
@@ -15,8 +15,8 @@ pdb2reaction dft -i INPUT -q CHARGE [-s SPIN] \
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
-| `-q, --charge INT` | Total charge supplied to PySCF. | Required |
-| `-s, --spin INT` | Spin multiplicity (2S+1). Converted to `2S` for PySCF. | `1` |
+| `-q, --charge INT` | Total charge supplied to PySCF. | `.gjf` template value or `0` |
+| `-s, --spin INT` | Spin multiplicity (2S+1). Converted to `2S` for PySCF. | `.gjf` template value or `1` |
 | `--func-basis TEXT` | Functional and basis in `FUNC/BASIS` form (quotes recommended when using `*`). | `wb97m-v/6-31g**` |
 | `--max-cycle INT` | Maximum SCF iterations (`dft.max_cycle`). | `100` |
 | `--conv-tol FLOAT` | SCF convergence tolerance in Hartree (`dft.conv_tol`). | `1e-9` |
@@ -31,7 +31,7 @@ pdb2reaction dft -i INPUT -q CHARGE [-s SPIN] \
 - `verbose` (`4`): PySCF verbosity (0–9).
 - `out_dir` (`"./result_dft/"`): Output directory.
 
-_Functional/basis selection and molecular charge must be supplied on the CLI. Spin defaults to `1` (singlet) but should be set explicitly for other states._
+_Functional/basis selection must be supplied on the CLI. Charge/spin inherit `.gjf` template metadata when present and otherwise default to `0`/`1`; set them explicitly for non-default states._
 
 ## Outputs
 - `<out-dir>/input_geometry.xyz`: Geometry snapshot passed to PySCF (identical coordinates to the input file).
@@ -44,7 +44,8 @@ _Functional/basis selection and molecular charge must be supplied on the CLI. Sp
 ## Notes
 - GPU4PySCF is used when available; otherwise a CPU SCF object is built. Nonlocal VV10 is enabled automatically for functionals ending with `-v` or containing `vv10`.
 - The YAML file must contain a mapping root with top-level key `dft`; non-mapping roots raise an error via `load_yaml_dict`.
-- `-q/--charge` is required. `-s/--spin` defaults to `1` (RKS) but should be specified explicitly for non-singlet states to ensure the correct (RKS vs UKS) solver.
+- Charge/spin inherit `.gjf` template metadata when available; otherwise they default to `0`/`1`. Override them explicitly to
+  ensure the correct RKS/UKS solver is chosen for the intended multiplicity.
 - Exit codes: `0` (converged), `3` (not converged), `2` (PySCF import failure), `1` (other errors), `130` (interrupt).
 - IAO spin/charge analysis may fail for challenging systems; in that case the IAO column values in `result.yaml` are `null` and a warning is printed.
 

--- a/docs/freq.md
+++ b/docs/freq.md
@@ -18,8 +18,8 @@ pdb2reaction freq -i INPUT -q CHARGE [--spin 2S+1]
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
-| `-q, --charge INT` | Total charge. | Required |
-| `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
+| `-q, --charge INT` | Total charge. | `.gjf` template value or `0` |
+| `-s, --spin INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--freeze-links BOOL` | Explicit `True`/`False`. For PDB inputs, freeze link-hydrogen parents (merged with `geom.freeze_atoms`). | `True` |
 | `--max-write INT` | Number of modes to export. | `20` |
 | `--amplitude-ang FLOAT` | Animation amplitude (Å). | `0.8` |
@@ -55,6 +55,8 @@ _The thermochemistry parameters (`temperature`, `pressure_atm`, `dump`) are curr
 - Imaginary modes are reported as negative frequencies; PHVA restricts the Hessian to active degrees of freedom when atoms are frozen.
 - `--hessian-calc-mode` overrides `calc.hessian_calc_mode`; Analytical mode may require more GPU memory than finite differences.
 - Mode animations use sinusoidal displacements; PDB animations employ MODEL/ENDMDL records for multi-model files.
+- Charge/spin inherit `.gjf` template metadata when the input is `.gjf`; otherwise they default to `0`/`1`. Override them
+  explicitly to enforce the correct state.
 
 ## YAML configuration (`--args-yaml`)
 Accepts a mapping; CLI overrides YAML. Shared sections reuse [`opt`](opt.md#yaml-configuration-args-yaml).

--- a/docs/irc.md
+++ b/docs/irc.md
@@ -18,8 +18,8 @@ pdb2reaction irc -i INPUT -q CHARGE [--spin 2S+1]
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH` | Transition-state structure accepted by `geom_loader`. | Required |
-| `-q, --charge INT` | Total charge. | Required |
-| `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
+| `-q, --charge INT` | Total charge. | `.gjf` template value or `0` |
+| `-s, --spin INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--max-cycles INT` | Maximum IRC steps (overrides `irc.max_cycles`). | _None_ (use YAML/default `125`) |
 | `--step-size FLOAT` | Step length in mass-weighted coordinates (overrides `irc.step_length`). | _None_ (default `0.10`) |
 | `--root INT` | Imaginary-mode index for the initial displacement (`irc.root`). | _None_ (default `0`) |
@@ -58,6 +58,8 @@ EulerPC / IRC controls (defaults in parentheses).
 - CLI boolean options `--forward` and `--backward` require explicit `True` or `False` (e.g., `--forward True`).
 - When the input is PDB, trajectory files are converted to PDB using the input topology.
 - IRC calculations reuse the UMA calculator across steps; large `step_length` values may destabilise the integration.
+- Charge/spin inherit `.gjf` template metadata when available; otherwise the CLI defaults to `0`/`1`. Override them explicitly to
+  keep the IRC on the intended potential-energy surface.
 
 ## YAML configuration (`--args-yaml`)
 Provide a mapping; CLI overrides YAML. Shared sections reuse [`opt`](opt.md#yaml-configuration-args-yaml) for geometry/calculator keys.

--- a/docs/opt.md
+++ b/docs/opt.md
@@ -16,8 +16,8 @@ pdb2reaction opt -i INPUT -q CHARGE [--spin 2S+1] [--opt-mode light|lbfgs|heavy|
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH` | Structure file accepted by `geom_loader` (`.pdb`, `.xyz`, `.trj`, …). | Required |
-| `-q, --charge INT` | Total charge passed to UMA. | Required |
-| `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
+| `-q, --charge INT` | Total charge passed to UMA. | `.gjf` template value or `0` |
+| `-s, --spin INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--dist-freeze TEXT` | Repeatable Python-like literal describing `(i, j, targetÅ)` tuples for harmonic restraints. Omit the target to freeze the initial distance. | _None_ |
 | `--one-based / --zero-based` | Interpret `--dist-freeze` indices as 1-based (default) or 0-based. | `--one-based` |
 | `--bias-k FLOAT` | Harmonic bias strength `k` (eV·Å⁻²) applied to every `--dist-freeze` tuple. | `10.0` |
@@ -81,7 +81,8 @@ Specific to RFOptimizer (`--opt-mode heavy|rfo`).
 - Console blocks summarising resolved `geom`, `calc`, `opt`, and LBFGS/RFO settings.
 
 ## Notes
-- Always provide the chemically correct charge and multiplicity.
+- Charge/spin resolution: when the input is `.gjf`, the CLI inherits the template charge/spin; otherwise it defaults to `0`/`1`.
+  Override them explicitly to enforce the chemically correct state.
 - `--freeze-links` is PDB-only and merges link parents into `geom.freeze_atoms`.
 - `--dist-freeze` lets you apply harmonic restraints to selected atom pairs; omit the target distance to freeze the current separation. Adjust the strength with `--bias-k` (eV·Å⁻²).
 - CLI precedence: CLI > YAML > built-in defaults.

--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -15,8 +15,8 @@ pdb2reaction path-opt -i REACTANT PRODUCT -q CHARGE [--spin 2S+1]
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH PATH` | Two endpoint structures (reactant, product). | Required |
-| `-q, --charge INT` | Total charge. | Required |
-| `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
+| `-q, --charge INT` | Total charge. | `.gjf` template value or `0` |
+| `-s, --spin INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--freeze-links BOOL` | Explicit `True`/`False`. For PDB inputs, freeze link-hydrogen parents. | `True` |
 | `--max-nodes INT` | Internal nodes in the string (total images = `max_nodes + 2`). | `30` |
 | `--max-cycles INT` | Maximum optimizer cycles. | `100` |
@@ -58,6 +58,8 @@ StringOptimizer controls (defaults in parentheses).
 - `<out-dir>/gsm_hei.xyz` (+ `.pdb` for PDB inputs) for the highest-energy image.
 - `<out-dir>/align_refine/` alignment diagnostics.
 - Optional optimizer dumps/restarts when `--dump` or YAML toggles them.
+- Charge/spin values default to `.gjf` template metadata when the endpoints are `.gjf`; otherwise they fall back to `0`/`1`.
+  Override them explicitly to enforce the intended electronic state.
 
 ## Notes
 - Inputs are rigidly aligned via Kabsch before optimisation; if freeze atoms are present, only those atoms guide the fit.

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -18,8 +18,8 @@ pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--spin 2S+1]
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH...` | Two or more structures in reaction order (reactant → product). A single `-i` may be followed by multiple paths. | Required |
-| `-q, --charge INT` | Total charge. | Required |
-| `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
+| `-q, --charge INT` | Total charge. | `.gjf` template value or `0` |
+| `-s, --spin INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--freeze-links BOOL` | Explicit `True`/`False`. When loading PDB pockets, freeze the parent atoms of link hydrogens. | `True` |
 | `--max-nodes INT` | Internal nodes for GSM segments (`String` has `max_nodes + 2` images). | `10` |
 | `--max-cycles INT` | Maximum GSM optimization cycles. | `100` |
@@ -87,6 +87,8 @@ Recursive path-building controls.
 - `--ref-pdb` can be given once followed by multiple filenames; with `--align`, only the first template is reused for merges.
 - All UMA calculators are shared across structures for efficiency.
 - When `--dump` is set, GSM and single-structure optimizations emit trajectories and restart YAML files.
+- Charge/spin inherit `.gjf` template metadata when available; otherwise the CLI defaults to `0`/`1`. Override them explicitly
+  when you need a different electronic state.
 
 ## YAML configuration (`--args-yaml`)
 The YAML root must be a mapping. CLI parameters override YAML values. Shared sections reuse [`opt`](opt.md#yaml-configuration-args-yaml).

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -17,8 +17,8 @@ pdb2reaction scan -i INPUT -q CHARGE --scan-lists "[(i,j,target), ...]" [...]
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
-| `-q, --charge INT` | Total charge. | Required |
-| `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
+| `-q, --charge INT` | Total charge. | `.gjf` template value or `0` |
+| `-s, --spin INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--scan-lists TEXT` | Repeatable Python-like list literal of `(i, j, targetÅ)` triples defining each scan stage. | Required |
 | `--one-based / --zero-based` | Interpret `(i, j)` indices as 1-based (default) or 0-based. | `--one-based` |
 | `--max-step-size FLOAT` | Maximum change in any scanned bond per integration step (Å). | `0.20` |
@@ -65,6 +65,8 @@ Parameters for UMA-based bond-change detection (mirrors `path_search`).
 - When `--one-based` is used (default), indices follow PDB conventions; invalid indices or non-positive target distances raise `click.BadParameter`.
 - Pre- and end-of-stage optimizations share UMA calculator instances for efficiency.
 - Stage dumping writes one trajectory per stage; `--dump` also triggers `.pdb` conversion for PDB inputs.
+- Charge/spin inherit `.gjf` template metadata when available; otherwise they default to `0`/`1`. Override them explicitly for the
+  chemically correct state.
 
 ## YAML configuration (`--args-yaml`)
 The YAML root must be a mapping. CLI parameters override YAML. Shared sections reuse the definitions documented for [`opt`](opt.md#yaml-configuration-args-yaml).

--- a/docs/ts_opt.md
+++ b/docs/ts_opt.md
@@ -19,8 +19,8 @@ pdb2reaction ts-opt -i INPUT -q CHARGE [--spin 2S+1]
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
-| `-q, --charge INT` | Total charge. | Required |
-| `-s, --spin INT` | Spin multiplicity (2S+1). | `1` |
+| `-q, --charge INT` | Total charge. | `.gjf` template value or `0` |
+| `-s, --spin INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--freeze-links BOOL` | Explicit `True`/`False`. For PDB inputs, freeze link-hydrogen parents (propagated to UMA). | `True` |
 | `--max-cycles INT` | Maximum macro cycles (forwarded to `opt.max_cycles`). | `10000` |
 | `--opt-mode TEXT` | Hessian Dimer aliases: `light`/`lbfgs`/`dimer`/`simple`/`simpledimer`/`hessian_dimer`. RS-I-RFO aliases: `heavy`/`rfo`/`rsirfo`/`rs-i-rfo`. | `light` |
@@ -69,7 +69,8 @@ Controls the heavy-mode RS-I-RFO optimizer. Defaults derive from [`opt`](opt.md#
 - Optional `.dimer_mode.dat` (light mode) and dump files when `--dump` is enabled.
 
 ## Notes
-- Always provide accurate charge and multiplicity; they are propagated to UMA.
+- Charge/spin inherit `.gjf` template metadata when present; otherwise the CLI defaults to `0`/`1`. Override them explicitly to
+  ensure the UMA calculations use the intended state.
 - `--hessian-calc-mode` overrides `calc.hessian_calc_mode` after YAML merging.
 - In light mode, the flattened active-subspace Hessian is maintained and updated between LBFGS passes.
 - Imaginary-mode analysis uses PHVA and translation/rotation projection consistent with the frequency module.

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -6,8 +6,8 @@ freq — Vibrational frequency analysis, mode export, and PHVA-based thermochemi
 
 Usage (CLI)
 -----
-    # Minimum (charge is effectively required to avoid wrong conditions)
-    pdb2reaction freq -i INPUT.(pdb|xyz|trj) -q CHARGE
+    # Minimum (charge defaults to .gjf metadata or 0; specify explicitly when possible)
+    pdb2reaction freq -i INPUT.(pdb|xyz|trj) [-q CHARGE]
 
     # Full example (all key options shown)
     pdb2reaction freq \
@@ -103,6 +103,8 @@ from .utils import (
     merge_freeze_atom_indices,
     prepare_input_structure,
     resolve_charge_spin_or_raise,
+    charge_option,
+    spin_option,
 )
 def _torch_device(auto: str = "auto") -> torch.device:
     if auto == "auto":
@@ -531,15 +533,8 @@ THERMO_KW = {
     required=True,
     help="Input structure (.pdb, .xyz, .trj, ...)",
 )
-@click.option("-q", "--charge", type=int, default=None, show_default=False, help="Total charge")
-@click.option(
-    "-s",
-    "--spin",
-    type=int,
-    default=None,
-    show_default=False,
-    help="Multiplicity (2S+1). Defaults to 1 when not provided.",
-)
+@charge_option()
+@spin_option()
 @click.option("--freeze-links", type=click.BOOL, default=True, show_default=True,
               help="Freeze parent atoms of link hydrogens (PDB only).")
 @click.option("--max-write", type=int, default=20, show_default=True,

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -39,11 +39,12 @@ Description
 - Configuration model: Only the CLI options listed above are accepted. All other parameters
   (geometry options, UMA calculator configuration, and detailed EulerPC/IRC settings) must be provided via YAML.
   Final configuration precedence: built-in defaults → YAML → CLI.
-- Strong recommendation: Provide both `-q/--charge` and `-s/--spin` explicitly to avoid running under unintended conditions.
+- Charge/spin defaults: `-q/--charge` and `-s/--spin` inherit values from `.gjf` templates when provided and otherwise fall back
+  to `0`/`1`. Set them explicitly to avoid running under unintended conditions.
 - CLI options:
   - `-i/--input PATH` (required): Structure file (.pdb/.xyz/.trj/…).
-  - `-q/--charge INT` (strongly recommended): Total charge; overrides `calc.charge` from YAML.
-  - `-s/--spin INT` (default 1; strongly recommended): Spin multiplicity (2S+1); overrides `calc.spin`.
+  - `-q/--charge INT`: Total charge; overrides `calc.charge` from YAML and defaults to a `.gjf` template value or `0` when omitted.
+  - `-s/--spin INT` (default 1): Spin multiplicity (2S+1); overrides `calc.spin` and defaults to the template multiplicity or `1`.
   - `--max-cycles INT`: Max number of IRC steps; overrides `irc.max_cycles`.
   - `--step-size FLOAT`: Step length in mass-weighted coordinates; overrides `irc.step_length`.
   - `--root INT`: Imaginary mode index for the initial displacement; overrides `irc.root`.
@@ -109,6 +110,8 @@ from pdb2reaction.utils import (
     merge_freeze_atom_indices,
     prepare_input_structure,
     resolve_charge_spin_or_raise,
+    charge_option,
+    spin_option,
 )
 
 
@@ -174,14 +177,11 @@ def _echo_convert_trj_to_pdb_if_exists(trj_path: Path, ref_pdb: Path, out_path: 
     required=True,
     help="Input structure file (.pdb, .xyz, .trj, etc.).",
 )
-@click.option("-q", "--charge", type=int, default=None, show_default=False, help="Total charge; overrides calc.charge from YAML.")
-@click.option(
-    "-s",
-    "--spin",
-    type=int,
-    default=None,
-    show_default=False,
-    help="Spin multiplicity (2S+1); overrides calc.spin from YAML.",
+@charge_option(
+    "Total charge; overrides calc.charge from YAML. Defaults to the .gjf template value when present, otherwise 0."
+)
+@spin_option(
+    "Spin multiplicity (2S+1); overrides calc.spin from YAML. Defaults to the .gjf template value when present, otherwise 1."
 )
 @click.option("--max-cycles", type=int, default=None, help="Maximum number of IRC steps; overrides irc.max_cycles from YAML.")
 @click.option("--step-size", type=float, default=None, help="Step length in mass-weighted coordinates; overrides irc.step_length from YAML.")

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -42,7 +42,8 @@ out_dir/ (default: ./result_path_opt/)
 
 Notes:
 -----
-- Always set correct total charge (`-q/--charge`) and spin multiplicity (`-s/--spin`) to avoid unphysical conditions.
+- Charge/spin: `-q/--charge` and `-s/--spin` inherit `.gjf` template values when provided and otherwise fall back to `0`/`1`.
+  Override them explicitly to avoid unphysical conditions.
 - Coordinates are Cartesian; `freeze_atoms` use 0-based indices. With `--freeze-links=True` and PDB inputs, link-hydrogen parents are added automatically.
 - `--max-nodes` sets the number of internal nodes; the string has (max_nodes + 2) images including endpoints.
 - `--max-cycles` limits optimization; after full growth, the same bound applies to additional refinement.
@@ -83,6 +84,8 @@ from .utils import (
     fill_charge_spin_from_gjf,
     maybe_convert_xyz_to_gjf,
     PreparedInputStructure,
+    charge_option,
+    spin_option,
 )
 from .align_freeze_atoms import align_and_refine_sequence_inplace
 
@@ -173,22 +176,8 @@ def _load_two_endpoints(
     required=True,
     help="Two endpoint structures (reactant and product); accepts .pdb or .xyz.",
 )
-@click.option(
-    "-q",
-    "--charge",
-    type=int,
-    default=None,
-    show_default=False,
-    help="Total charge (defaults to 0 when omitted).",
-)
-@click.option(
-    "-s",
-    "--spin",
-    type=int,
-    default=None,
-    show_default=False,
-    help="Spin multiplicity (2S+1). Defaults to 1 when omitted.",
-)
+@charge_option()
+@spin_option()
 @click.option("--freeze-links", "freeze_links_flag", type=click.BOOL, default=True, show_default=True,
               help="If a PDB is provided, freeze the parent atoms of link hydrogens.")
 @click.option("--max-nodes", type=int, default=30, show_default=True,

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -10,10 +10,10 @@ Usage (CLI)
 
 Required-like:
     -i/--input           Two or more structures in reaction order (repeatable or space‑separated after a single -i).
-    -q/--charge          Total system charge (integer).
+    -q/--charge          Total system charge (defaults to a .gjf template value or 0 when omitted).
 
 Recommended/common:
-    -s/--spin            Spin multiplicity (2S+1); default 1.
+    -s/--spin            Spin multiplicity (2S+1); defaults to a .gjf template value or 1 when omitted.
     --sopt-mode          Single-structure optimizer: lbfgs|rfo|light|heavy; default lbfgs.
     --max-nodes          Internal nodes for segment GSM; default 10.
     --max-cycles         Max optimization cycles; default 100.
@@ -160,6 +160,8 @@ from .utils import (
     maybe_convert_xyz_to_gjf,
     PreparedInputStructure,
     GjfTemplate,
+    charge_option,
+    spin_option,
 )
 from .trj2fig import run_trj2fig  # auto‑generate an energy plot when a .trj is produced
 from .bond_changes import compare_structures, summarize_changes
@@ -1434,22 +1436,8 @@ def _merge_final_and_write(final_images: List[Any],
           "Either repeat '-i' (e.g., '-i A -i B -i C') or use a single '-i' "
           "followed by multiple space-separated paths (e.g., '-i A B C').")
 )
-@click.option(
-    "-q",
-    "--charge",
-    type=int,
-    default=None,
-    show_default=False,
-    help="Total system charge (defaults to 0 when omitted).",
-)
-@click.option(
-    "-s",
-    "--spin",
-    type=int,
-    default=None,
-    show_default=False,
-    help="Multiplicity (2S+1). Defaults to 1 when omitted.",
-)
+@charge_option()
+@spin_option()
 @click.option("--freeze-links", "freeze_links_flag", type=click.BOOL, default=True, show_default=True,
               help="For PDB input, freeze parent atoms of link hydrogens.")
 @click.option("--max-nodes", type=int, default=10, show_default=True,

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -146,6 +146,8 @@ from .utils import (
     prepare_input_structure,
     resolve_charge_spin_or_raise,
     maybe_convert_xyz_to_gjf,
+    charge_option,
+    spin_option,
 )
 from .bond_changes import compare_structures, summarize_changes
 
@@ -351,15 +353,8 @@ def _snapshot_geometry(g) -> Any:
     required=True,
     help="Input structure file (.pdb, .xyz, .trj, ...).",
 )
-@click.option("-q", "--charge", type=int, default=None, show_default=False, help="Total charge.")
-@click.option(
-    "-s",
-    "--spin",
-    type=int,
-    default=None,
-    show_default=False,
-    help="Multiplicity (2S+1). Defaults to 1 when not provided.",
-)
+@charge_option()
+@spin_option()
 @click.option(
     "--scan-lists", "scan_lists_raw",
     type=str, multiple=True, required=True,

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -103,6 +103,8 @@ from .utils import (
     normalize_choice,
     prepare_input_structure,
     resolve_charge_spin_or_raise,
+    charge_option,
+    spin_option,
 )
 
 # 2D スキャンで使う既定群（必要部分のみ上書き）
@@ -286,15 +288,8 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
     required=True,
     help="Input structure file (.pdb, .xyz, .trj, ...).",
 )
-@click.option("-q", "--charge", type=int, default=None, show_default=False, help="Total charge.")
-@click.option(
-    "-s",
-    "--spin",
-    type=int,
-    default=None,
-    show_default=False,
-    help="Multiplicity (2S+1). Defaults to 1 when not provided.",
-)
+@charge_option()
+@spin_option()
 @click.option(
     "--scan-list", "scan_list_raw",
     type=str, required=True,

--- a/pdb2reaction/ts_opt.py
+++ b/pdb2reaction/ts_opt.py
@@ -89,7 +89,8 @@ DIR (default: ./result_ts_opt/)
 
 Notes:
 -----
-- Always set charge (-q) and spin (-s) to avoid unphysical conditions.
+- Charge/spin resolution: `-q/--charge` and `-s/--spin` inherit `.gjf` template values when the input is `.gjf` and otherwise
+  default to `0`/`1`. Override them explicitly to avoid unphysical conditions.
 - --opt-mode light runs the HessianDimer with periodic Hessian-based direction refresh;
   --opt-mode heavy runs RS-I-RFO.
 - --freeze-links is PDB-only and freezes parents of link hydrogens; these indices are
@@ -151,6 +152,8 @@ from .utils import (
     prepare_input_structure,
     resolve_charge_spin_or_raise,
     maybe_convert_xyz_to_gjf,
+    charge_option,
+    spin_option,
 )
 from .freq import (
     _torch_device,
@@ -1283,22 +1286,8 @@ RSIRFO_KW.update({
     required=True,
     help="Input structure (.pdb, .xyz, .trj, ...)",
 )
-@click.option(
-    "-q",
-    "--charge",
-    type=int,
-    default=None,
-    show_default=False,
-    help="Total charge (defaults to 0 when omitted).",
-)
-@click.option(
-    "-s",
-    "--spin",
-    type=int,
-    default=None,
-    show_default=False,
-    help="Multiplicity (2S+1). Defaults to 1 when omitted.",
-)
+@charge_option()
+@spin_option()
 @click.option("--freeze-links", type=click.BOOL, default=True, show_default=True,
               help="Freeze parent atoms of link hydrogens (PDB only).")
 @click.option("--max-cycles", type=int, default=10000, show_default=True, help="Max cycles / steps cap")

--- a/pdb2reaction/utils.py
+++ b/pdb2reaction/utils.py
@@ -73,11 +73,55 @@ import time
 from collections.abc import Iterable as _Iterable, Mapping, Sequence as _Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional, Sequence, List, Tuple
+from typing import Any, Dict, Optional, Sequence, List, Tuple, Callable, TypeVar
 
 import click
 import yaml
 from ase.data import chemical_symbols
+
+_ClickCallable = TypeVar("_ClickCallable", bound=Callable[..., Any])
+
+
+def charge_option(help_text: Optional[str] = None) -> Callable[[_ClickCallable], _ClickCallable]:
+    """Reusable Click option decorator for charge (inherits .gjf defaults)."""
+
+    default_help = (
+        "Total charge. Defaults to the value parsed from a Gaussian .gjf template when available, "
+        "otherwise 0."
+    )
+
+    def decorator(func: _ClickCallable) -> _ClickCallable:
+        return click.option(
+            "-q",
+            "--charge",
+            type=int,
+            default=None,
+            show_default=False,
+            help=help_text or default_help,
+        )(func)
+
+    return decorator
+
+
+def spin_option(help_text: Optional[str] = None) -> Callable[[_ClickCallable], _ClickCallable]:
+    """Reusable Click option decorator for spin multiplicity (inherits .gjf defaults)."""
+
+    default_help = (
+        "Spin multiplicity (2S+1). Defaults to the value parsed from a Gaussian .gjf template when available, "
+        "otherwise 1."
+    )
+
+    def decorator(func: _ClickCallable) -> _ClickCallable:
+        return click.option(
+            "-s",
+            "--spin",
+            type=int,
+            default=None,
+            show_default=False,
+            help=help_text or default_help,
+        )(func)
+
+    return decorator
 from ase.io import read, write
 import plotly.graph_objs as go
 


### PR DESCRIPTION
## Summary
- add reusable Click option decorators for charge/spin so every CLI describes the same fallback behaviour
- update all CLI docstrings and markdown docs so charge/spin defaults now match the implementation (inherit .gjf metadata or fall back to 0/1)
- mention the new defaults in each subcommand’s notes and align the wording to remove the outdated “required” messaging

## Testing
- python -m compileall pdb2reaction


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a67847660832dbc3ce8cd57f17212)