### PR TITLE
Standardize CLI docstring usage sections

### DIFF
--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -8,52 +8,45 @@ DFT, and DFT//UMA diagrams
 ================================================================================================================
 
 Usage (CLI)
------
-    # Standard (multi-structure ensemble in reaction order)
-    pdb2reaction all -i R.pdb [I1.pdb ...] P.pdb -c <substrate-spec> [--ligand-charge <map-or-number>]
-                      [--spin <2S+1>] [--freeze-links True|False] [--max-nodes N] [--max-cycles N]
-                      [--climb True|False] [--sopt-mode lbfgs|rfo|light|heavy]
-                      [--opt-mode light|lbfgs|heavy|rfo]
-                      [--dump True|False] [--args-yaml params.yaml]
-                      [--preopt True|False] [--hessian-calc-mode Analytical|FiniteDifference] [--out-dir DIR]
-                      [--tsopt True|False] [--thermo True|False] [--dft True|False]
-                      [--tsopt-max-cycles N] [--freq-* overrides] [--dft-* overrides]
-                      [--dft-engine gpu|cpu|auto]
+-----------
+    pdb2reaction all -i INPUT1 [INPUT2 ...] -c <substrate-spec> \
+        [--ligand-charge <number|"RES:Q,...">] [--spin <2S+1>] \
+        [--freeze-links {True|False}] [--max-nodes <int>] [--max-cycles <int>] \
+        [--climb {True|False}] [--sopt-mode {lbfgs|rfo|light|heavy}] \
+        [--opt-mode {light|lbfgs|heavy|rfo}] [--dump {True|False}] \
+        [--args-yaml <file>] [--preopt {True|False}] \
+        [--hessian-calc-mode {Analytical|FiniteDifference}] [--out-dir <dir>] \
+        [--tsopt {True|False}] [--thermo {True|False}] [--dft {True|False}] \
+        [--tsopt-max-cycles <int>] [--freq-* overrides] [--dft-* overrides] \
+        [--dft-engine {gpu|cpu|auto}] [--scan-lists "[(...)]" ...]
 
-    # Override examples (repeatable; use only what you need)
-      ... --scan-lists "[(12,45,1.35)]" --scan-one-based True --scan-bias-k 0.05 --scan-relax-max-cycles 150 \
-          --tsopt-max-cycles 250 --freq-temperature 298.15 --freq-max-write 15 --dft-func-basis "wb97m-v/def2-tzvpd"
+    # Single-structure scan builder (repeat --scan-lists to define stages)
+    pdb2reaction all -i INPUT.pdb -c <substrate-spec> --scan-lists "[(...)]" [...]
 
-    # Single-structure + staged scan (the scan creates intermediate/product candidates after extraction)
-    pdb2reaction all -i A.pdb -c "308,309" --scan-lists "[(12,45,1.35)]" [--scan-lists "..."] \
-                      --spin 1 --freeze-links True --sopt-mode lbfgs --preopt True \
-                      --out-dir result_all --tsopt True --thermo True --dft True
-
-    # Single-structure TSOPT-only mode (no path search):
-    # if exactly one input is given, --scan-lists is NOT provided, and --tsopt True:
-    # run TS optimization on the extracted pocket, do IRC (EulerPC), minimize both ends by IRC termination, and make diagrams.
-    pdb2reaction all -i single.pdb -c "GPP,MMT" --ligand-charge "GPP:-3,MMT:-1" \
-                      --tsopt True --thermo True --dft True --out-dir result_tsopt_single
+    # Single-structure TSOPT-only mode (no path_search) when --scan-lists is omitted and --tsopt True
+    pdb2reaction all -i INPUT.pdb -c <substrate-spec> --tsopt True [other options]
 
 
 Examples
------
+--------
     # Minimal end-to-end run with explicit substrate and ligand charges (multi-structure)
