### PR TITLE
Remove DFT checkpoint handling

### DIFF
--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -1039,9 +1039,7 @@ def _run_dft_for_state(pdb_path: Path,
                        args_yaml: Optional[Path],
                        func_basis: str = "wb97m-v/def2-tzvpd",
                        overrides: Optional[Dict[str, Any]] = None,
-                       engine: str = "gpu",
-                       chk_in: Optional[Path] = None,
-                       chk_out: Optional[Path] = None) -> Dict[str, Any]:
+                       engine: str = "gpu") -> Dict[str, Any]:
     """
     Run dft CLI; return parsed result.yaml dict (may be empty).
     """
@@ -1064,10 +1062,6 @@ def _run_dft_for_state(pdb_path: Path,
     _append_cli_arg(args, "--max-cycle", overrides.get("max_cycle"))
     _append_cli_arg(args, "--conv-tol", overrides.get("conv_tol"))
     _append_cli_arg(args, "--grid-level", overrides.get("grid_level"))
-    if chk_in is not None:
-        args.extend(["--chk-in", str(chk_in)])
-    if chk_out is not None:
-        args.extend(["--chk-out", str(chk_out)])
 
     if args_yaml is not None:
         args.extend(["--args-yaml", str(args_yaml)])
@@ -1096,16 +1090,12 @@ def _run_dft_sequence(state_jobs: Sequence[Tuple[str, Optional[Path], Path]],
                       args_yaml: Optional[Path],
                       func_basis: str,
                       overrides: Optional[Dict[str, Any]],
-                      engine: str,
-                      enable_chk: bool) -> Dict[str, Dict[str, Any]]:
-    """Run DFT on a sequence of states, optionally chaining SCF checkpoints."""
+                      engine: str) -> Dict[str, Dict[str, Any]]:
+    """Run DFT on a sequence of states."""
     results: Dict[str, Dict[str, Any]] = {}
-    prev_chk: Optional[Path] = None
     for label, pdb_path, out_dir in state_jobs:
         if pdb_path is None:
             continue
