### PR TITLE
Clarify optional charge/spin flags in CLI docstrings

### DIFF
--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -6,7 +6,7 @@ dft — Single-point DFT (GPU4PySCF with CPU PySCF fallback)
 
 Usage (CLI)
 -----------
-    pdb2reaction dft -i INPUT.{pdb|xyz|gjf|...} -q <charge> [-s <spin>] \
+    pdb2reaction dft -i INPUT.{pdb|xyz|gjf|...} [-q <charge>] [-s <spin>] \
         [--func-basis "FUNC/BASIS"] [--max-cycle <int>] [--conv-tol <hartree>] \
         [--grid-level <int>] [--out-dir <dir>] [--engine {gpu|cpu|auto}] \
         [--args-yaml <file>]

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -6,7 +6,7 @@ irc — Concise CLI for IRC calculations with the EulerPC integrator
 
 Usage (CLI)
 -----------
-    pdb2reaction irc -i INPUT.{pdb|xyz|trj|...} -q <charge> -s <spin> \
+    pdb2reaction irc -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [-s <spin>] \
         [--max-cycles <int>] [--step-size <float>] [--root <int>] \
         [--forward {True|False}] [--backward {True|False}] \
         [--freeze-links {True|False}] [--out-dir <dir>] \

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -6,7 +6,7 @@ opt — Single-structure geometry optimization (LBFGS or RFO)
 
 Usage (CLI)
 -----------
-    pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} -q <charge> [-s <spin>] \
+    pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [-s <spin>] \
         [--opt-mode {light|lbfgs|heavy|rfo}] [--freeze-links {True|False}] \
         [--dist-freeze "[(I,J,TARGET_A), ...]"] [--one-based|--zero-based] \
         [--bias-k <float>] [--dump {True|False}] [--out-dir <dir>] \

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -7,7 +7,7 @@ path_opt — Minimum-energy path (MEP) optimization via the Growing String metho
 Usage (CLI)
 -----------
     pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} \
-        -q <charge> [-s <multiplicity>] [--freeze-links {True|False}] \
+        [-q <charge>] [-s <multiplicity>] [--freeze-links {True|False}] \
         [--max-nodes <int>] [--max-cycles <int>] [--climb {True|False}] \
         [--dump {True|False}] [--out-dir <dir>] [--thresh <preset>] \
         [--args-yaml <file>]

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -6,7 +6,7 @@ path_search — Recursive GSM segmentation to build a continuous multistep MEP
 
 Usage (CLI)
 -----------
-    pdb2reaction path-search -i STRUCT1 STRUCT2 [STRUCT3 ...] -q <charge> \
+    pdb2reaction path-search -i STRUCT1 STRUCT2 [STRUCT3 ...] [-q <charge>] \
         [-s <spin>] [--sopt-mode {lbfgs|rfo|light|heavy}] \
         [--max-nodes <int>] [--max-cycles <int>] [--climb {True|False}] \
         [--preopt {True|False}] [--align/--no-align] [--thresh <preset>] \
@@ -14,7 +14,7 @@ Usage (CLI)
         [--freeze-links {True|False}] [--dump {True|False}] \
         [--hessian-calc-mode {Analytical|FiniteDifference}]
 
-Required-like:
+Core inputs (strongly recommended):
     -i/--input
         Two or more structures in reaction order (repeatable or space‑separated after a single -i).
     -q/--charge

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -6,7 +6,7 @@ scan — Bond‑length–driven staged scan with harmonic distance restraints an
 
 Usage (CLI)
 -----------
-    pdb2reaction scan -i INPUT.{pdb|xyz|trj|...} -q <charge> \
+    pdb2reaction scan -i INPUT.{pdb|xyz|trj|...} [-q <charge>] \
         [--scan-lists "[(I,J,TARGET_ANG), ...]" ...] [-s <spin>] \
         [--one-based|--zero-based] [--max-step-size <float>] \
         [--bias-k <float>] [--relax-max-cycles <int>] \

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -4,7 +4,7 @@ scan2d — Two-distance 2D scan with harmonic restraints (UMA only)
 
 Usage (CLI)
 -----------
-    pdb2reaction scan2d -i INPUT.{pdb,xyz,trj,...} -q CHARGE \
+    pdb2reaction scan2d -i INPUT.{pdb,xyz,trj,...} [-q <charge>] [-s <spin>] \
         --scan-list "[(I1,J1,LOW1,HIGH1),(I2,J2,LOW2,HIGH2)]" \
         [--one-based|--zero-based] \
         --max-step-size FLOAT \

--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -6,7 +6,7 @@ tsopt — Transition-state optimization CLI
 
 Usage (CLI)
 -----------
-    pdb2reaction tsopt -i INPUT.{pdb|xyz|trj|...} -q <charge> -s <spin> \
+    pdb2reaction tsopt -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [-s <spin>] \
         [--opt-mode {light|lbfgs|dimer|simple|simpledimer|hessian_dimer| \
                      heavy|rfo|rsirfo|rs-i-rfo}] \
         [--freeze-links {True|False}] [--max-cycles <int>] [--dump {True|False}] \


### PR DESCRIPTION
## Summary
- mark the charge and spin CLI options as optional in the module docstrings for the CLI entry points that already default to template/0/1 values
- refresh the path-search doc section header so it no longer implies the charge flag is mandatory

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c9c4cf714832db0c7465cb4d74cd6)