-    pdb2reaction all -i reactant.pdb product.pdb -c "GPP,MMT" --ligand-charge "GPP:-3,MMT:-1"
+    pdb2reaction all -i reactant.pdb product.pdb -c "GPP,MMT" \
+        --ligand-charge "GPP:-3,MMT:-1"
 
     # Full ensemble with an intermediate, residue-ID substrate spec, and full post-processing
     pdb2reaction all -i A.pdb B.pdb C.pdb -c "308,309" --ligand-charge "-1" \
-      --spin 1 --freeze-links True --max-nodes 10 --max-cycles 100 --climb True \
-      --sopt-mode lbfgs --dump False --args-yaml params.yaml --preopt True \
-      --out-dir result_all --tsopt True --thermo True --dft True
+        --spin 1 --freeze-links True --max-nodes 10 --max-cycles 100 --climb True \
+        --sopt-mode lbfgs --dump False --args-yaml params.yaml --preopt True \
+        --out-dir result_all --tsopt True --thermo True --dft True
 
-    # Single-structure + scan to build an ordered series (initial + stage results) → path_search + post
-    pdb2reaction all -i A.pdb -c "308,309" --scan-lists "[(10,55,2.20),(23,34,1.80)]" \
-      --spin 1 --out-dir result_scan_all --tsopt True --thermo True --dft True
+    # Single-structure + scan to build an ordered series before path_search + post-processing
+    pdb2reaction all -i A.pdb -c "308,309" \
+        --scan-lists "[(10,55,2.20),(23,34,1.80)]" --spin 1 --out-dir result_scan_all \
+        --tsopt True --thermo True --dft True
 
     # Single-structure TSOPT-only mode (no path_search)
     pdb2reaction all -i A.pdb -c "GPP,MMT" --ligand-charge "GPP:-3,MMT:-1" \
-      --tsopt True --thermo True --dft True --out-dir result_tsopt_only
+        --tsopt True --thermo True --dft True --out-dir result_tsopt_only
 
 
 Description

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -5,17 +5,20 @@ dft — Single-point DFT (GPU4PySCF with CPU PySCF fallback)
 ====================================================================
 
 Usage (CLI)
------
-    pdb2reaction dft -i INPUT -q CHARGE [-s SPIN] [--func-basis "FUNC/BASIS"] [--max-cycle N] [--conv-tol Eh] [--grid-level L] [--out-dir OUT_DIR] [--engine {gpu|cpu|auto}] [--args-yaml YAML]
-
-    # -q/--charge and -s/--spin fall back to .gjf template values when available (otherwise 0/1).
-    # Set them explicitly to avoid unphysical states. Here, SPIN means multiplicity (2S+1).
+-----------
+    pdb2reaction dft -i INPUT.{pdb|xyz|gjf|...} -q <charge> [-s <spin>] \
+        [--func-basis "FUNC/BASIS"] [--max-cycle <int>] [--conv-tol <hartree>] \
+        [--grid-level <int>] [--out-dir <dir>] [--engine {gpu|cpu|auto}] \
+        [--args-yaml <file>]
 
 Examples
------
+--------
+    # Default GPU-first policy with an explicit functional/basis pair
     pdb2reaction dft -i input.pdb -q 0 -s 1 --func-basis "wb97m-v/6-31g**"
-    pdb2reaction dft -i input.pdb -q 0 -s 2 --func-basis "wb97m-v/def2-tzvpd" --max-cycle 150 --conv-tol 1e-9
-    pdb2reaction dft -i input.xyz -q -1 -s 2 --engine cpu
+
+    # Tight SCF controls with a larger basis and CPU-only fallback
+    pdb2reaction dft -i input.pdb -q 0 -s 2 --func-basis "wb97m-v/def2-tzvpd" \
+        --max-cycle 150 --conv-tol 1e-9 --engine cpu
 
 Description
 -----

--- a/pdb2reaction/extract.py
+++ b/pdb2reaction/extract.py
@@ -5,40 +5,28 @@ extract — Automated binding‑pocket (active‑site) extractor
 ====================================================================
 
 Usage (CLI)