-        chk_in = prev_chk if enable_chk else None
-        chk_out = (out_dir / "scf.chk") if enable_chk else None
         res = _run_dft_for_state(
             pdb_path,
             q_int,
@@ -1115,14 +1105,8 @@ def _run_dft_sequence(state_jobs: Sequence[Tuple[str, Optional[Path], Path]],
             func_basis=func_basis,
             overrides=overrides,
             engine=engine,
-            chk_in=chk_in,
-            chk_out=chk_out,
         )
         results[label] = res
-        if enable_chk and chk_out is not None and chk_out.exists():
-            prev_chk = chk_out
-        elif enable_chk:
-            prev_chk = None
     return results
 
 
@@ -1246,8 +1230,6 @@ def _run_dft_sequence(state_jobs: Sequence[Tuple[str, Optional[Path], Path]],
               default="gpu",
               show_default=True,
               help="Preferred DFT backend: GPU (default), CPU, or auto (try GPU then CPU).")
-@click.option("--dft-chk", "dft_chk", type=click.BOOL, default=True, show_default=True,
-              help="When True, store PySCF checkpoints per state and reuse the previous density as the next initial guess.")
 @click.option(
     "--scan-lists", "scan_lists_raw",
     type=str, multiple=True, required=False,
@@ -1321,7 +1303,6 @@ def cli(
     dft_conv_tol: Optional[float],
     dft_grid_level: Optional[int],
     dft_engine: str,
-    dft_chk: bool,
 ) -> None:
     """
     The **all** command composes `extract` → (optional `scan` on pocket) → `path_search` and hides ref-template bookkeeping.
@@ -1660,7 +1641,6 @@ def cli(
                 dft_func_basis_use,
                 dft_overrides,
                 dft_engine,
-                enable_chk=dft_chk,
             )
             dR = dft_payloads.get("R")
             dT = dft_payloads.get("TS")
@@ -2089,7 +2069,6 @@ def cli(
                     dft_func_basis_use,
                     dft_overrides,
                     dft_engine,
-                    enable_chk=dft_chk,
                 )
                 dR = dft_payloads.get("R")
                 dT = dft_payloads.get("TS")

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -53,7 +53,7 @@ Notes:
 - Charge/spin resolution: `-q/--charge` and `-s/--spin` inherit values from `.gjf` templates when present and otherwise fall back
   to `0`/`1`. Provide explicit values whenever possible to enforce the intended state (multiplicity > 1 selects UKS).
 - YAML overrides: --args-yaml points to a file with top-level key "dft" (conv_tol, max_cycle, grid_level, verbose, out_dir).
-- Grids and checkpointing: sets `grids.level` when supported; disables SCF checkpoint files when possible.
+- Grids: sets `grids.level` when supported.
 - Units: input coordinates are in Å. Functional/basis names are PySCF-style and case-insensitive for common sets.
 - Exit codes: 0 if SCF converged; 3 if not converged; 2 if PySCF import fails; 1 on unhandled errors; 130 on user interrupt.
 - If any population analysis (Mulliken, meta‑Löwdin, IAO) fails, a WARNING is printed and the corresponding column becomes `null`.
@@ -433,19 +433,6 @@ def _compute_atomic_spin_densities(mol, mf) -> Dict[str, Optional[List[float]]]:
     default=None,
     help='Optional YAML overrides under key "dft" (conv_tol, max_cycle, grid_level, verbose, out_dir).',
 )
-@click.option(
-    "--chk-in",
-    type=click.Path(path_type=Path, exists=False, dir_okay=False),
-    default=None,
-    help="Optional SCF checkpoint to use as the initial density guess.",
-)
-@click.option(
-    "--chk-out",
-    type=click.Path(path_type=Path, exists=False, dir_okay=False),
-    default=None,
-    help="Optional path to write the SCF checkpoint after completion.",
-)
-
 def cli(
     input_path: Path,
     charge: Optional[int],
@@ -457,8 +444,6 @@ def cli(
     out_dir: str,
     engine: str,
     args_yaml: Optional[Path],
-    chk_in: Optional[Path],
-    chk_out: Optional[Path],
 ) -> None:
     prepared_input = prepare_input_structure(input_path)
     geom_input_path = prepared_input.geom_path
@@ -569,36 +554,13 @@ def cli(
 
         mf = _configure_scf_object(mf, aux_basis_guess, dft_cfg, xc)
 
-        dm0 = None
-        chk_in_path = Path(chk_in).resolve() if chk_in else None
-        if chk_in_path is not None:
-            if chk_in_path.exists():
-                try:
-                    from pyscf import scf as pyscf_scf
-
-                    _, scf_data = pyscf_scf.chkfile.load_scf(str(chk_in_path))
-                    mo_coeff = scf_data.get("mo_coeff")
-                    mo_occ = scf_data.get("mo_occ")
-                    if mo_coeff is not None and mo_occ is not None:
-                        dm0 = mf.make_rdm1(mo_coeff, mo_occ)
-                        click.echo(f"[chk] Loaded initial guess from '{chk_in_path}'.")
-                    else:
-                        click.echo(
-                            f"[chk] WARNING: Checkpoint '{chk_in_path}' is missing orbital data; ignoring.",
-                            err=True,
-                        )
-                except Exception as e:
-                    click.echo(f"[chk] WARNING: Failed to load checkpoint '{chk_in_path}': {e}", err=True)
-            else:
-                click.echo(f"[chk] WARNING: Checkpoint '{chk_in_path}' not found; continuing without it.", err=True)
-
         # --------------------------
         # 5) Run SCF
         # --------------------------
         click.echo("\n=== DFT single-point started (GPU if available) ===\n")
         tic_scf = time.time()
         try:
-            e_tot = mf.kernel(dm0=dm0)
+            e_tot = mf.kernel()
         except Exception as scf_exc:
             if using_gpu:
                 click.echo(
@@ -612,7 +574,7 @@ def cli(
                 using_gpu = False
                 engine_label = "pyscf(cpu)"
                 tic_scf = time.time()
-                e_tot = mf.kernel(dm0=dm0)
+                e_tot = mf.kernel()
             else:
                 raise
         toc_scf = time.time()
@@ -633,18 +595,6 @@ def cli(
             mf_for_analysis = mf.to_cpu()  # GPU → CPU (no-op on CPU backend)
         except Exception:
             mf_for_analysis = mf
-
-        if chk_out:
-            chk_out_path = Path(chk_out).resolve()
-            try:
-                chk_out_path.parent.mkdir(parents=True, exist_ok=True)
-                from pyscf import scf as pyscf_scf
-
-                mf_for_chk = getattr(mf, "to_cpu", lambda: mf)()
-                pyscf_scf.chkfile.dump_scf(mf_for_chk, str(chk_out_path))
-                click.echo(f"[chk] Saved checkpoint to '{chk_out_path}'.")
-            except Exception as e:
-                click.echo(f"[chk] WARNING: Failed to write checkpoint '{chk_out_path}': {e}", err=True)
 
         charges = _compute_atomic_charges(mol, mf_for_analysis)
         spins   = _compute_atomic_spin_densities(mol, mf_for_analysis)


### PR DESCRIPTION
## Summary
- remove the DFT checkpoint CLI options and plumbing from the `all` orchestrator so DFT runs no longer attempt to save or reuse SCF checkpoint files
- simplify the standalone `dft` command by deleting the `--chk-in/--chk-out` options, the related SCF initial guess/serialization code, and adjusting the documentation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c039f11d8832dbd01a04b16de3379)