------
-    # Minimal and full examples shown below.
+-----------
+    pdb2reaction extract -i INPUT.pdb [INPUT2.pdb ...] -c <substrate_spec> \
+        [-o OUTPUT.pdb ...] [-r <Å>] [--radius-het2het <Å>] \
+        [--include-H2O {true|false}] [--exclude-backbone {true|false}] \
+        [--add-linkH {true|false}] [--selected-resn "CHAIN:RES" ...] \
+        [--ligand-charge <number|"RES:Q,...">] [--verbose {true|false}]
 
-Single structure:
-    pdb2reaction extract -i complex.pdb -c <substrate_spec> [-o pocket.pdb]
-                         [-r 2.6] [--radius-het2het 2.6]
-                         [--include-H2O true|false] [--exclude-backbone true|false]
-                         [--add-linkH true|false] [--selected-resn "A:123,456"]
-                         [--ligand-charge <Q> | --ligand-charge "RES1:Q1,RES2:Q2"]
-                         [--verbose true|false]
-
-Multiple structures → single multi‑MODEL PDB:
-    pdb2reaction extract -i complex1.pdb complex2.pdb [...] -c <substrate_spec>
-                         -o pocket_multi.pdb [other options...]
-
-Multiple structures → per‑structure outputs:
-    pdb2reaction extract -i complex1.pdb complex2.pdb [...] -c <substrate_spec>
-                         -o pocket1.pdb pocket2.pdb [...] [other options...]
-    # If -o is omitted with multiple inputs, files are named pocket_{original}.pdb.
-
-Examples::
-    # Minimal (ID‑based substrate) with explicit total ligand charge
+Examples
+--------
+    # Minimal (ID-based substrate) with explicit total ligand charge
     pdb2reaction extract -i complex.pdb -c A:123 -o pocket.pdb --ligand-charge -3
 
-    # Substrate provided as a PDB; per‑resname charge mapping (others remain 0)
+    # Substrate provided as a PDB; per-resname charge mapping (others remain 0)
     pdb2reaction extract -i complex.pdb -c substrate.pdb -o pocket.pdb \
-                         --ligand-charge "GPP:-3,MMT:-1"
+        --ligand-charge "GPP:-3,MMT:-1"
 
-    # Name‑based substrate selection including all matches (WARNING is logged)
+    # Name-based substrate selection including all matches (WARNING is logged)
     pdb2reaction extract -i complex.pdb -c "GPP,MMT" -o pocket.pdb --ligand-charge -4
 
-    # Multi‑structure → single multi‑MODEL output, with hetero‑hetero proximity enabled
+    # Multi-structure to single multi-MODEL output with hetero-hetero proximity enabled
     pdb2reaction extract -i complex1.pdb complex2.pdb -c A:123 \
-                         -o pocket_multi.pdb --radius-het2het 2.6 --ligand-charge -3 --verbose true
+        -o pocket_multi.pdb --radius-het2het 2.6 --ligand-charge -3 --verbose true
 
 Description
 -----

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -5,28 +5,20 @@ freq — Vibrational frequency analysis, mode export, and PHVA-based thermochemi
 ====================================================================
 
 Usage (CLI)
------
-    # Minimum (charge/multiplicity are resolved from the input when available; otherwise 0/1).
-    # Specify them explicitly when possible.
-    pdb2reaction freq -i INPUT.(pdb|xyz|trj) [-q CHARGE] [-s MULT]
+-----------
+    pdb2reaction freq -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [-s <spin>] \
+        [--freeze-links {True|False}] [--max-write <int>] \
+        [--amplitude-ang <float>] [--n-frames <int>] [--sort {value|abs}] \
+        [--out-dir <dir>] [--args-yaml <file>] [--temperature <K>] \
+        [--pressure <atm>] [--dump {True|False}] \
+        [--hessian-calc-mode {Analytical|FiniteDifference}]
 
-    # Full example (all key options shown)
-    pdb2reaction freq \
-      -i a.pdb -q 0 -s 1 \
-      --freeze-links True \
-      --max-write 20 \
-      --amplitude-ang 0.8 \
-      --n-frames 20 \
-      --sort value \
-      --out-dir ./result_freq/ \
-      --args-yaml ./args.yaml \
-      --temperature 298.15 \
-      --pressure 1.0 \
-      --dump False \
-      --hessian-calc-mode Analytical
+Examples
+--------
+    # Minimal frequency run with explicit charge and spin
+    pdb2reaction freq -i a.pdb -q 0 -s 1
 
-Examples::
-    pdb2reaction freq -i a.pdb -q 0
+    # PHVA with YAML overrides and a custom output directory
     pdb2reaction freq -i a.xyz -q -1 --args-yaml ./args.yaml --out-dir ./result_freq/
 
 Description

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -6,27 +6,18 @@ irc — Concise CLI for IRC calculations with the EulerPC integrator
 
 Usage (CLI)
 -----------
-    # Minimal (explicitly set charge/spin to avoid unintended conditions)
-    pdb2reaction irc -i a.pdb -q 0 -s 1
-
-    # Full example
-    pdb2reaction irc \
-      -i a.pdb -q 0 -s 1 \
-      --max-cycles 20 \
-      --step-size 0.5 \
-      --root 0 \
-      --forward True \
-      --backward False \
-      --freeze-links True \
-      --out-dir "./result_irc/" \
-      --hessian-calc-mode Analytical \
-      --args-yaml args.yaml
+    pdb2reaction irc -i INPUT.{pdb|xyz|trj|...} -q <charge> -s <spin> \
+        [--max-cycles <int>] [--step-size <float>] [--root <int>] \
+        [--forward {True|False}] [--backward {True|False}] \
+        [--freeze-links {True|False}] [--out-dir <dir>] \
+        [--hessian-calc-mode {Analytical|FiniteDifference}] \
+        [--args-yaml <file>]
 
 Examples
 --------
     # Forward-only with finite-difference Hessian and custom step size
     pdb2reaction irc -i ts.xyz -q -1 -s 2 --forward True --backward False \
-      --step-size 0.2 --hessian-calc-mode FiniteDifference --out-dir ./irc_fd/
+        --step-size 0.2 --hessian-calc-mode FiniteDifference --out-dir ./irc_fd/
 
     # Use a PDB input so trajectories are also exported as PDB
     pdb2reaction irc -i ts.pdb -q 0 -s 1 --max-cycles 50 --out-dir ./result_irc/

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -5,17 +5,21 @@ opt — Single-structure geometry optimization (LBFGS or RFO)
 ====================================================================
 
 Usage (CLI)
------
-    pdb2reaction opt -i INPUT -q CHARGE [-s SPIN]
-        [--opt-mode {light|lbfgs|heavy|rfo}] [--freeze-links {True|False}]
-        [--dist-freeze "[(I,J,TARGET_A), ...]"] [--one-based|--zero-based] [--bias-k FLOAT]
-        [--dump {True|False}] [--out-dir DIR] [--max-cycles N] [--thresh PRESET]
-        [--args-yaml FILE]
+-----------
+    pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} -q <charge> [-s <spin>] \
+        [--opt-mode {light|lbfgs|heavy|rfo}] [--freeze-links {True|False}] \
+        [--dist-freeze "[(I,J,TARGET_A), ...]"] [--one-based|--zero-based] \
+        [--bias-k <float>] [--dump {True|False}] [--out-dir <dir>] \
+        [--max-cycles <int>] [--thresh <preset>] [--args-yaml <file>]
 
 Examples
------
-    pdb2reaction opt -i input.pdb -q 0
-    pdb2reaction opt -i input.pdb -q 0 -s 1 --opt-mode rfo --dump True --out-dir ./result_opt/ --args-yaml ./args.yaml
+--------
+    # Minimal geometry optimization with default LBFGS settings
+    pdb2reaction opt -i input.pdb -q 0 -s 1
+
+    # RFO with trajectory dumps and YAML overrides
+    pdb2reaction opt -i input.pdb -q 0 -s 1 --opt-mode rfo --dump True \
+        --out-dir ./result_opt/ --args-yaml ./args.yaml
 
 Description
 -----

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -6,7 +6,13 @@ path_search — Recursive GSM segmentation to build a continuous multistep MEP
 
 Usage (CLI)
 -----------
-    pdb2reaction path-search -i A.pdb B.pdb -q <charge> [options]
+    pdb2reaction path-search -i STRUCT1 STRUCT2 [STRUCT3 ...] -q <charge> \
+        [-s <spin>] [--sopt-mode {lbfgs|rfo|light|heavy}] \
+        [--max-nodes <int>] [--max-cycles <int>] [--climb {True|False}] \
+        [--preopt {True|False}] [--align/--no-align] [--thresh <preset>] \
+        [--ref-pdb <path> ...] [--out-dir <dir>] [--args-yaml <file>] \
+        [--freeze-links {True|False}] [--dump {True|False}] \
+        [--hessian-calc-mode {Analytical|FiniteDifference}]
 
 Required-like:
     -i/--input

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -6,26 +6,13 @@ scan — Bond‑length–driven staged scan with harmonic distance restraints an
 
 Usage (CLI)
 -----------
-    # Minimal (define at least one stage)
-    pdb2reaction scan -i INPUT.{pdb,xyz,trj,...} -q CHARGE \
-        --scan-lists "[(I,J,TARGET_ANG)]"
-
-    # Full (repeat --scan-lists for multiple stages)
-    pdb2reaction scan -i INPUT.{pdb,xyz,trj,...} -q CHARGE \
-        -s SPIN \
-        --scan-lists "[(I,J,TARGET_ANG), ...]" [--scan-lists "..."]... \
-        [--one-based|--zero-based] \
-        --max-step-size FLOAT \
-        --bias-k FLOAT \
-        --relax-max-cycles INT \
-        --opt-mode {light,lbfgs,heavy,rfo} \
-        --freeze-links {True|False} \
-        --dump {True|False} \
-        --out-dir PATH \
-        [--thresh PRESET] \
-        [--args-yaml FILE] \
-        [--preopt {True|False}] \
-        [--endopt {True|False}]
+    pdb2reaction scan -i INPUT.{pdb|xyz|trj|...} -q <charge> \
+        [--scan-lists "[(I,J,TARGET_ANG), ...]" ...] [-s <spin>] \
+        [--one-based|--zero-based] [--max-step-size <float>] \
+        [--bias-k <float>] [--relax-max-cycles <int>] \
+        [--opt-mode {light|lbfgs|heavy|rfo}] [--freeze-links {True|False}] \
+        [--dump {True|False}] [--out-dir <dir>] [--thresh <preset>] \
+        [--args-yaml <file>] [--preopt {True|False}] [--endopt {True|False}]
 
 Examples
 --------

--- a/pdb2reaction/trj2fig.py
+++ b/pdb2reaction/trj2fig.py
@@ -5,31 +5,24 @@ trj2fig — Energy-profile utility for XYZ trajectories
 ====================================================================
 
 Usage (CLI)
------
-    Package CLI (Click-based):
-        Minimal:
-            pdb2reaction trj2fig -i traj.xyz
+-----------
+    # Package CLI (Click-based)
+    pdb2reaction trj2fig -i traj.xyz [-o OUTPUT ...] [-r {init|None|INT}] \
+        [--unit {kcal|hartree}] [--reverse-x]
 
-        Full (all key options; multiple outputs allowed):
-            pdb2reaction trj2fig -i traj.xyz \
-                -o energy.png energy.html energy.svg energy.pdf energy.csv \
-                -r init \
-                --unit kcal \
-                --reverse-x
-
-    Standalone script (argparse):
-        python trj2fig.py -i traj.xyz -o energy.png energy.html
+    # Standalone script (argparse)
+    python trj2fig.py -i traj.xyz [-o OUTPUT ...] [-r {init|None|INT}] \
+        [--unit {kcal|hartree}] [--reverse-x]
 
 Examples
------
-    # 1) High-resolution PNG with x-axis reversed
-    #    (reference is the leftmost point = last frame)
+--------
+    # High-resolution PNG with x-axis reversed (reference is the last frame)
     pdb2reaction trj2fig -i traj.xyz --reverse-x
 
-    # 2) CSV + figure (reference frame #5; output values in hartree)
+    # CSV + figure (reference frame #5; output values in hartree)
     pdb2reaction trj2fig -i traj.xyz -o energy.csv energy.svg -r 5 --unit hartree
 
-    # 3) Produce multiple outputs in one run (PNG, HTML, PDF)
+    # Produce multiple outputs in one run (PNG, HTML, PDF)
     pdb2reaction trj2fig -i traj.xyz -o energy.png energy.html energy.pdf
 
 Description

--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -5,31 +5,29 @@ tsopt — Transition-state optimization CLI
 ====================================================================
 
 Usage (CLI)
------
-    pdb2reaction tsopt -i INPUT.(pdb|xyz|trj) -q CHARGE -s SPIN
-                        [--opt-mode light|lbfgs|dimer|simple|simpledimer|hessian_dimer|
-                                    heavy|rfo|rsirfo|rs-i-rfo]
-                        [--freeze-links True|False]
-                        [--max-cycles N]
-                        [--dump True|False]
-                        [--out-dir DIR]
-                        [--args-yaml args.yaml]
-                        [--hessian-calc-mode Analytical|FiniteDifference]
+-----------
+    pdb2reaction tsopt -i INPUT.{pdb|xyz|trj|...} -q <charge> -s <spin> \
+        [--opt-mode {light|lbfgs|dimer|simple|simpledimer|hessian_dimer| \
+                     heavy|rfo|rsirfo|rs-i-rfo}] \
+        [--freeze-links {True|False}] [--max-cycles <int>] [--dump {True|False}] \
+        [--out-dir <dir>] [--args-yaml <file>] \
+        [--hessian-calc-mode {Analytical|FiniteDifference}]
 
 Examples
------
+--------
     # Minimal (recommended: always specify charge and spin)
-    pdb2reaction tsopt -i ts_cand.pdb -q 0 -s 1 --opt-mode light --out-dir ./result_tsopt/
+    pdb2reaction tsopt -i ts_cand.pdb -q 0 -s 1 --opt-mode light \
+        --out-dir ./result_tsopt/
 
     # Light mode (Hessian Dimer) with YAML overrides and finite-difference Hessian
     pdb2reaction tsopt -i ts_cand.pdb -q 0 -s 1 \
-      --freeze-links True --opt-mode light --max-cycles 10000 --dump False \
-      --out-dir ./result_tsopt/ --args-yaml ./args.yaml \
-      --hessian-calc-mode FiniteDifference
+        --freeze-links True --opt-mode light --max-cycles 10000 --dump False \
+        --out-dir ./result_tsopt/ --args-yaml ./args.yaml \
+        --hessian-calc-mode FiniteDifference
 
     # Heavy mode (RS-I-RFO) using YAML
     pdb2reaction tsopt -i ts_cand.pdb -q 0 -s 1 --opt-mode heavy \
-      --args-yaml ./args.yaml --out-dir ./result_tsopt/
+        --args-yaml ./args.yaml --out-dir ./result_tsopt/
 
 
 Description


### PR DESCRIPTION
## Summary
- align the Usage (CLI) headings across the CLI modules with the path_opt format
- format each Examples block consistently so commands and descriptive comments are easy to skim

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c90423440832db9f3298c4edefd3e)