### PR TITLE
Rename CLI spin flag to multiplicity flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pdb2reaction -i R.pdb -c "GPP,MMT" --ligand-charge "GPP:-3,MMT:-1" --scan-lists 
 pdb2reaction -i SINGLE.pdb \
              -c "GPP,MMT" \
              --scan-lists "[(10,55,2.20),(23,34,1.80)]" \
-             --spin 1 --outdir ./result_scan_all \
+             --mult 1 --outdir ./result_scan_all \
              --tsopt True --thermo True --dft True
 ```
 

--- a/docs/all.md
+++ b/docs/all.md
@@ -7,7 +7,7 @@ Run an end-to-end enzymatic reaction workflow on pocket models: extract pockets,
 ```bash
 # Multi-structure ensemble (reaction order)
 pdb2reaction all -i R.pdb [I.pdb ...] P.pdb -c SUBSTRATE_SPEC \
-                 [--ligand-charge MAP_OR_NUMBER] [--spin 2S+1] \
+                 [--ligand-charge MAP_OR_NUMBER] [--mult 2S+1] \
                  [--freeze-links True|False] [--max-nodes N] [--max-cycles N] \
                  [--climb True|False] [--sopt-mode lbfgs|rfo|light|heavy] \
                  [--dump True|False] [--preopt True|False] \
@@ -37,7 +37,7 @@ pdb2reaction all -i SINGLE.pdb -c SUBSTRATE_SPEC --tsopt True [other toggles]
 | `--selected_resn TEXT` | Residues to force include (comma/space separated; chain/insertion codes allowed). | `""` |
 | `--ligand-charge TEXT` | Total charge or mapping for unknown residues (recommended). | `None` |
 | `--verbose BOOLEAN` | Enable INFO-level logging in the extractor. | `True` |
-| `-s, --spin INT` | Spin multiplicity forwarded to GSM, scan, and post-processing. | `1` |
+| `-m, --mult INT` | Spin multiplicity forwarded to GSM, scan, and post-processing. | `1` |
 | `--freeze-links BOOLEAN` | Freeze link parents in pocket PDBs during GSM/scan (also reused by scan/tsopt/freq). | `True` |
 | `--max-nodes INT` | GSM internal nodes per segment. | `10` |
 | `--max-cycles INT` | GSM maximum optimisation cycles. | `100` |

--- a/docs/dft.md
+++ b/docs/dft.md
@@ -16,7 +16,7 @@ pdb2reaction dft -i INPUT -q CHARGE [-s SPIN] \
 | --- | --- | --- |
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
 | `-q, --charge INT` | Total charge supplied to PySCF. | `.gjf` template value or `0` |
-| `-s, --spin INT` | Spin multiplicity (2S+1). Converted to `2S` for PySCF. | `.gjf` template value or `1` |
+| `-m, --mult INT` | Spin multiplicity (2S+1). Converted to `2S` for PySCF. | `.gjf` template value or `1` |
 | `--func-basis TEXT` | Functional and basis in `FUNC/BASIS` form (quotes recommended when using `*`). | `wb97m-v/6-31g**` |
 | `--max-cycle INT` | Maximum SCF iterations (`dft.max_cycle`). | `100` |
 | `--conv-tol FLOAT` | SCF convergence tolerance in Hartree (`dft.conv_tol`). | `1e-9` |

--- a/docs/freq.md
+++ b/docs/freq.md
@@ -5,7 +5,7 @@ Computes vibrational frequencies using UMA, performs partial Hessian vibrational
 
 ## Usage
 ```bash
-pdb2reaction freq -i INPUT -q CHARGE [--spin 2S+1]
+pdb2reaction freq -i INPUT -q CHARGE [--mult 2S+1]
                   [--freeze-links BOOL]
                   [--max-write N] [--amplitude-ang Å] [--n-frames N]
                   [--sort value|abs] [--out-dir DIR]
@@ -19,7 +19,7 @@ pdb2reaction freq -i INPUT -q CHARGE [--spin 2S+1]
 | --- | --- | --- |
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
 | `-q, --charge INT` | Total charge. | `.gjf` template value or `0` |
-| `-s, --spin INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
+| `-m, --mult INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--freeze-links BOOL` | Explicit `True`/`False`. For PDB inputs, freeze link-hydrogen parents (merged with `geom.freeze_atoms`). | `True` |
 | `--max-write INT` | Number of modes to export. | `20` |
 | `--amplitude-ang FLOAT` | Animation amplitude (Å). | `0.8` |

--- a/docs/irc.md
+++ b/docs/irc.md
@@ -5,7 +5,7 @@ Runs Intrinsic Reaction Coordinate (IRC) integrations with the EulerPC predictor
 
 ## Usage
 ```bash
-pdb2reaction irc -i INPUT -q CHARGE [--spin 2S+1]
+pdb2reaction irc -i INPUT -q CHARGE [--mult 2S+1]
                  [--max-cycles N] [--step-size Δs] [--root k]
                  [--forward BOOL] [--backward BOOL]
                  [--freeze-links BOOL]
@@ -19,7 +19,7 @@ pdb2reaction irc -i INPUT -q CHARGE [--spin 2S+1]
 | --- | --- | --- |
 | `-i, --input PATH` | Transition-state structure accepted by `geom_loader`. | Required |
 | `-q, --charge INT` | Total charge. | `.gjf` template value or `0` |
-| `-s, --spin INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
+| `-m, --mult INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--max-cycles INT` | Maximum IRC steps (overrides `irc.max_cycles`). | _None_ (use YAML/default `125`) |
 | `--step-size FLOAT` | Step length in mass-weighted coordinates (overrides `irc.step_length`). | _None_ (default `0.10`) |
 | `--root INT` | Imaginary-mode index for the initial displacement (`irc.root`). | _None_ (default `0`) |

--- a/docs/opt.md
+++ b/docs/opt.md
@@ -5,7 +5,7 @@ Performs single-structure geometry optimizations with pysisyphus using either th
 
 ## Usage
 ```bash
-pdb2reaction opt -i INPUT -q CHARGE [--spin 2S+1] [--opt-mode light|lbfgs|heavy|rfo]
+pdb2reaction opt -i INPUT -q CHARGE [--mult 2S+1] [--opt-mode light|lbfgs|heavy|rfo]
                  [--freeze-links BOOL] [--dist-freeze "[(i,j,target), ...]"]
                  [--one-based/--zero-based] [--bias-k k]
                  [--dump BOOL] [--thresh PRESET]
@@ -17,7 +17,7 @@ pdb2reaction opt -i INPUT -q CHARGE [--spin 2S+1] [--opt-mode light|lbfgs|heavy|
 | --- | --- | --- |
 | `-i, --input PATH` | Structure file accepted by `geom_loader` (`.pdb`, `.xyz`, `.trj`, …). | Required |
 | `-q, --charge INT` | Total charge passed to UMA. | `.gjf` template value or `0` |
-| `-s, --spin INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
+| `-m, --mult INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--dist-freeze TEXT` | Repeatable Python-like literal describing `(i, j, targetÅ)` tuples for harmonic restraints. Omit the target to freeze the initial distance. | _None_ |
 | `--one-based / --zero-based` | Interpret `--dist-freeze` indices as 1-based (default) or 0-based. | `--one-based` |
 | `--bias-k FLOAT` | Harmonic bias strength `k` (eV·Å⁻²) applied to every `--dist-freeze` tuple. | `10.0` |

--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -5,7 +5,7 @@ Optimizes a minimum-energy path between two endpoints using the pysisyphus Growi
 
 ## Usage
 ```bash
-pdb2reaction path-opt -i REACTANT PRODUCT -q CHARGE [--spin 2S+1]
+pdb2reaction path-opt -i REACTANT PRODUCT -q CHARGE [--mult 2S+1]
                       [--freeze-links BOOL] [--thresh PRESET]
                       [--max-nodes N] [--max-cycles N] [--climb BOOL]
                       [--dump BOOL] [--out-dir DIR] [--args-yaml FILE]
@@ -16,7 +16,7 @@ pdb2reaction path-opt -i REACTANT PRODUCT -q CHARGE [--spin 2S+1]
 | --- | --- | --- |
 | `-i, --input PATH PATH` | Two endpoint structures (reactant, product). | Required |
 | `-q, --charge INT` | Total charge. | `.gjf` template value or `0` |
-| `-s, --spin INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
+| `-m, --mult INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--freeze-links BOOL` | Explicit `True`/`False`. For PDB inputs, freeze link-hydrogen parents. | `True` |
 | `--max-nodes INT` | Internal nodes in the string (total images = `max_nodes + 2`). | `30` |
 | `--max-cycles INT` | Maximum optimizer cycles. | `100` |

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -5,7 +5,7 @@ Runs a recursive Growing String (GSM) search across multiple structures (reactan
 
 ## Usage
 ```bash
-pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--spin 2S+1]
+pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--mult 2S+1]
                          [--freeze-links BOOL] [--thresh PRESET]
                          [--max-nodes N] [--max-cycles N] [--climb BOOL]
                          [--sopt-mode lbfgs|rfo|light|heavy] [--dump BOOL]
@@ -19,7 +19,7 @@ pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--spin 2S+1]
 | --- | --- | --- |
 | `-i, --input PATH...` | Two or more structures in reaction order (reactant → product). A single `-i` may be followed by multiple paths. | Required |
 | `-q, --charge INT` | Total charge. | `.gjf` template value or `0` |
-| `-s, --spin INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
+| `-m, --mult INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--freeze-links BOOL` | Explicit `True`/`False`. When loading PDB pockets, freeze the parent atoms of link hydrogens. | `True` |
 | `--max-nodes INT` | Internal nodes for GSM segments (`String` has `max_nodes + 2` images). | `10` |
 | `--max-cycles INT` | Maximum GSM optimization cycles. | `100` |

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -18,7 +18,7 @@ pdb2reaction scan -i INPUT -q CHARGE --scan-lists "[(i,j,target), ...]" [...]
 | --- | --- | --- |
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
 | `-q, --charge INT` | Total charge. | `.gjf` template value or `0` |
-| `-s, --spin INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
+| `-m, --mult INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--scan-lists TEXT` | Repeatable Python-like list literal of `(i, j, targetÅ)` triples defining each scan stage. | Required |
 | `--one-based / --zero-based` | Interpret `(i, j)` indices as 1-based (default) or 0-based. | `--one-based` |
 | `--max-step-size FLOAT` | Maximum change in any scanned bond per integration step (Å). | `0.20` |

--- a/docs/scan2d.md
+++ b/docs/scan2d.md
@@ -22,7 +22,7 @@ pdb2reaction scan2d -i INPUT -q CHARGE \
 | --- | --- | --- |
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
 | `-q, --charge INT` | Total charge. | `.gjf` template value or `0` |
-| `-s, --spin INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
+| `-m, --mult INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--scan-list TEXT` | **Single** Python-like literal with two `(i, j, lowÅ, highÅ)` quadruples, one per distance. | Required |
 | `--one-based / --zero-based` | Interpret `(i, j)` indices in `--scan-list` as 1-based or 0-based. | `--one-based` |
 | `--max-step-size FLOAT` | Largest change allowed for either distance per grid increment. Determines the number of points. | `0.20` |

--- a/docs/tsopt.md
+++ b/docs/tsopt.md
@@ -5,7 +5,7 @@ Optimizes transition states using either the Hessian Dimer method ("light") or R
 
 ## Usage
 ```bash
-pdb2reaction tsopt -i INPUT -q CHARGE [--spin 2S+1]
+pdb2reaction tsopt -i INPUT -q CHARGE [--mult 2S+1]
                     [--freeze-links BOOL] [--thresh PRESET]
                     [--max-cycles N]
                     [--opt-mode light|lbfgs|dimer|simple|simpledimer|hessian_dimer|
@@ -20,7 +20,7 @@ pdb2reaction tsopt -i INPUT -q CHARGE [--spin 2S+1]
 | --- | --- | --- |
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
 | `-q, --charge INT` | Total charge. | `.gjf` template value or `0` |
-| `-s, --spin INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
+| `-m, --mult INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--freeze-links BOOL` | Explicit `True`/`False`. For PDB inputs, freeze link-hydrogen parents (propagated to UMA). | `True` |
 | `--max-cycles INT` | Maximum macro cycles (forwarded to `opt.max_cycles`). | `10000` |
 | `--opt-mode TEXT` | Hessian Dimer aliases: `light`/`lbfgs`/`dimer`/`simple`/`simpledimer`/`hessian_dimer`. RS-I-RFO aliases: `heavy`/`rfo`/`rsirfo`/`rs-i-rfo`. | `light` |

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -6,7 +6,7 @@ dft — Single-point DFT (GPU4PySCF with CPU PySCF fallback)
 
 Usage (CLI)
 -----------
-    pdb2reaction dft -i INPUT.{pdb|xyz|gjf|...} [-q <charge>] [-s <spin>] \
+    pdb2reaction dft -i INPUT.{pdb|xyz|gjf|...} [-q <charge>] [-m <multiplicity>] \
         [--func-basis "FUNC/BASIS"] [--max-cycle <int>] [--conv-tol <hartree>] \
         [--grid-level <int>] [--out-dir <dir>] [--engine {gpu|cpu|auto}] \
         [--args-yaml <file>]
@@ -14,10 +14,10 @@ Usage (CLI)
 Examples
 --------
     # Default GPU-first policy with an explicit functional/basis pair
-    pdb2reaction dft -i input.pdb -q 0 -s 1 --func-basis "wb97m-v/6-31g**"
+    pdb2reaction dft -i input.pdb -q 0 -m 1 --func-basis "wb97m-v/6-31g**"
 
     # Tight SCF controls with a larger basis and CPU-only fallback
-    pdb2reaction dft -i input.pdb -q 0 -s 2 --func-basis "wb97m-v/def2-tzvpd" \
+    pdb2reaction dft -i input.pdb -q 0 -m 2 --func-basis "wb97m-v/def2-tzvpd" \
         --max-cycle 150 --conv-tol 1e-9 --engine cpu
 
 Description
@@ -54,7 +54,7 @@ out_dir/ (default: ./result_dft/)
 
 Notes
 -----
-- Charge/spin resolution: `-q/--charge` and `-s/--spin` inherit values from `.gjf` templates when present
+- Charge/spin resolution: `-q/--charge` and `-m/--mult` inherit values from `.gjf` templates when present
   and otherwise fall back to `0`/`1`. Provide explicit values whenever possible to enforce the intended state
   (multiplicity > 1 selects UKS).
 - YAML overrides: `--args-yaml` points to a file with top-level key `dft` (`conv_tol`, `max_cycle`,
@@ -91,7 +91,7 @@ from .utils import (
     resolve_charge_spin_or_raise,
     maybe_convert_xyz_to_gjf,
     charge_option,
-    spin_option,
+    multiplicity_option,
 )
 
 
@@ -413,7 +413,7 @@ def _compute_atomic_spin_densities(mol, mf) -> Dict[str, Optional[List[float]]]:
     help="Input structure file (.pdb, .xyz, .trj, etc.; loaded via pysisyphus.helpers.geom_loader).",
 )
 @charge_option()
-@spin_option()
+@multiplicity_option()
 @click.option(
     "--func-basis",
     "func_basis",

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -98,7 +98,7 @@ from .utils import (
     prepare_input_structure,
     resolve_charge_spin_or_raise,
     charge_option,
-    spin_option,
+    multiplicity_option,
 )
 
 
@@ -498,7 +498,7 @@ THERMO_KW = {
     help="Input structure (.pdb, .xyz, .trj, ...)",
 )
 @charge_option()
-@spin_option()
+@multiplicity_option()
 @click.option("--freeze-links", type=click.BOOL, default=True, show_default=True,
               help="Freeze parent atoms of link hydrogens (PDB only).")
 @click.option("--max-write", type=int, default=20, show_default=True,

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -6,7 +6,7 @@ irc — Concise CLI for IRC calculations with the EulerPC integrator
 
 Usage (CLI)
 -----------
-    pdb2reaction irc -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [-s <spin>] \
+    pdb2reaction irc -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [-m <multiplicity>] \
         [--max-cycles <int>] [--step-size <float>] [--root <int>] \
         [--forward {True|False}] [--backward {True|False}] \
         [--freeze-links {True|False}] [--out-dir <dir>] \
@@ -16,11 +16,11 @@ Usage (CLI)
 Examples
 --------
     # Forward-only with finite-difference Hessian and custom step size
-    pdb2reaction irc -i ts.xyz -q -1 -s 2 --forward True --backward False \
+    pdb2reaction irc -i ts.xyz -q -1 -m 2 --forward True --backward False \
         --step-size 0.2 --hessian-calc-mode FiniteDifference --out-dir ./irc_fd/
 
     # Use a PDB input so trajectories are also exported as PDB
-    pdb2reaction irc -i ts.pdb -q 0 -s 1 --max-cycles 50 --out-dir ./result_irc/
+    pdb2reaction irc -i ts.pdb -q 0 -m 1 --max-cycles 50 --out-dir ./result_irc/
 
 Description
 -----------
@@ -30,14 +30,14 @@ Description
 - Configuration model: Only the CLI options listed above are accepted. All other parameters
   (geometry options, UMA calculator configuration, and detailed EulerPC/IRC settings) must be provided via YAML.
   Final configuration precedence: built-in defaults → YAML → CLI.
-- Charge/spin defaults: `-q/--charge` and `-s/--spin` inherit values from `.gjf` templates when provided and otherwise fall back
+- Charge/spin defaults: `-q/--charge` and `-m/--mult` inherit values from `.gjf` templates when provided and otherwise fall back
   to `0`/`1`. Set them explicitly to avoid running under unintended conditions.
 
 CLI options
 -----------
   - `-i/--input PATH` (required): Structure file (.pdb/.xyz/.trj/…).
   - `-q/--charge INT`: Total charge; overrides `calc.charge` from YAML and defaults to a `.gjf` template value or `0` when omitted.
-  - `-s/--spin INT` (default 1): Spin multiplicity (2S+1); overrides `calc.spin` and defaults to the template multiplicity or `1`.
+  - `-m/--mult INT` (default 1): Spin multiplicity (2S+1); overrides `calc.spin` and defaults to the template multiplicity or `1`.
   - `--max-cycles INT`: Max number of IRC steps; overrides `irc.max_cycles`.
   - `--step-size FLOAT`: Step length in mass-weighted coordinates; overrides `irc.step_length`.
   - `--root INT`: Imaginary mode index for the initial displacement; overrides `irc.root`.
@@ -64,7 +64,7 @@ All files honor ``irc.prefix`` when it is set; the directory is created if missi
 Notes
 -----
 - CLI overrides YAML for:
-  `charge`→`calc.charge`, `spin`→`calc.spin`, `step-size`→`irc.step_length`, `max-cycles`→`irc.max_cycles`,
+  `charge`→`calc.charge`, `mult`→`calc.spin`, `step-size`→`irc.step_length`, `max-cycles`→`irc.max_cycles`,
   `root`→`irc.root`, `forward`→`irc.forward`, `backward`→`irc.backward`, `out-dir`→`irc.out_dir`,
   `hessian-calc-mode`→`calc.hessian_calc_mode`.
 - UMA options are passed directly to `pdb2reaction.uma_pysis.uma_pysis`. With `device: "auto"`,
@@ -104,7 +104,7 @@ from pdb2reaction.utils import (
     prepare_input_structure,
     resolve_charge_spin_or_raise,
     charge_option,
-    spin_option,
+    multiplicity_option,
 )
 
 
@@ -171,7 +171,7 @@ def _echo_convert_trj_to_pdb_if_exists(trj_path: Path, ref_pdb: Path, out_path: 
 @charge_option(
     "Total charge; overrides calc.charge from YAML. Defaults to the .gjf template value when present, otherwise 0."
 )
-@spin_option(
+@multiplicity_option(
     "Spin multiplicity (2S+1); overrides calc.spin from YAML. Defaults to the .gjf template value when present, otherwise 1."
 )
 @click.option("--max-cycles", type=int, default=None, help="Maximum number of IRC steps; overrides irc.max_cycles from YAML.")

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -6,7 +6,7 @@ opt — Single-structure geometry optimization (LBFGS or RFO)
 
 Usage (CLI)
 -----------
-    pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [-s <spin>] \
+    pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [-m <multiplicity>] \
         [--opt-mode {light|lbfgs|heavy|rfo}] [--freeze-links {True|False}] \
         [--dist-freeze "[(I,J,TARGET_A), ...]"] [--one-based|--zero-based] \
         [--bias-k <float>] [--dump {True|False}] [--out-dir <dir>] \
@@ -15,10 +15,10 @@ Usage (CLI)
 Examples
 --------
     # Minimal geometry optimization with default LBFGS settings
-    pdb2reaction opt -i input.pdb -q 0 -s 1
+    pdb2reaction opt -i input.pdb -q 0 -m 1
 
     # RFO with trajectory dumps and YAML overrides
-    pdb2reaction opt -i input.pdb -q 0 -s 1 --opt-mode rfo --dump True \
+    pdb2reaction opt -i input.pdb -q 0 -m 1 --opt-mode rfo --dump True \
         --out-dir ./result_opt/ --args-yaml ./args.yaml
 
 Description
@@ -37,7 +37,7 @@ Key options (YAML keys → meaning; defaults)
   - `freeze_atoms`: list[int], 0‑based indices to freeze (default: []).
 - Calculator (`calc`, UMA via `uma_pysis`):
   - `charge` (overridden by `-q`; defaults to a `.gjf` template value when available, otherwise `0`),
-    `spin` (`-s`; defaults to the template multiplicity or `1`). Prefer explicitly setting physically correct values.
+    `spin` (`-m`; defaults to the template multiplicity or `1`). Prefer explicitly setting physically correct values.
   - `model`: "uma-s-1p1" (default) | "uma-m-1p1"; `task_name`: "omol".
   - `device`: "auto" (GPU if available) | "cuda" | "cpu".
   - `max_neigh`: Optional[int]; `radius`: Optional[float] (Å); `r_edges`: bool.
@@ -85,7 +85,7 @@ Console output echoes the resolved geom/calc/opt/(lbfgs|rfo) blocks, per-print p
 
 Notes
 -----
-- **Charge/spin defaults:** `-q/--charge` and `-s/--spin` fall back to `.gjf` template values (when available) or to
+- **Charge/spin defaults:** `-q/--charge` and `-m/--mult` fall back to `.gjf` template values (when available) or to
   `0`/`1`. Override them explicitly to avoid unphysical states.
 - **Input handling:** Supports .pdb/.xyz/.trj and other formats accepted by `geom_loader`. `geom.coord_type="dlc"` can improve stability for small molecules.
 - **Freeze links (PDB only):** With `--freeze-links` (default), parent atoms of link hydrogens are detected and frozen; indices are 0‑based and merged with `geom.freeze_atoms`.
@@ -133,7 +133,7 @@ from .utils import (
     maybe_convert_xyz_to_gjf,
     GjfTemplate,
     charge_option,
-    spin_option,
+    multiplicity_option,
 )
 
 EV2AU = 1.0 / AU2EV  # eV → Hartree
@@ -456,7 +456,7 @@ def _maybe_write_final_gjf(
     help="Input structure file (.pdb, .xyz, .trj, ...).",
 )
 @charge_option()
-@spin_option()
+@multiplicity_option()
 @click.option(
     "--dist-freeze",
     "dist_freeze_raw",

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -7,7 +7,7 @@ path_opt — Minimum-energy path (MEP) optimization via the Growing String metho
 Usage (CLI)
 -----------
     pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} \
-        [-q <charge>] [-s <multiplicity>] [--freeze-links {True|False}] \
+        [-q <charge>] [-m <multiplicity>] [--freeze-links {True|False}] \
         [--max-nodes <int>] [--max-cycles <int>] [--climb {True|False}] \
         [--dump {True|False}] [--out-dir <dir>] [--thresh <preset>] \
         [--args-yaml <file>]
@@ -15,10 +15,10 @@ Usage (CLI)
 Examples
 --------
     # Minimal: two endpoints, neutral singlet
-    pdb2reaction path-opt -i reac.pdb prod.pdb -q 0 -s 1
+    pdb2reaction path-opt -i reac.pdb prod.pdb -q 0 -m 1
 
     # Typical full run with YAML overrides, dumps, and a convergence preset
-    pdb2reaction path-opt -i reac.pdb prod.pdb -q 0 -s 1 \
+    pdb2reaction path-opt -i reac.pdb prod.pdb -q 0 -m 1 \
       --freeze-links True --max-nodes 10 --max-cycles 100 \
       --climb True --dump True --out-dir ./result_path_opt/ \
       --thresh gau_tight --args-yaml ./args.yaml
@@ -47,7 +47,7 @@ out_dir/ (default: ./result_path_opt/)
 
 Notes
 -----
-- Charge/spin: `-q/--charge` and `-s/--spin` inherit `.gjf` template values when provided and otherwise fall back to `0`/`1`. Override explicitly to avoid unphysical conditions.
+- Charge/spin: `-q/--charge` and `-m/--mult` inherit `.gjf` template values when provided and otherwise fall back to `0`/`1`. Override explicitly to avoid unphysical conditions.
 - Coordinates are Cartesian; `freeze_atoms` use 0-based indices. With `--freeze-links=True` and PDB inputs, link-hydrogen parents are added automatically.
 - `--max-nodes` sets the number of internal nodes; the string has (max_nodes + 2) images including endpoints.
 - `--max-cycles` limits optimization; after full growth, the same bound applies to additional refinement.
@@ -89,7 +89,7 @@ from .utils import (
     maybe_convert_xyz_to_gjf,
     PreparedInputStructure,
     charge_option,
-    spin_option,
+    multiplicity_option,
 )
 from .align_freeze_atoms import align_and_refine_sequence_inplace
 
@@ -182,7 +182,7 @@ def _load_two_endpoints(
     help="Two endpoint structures (reactant and product); accepts .pdb or .xyz.",
 )
 @charge_option()
-@spin_option()
+@multiplicity_option()
 @click.option("--freeze-links", "freeze_links_flag", type=click.BOOL, default=True, show_default=True,
               help="If a PDB is provided, freeze the parent atoms of link hydrogens.")
 @click.option("--max-nodes", type=int, default=30, show_default=True,

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -7,7 +7,7 @@ path_search — Recursive GSM segmentation to build a continuous multistep MEP
 Usage (CLI)
 -----------
     pdb2reaction path-search -i STRUCT1 STRUCT2 [STRUCT3 ...] [-q <charge>] \
-        [-s <spin>] [--sopt-mode {lbfgs|rfo|light|heavy}] \
+        [-m <multiplicity>] [--sopt-mode {lbfgs|rfo|light|heavy}] \
         [--max-nodes <int>] [--max-cycles <int>] [--climb {True|False}] \
         [--preopt {True|False}] [--align/--no-align] [--thresh <preset>] \
         [--ref-pdb <path> ...] [--out-dir <dir>] [--args-yaml <file>] \
@@ -21,7 +21,7 @@ Core inputs (strongly recommended):
         Total system charge (defaults to a .gjf template value or 0 when omitted).
 
 Recommended/common:
-    -s/--spin
+    -m/--mult
         Spin multiplicity (2S+1); defaults to a .gjf template value or 1 when omitted.
     --sopt-mode
         Single-structure optimizer: lbfgs|rfo|light|heavy; default lbfgs
@@ -187,7 +187,7 @@ from .utils import (
     PreparedInputStructure,
     GjfTemplate,
     charge_option,
-    spin_option,
+    multiplicity_option,
 )
 from .trj2fig import run_trj2fig
 from .bond_changes import compare_structures, summarize_changes
@@ -1452,7 +1452,7 @@ def _merge_final_and_write(final_images: List[Any],
           "followed by multiple space-separated paths (e.g., '-i A B C').")
 )
 @charge_option()
-@spin_option()
+@multiplicity_option()
 @click.option("--freeze-links", "freeze_links_flag", type=click.BOOL, default=True, show_default=True,
               help="For PDB input, freeze parent atoms of link hydrogens.")
 @click.option("--max-nodes", type=int, default=10, show_default=True,

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -131,7 +131,7 @@ from .utils import (
     resolve_charge_spin_or_raise,
     maybe_convert_xyz_to_gjf,
     charge_option,
-    spin_option,
+    multiplicity_option,
 )
 from .bond_changes import compare_structures, summarize_changes
 
@@ -339,7 +339,7 @@ def _snapshot_geometry(g) -> Any:
     help="Input structure file (.pdb, .xyz, .trj, ...).",
 )
 @charge_option()
-@spin_option()
+@multiplicity_option()
 @click.option(
     "--scan-lists", "scan_lists_raw",
     type=str, multiple=True, required=True,

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -110,7 +110,7 @@ from .utils import (
     prepare_input_structure,
     resolve_charge_spin_or_raise,
     charge_option,
-    spin_option,
+    multiplicity_option,
 )
 
 # Default keyword dictionaries for the 2D scan (override only the knobs we touch)
@@ -257,7 +257,7 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
     help="Input structure file (.pdb, .xyz, .trj, ...).",
 )
 @charge_option()
-@spin_option()
+@multiplicity_option()
 @click.option(
     "--scan-list", "scan_list_raw",
     type=str, required=True,

--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -6,7 +6,7 @@ tsopt — Transition-state optimization CLI
 
 Usage (CLI)
 -----------
-    pdb2reaction tsopt -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [-s <spin>] \
+    pdb2reaction tsopt -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [-m <multiplicity>] \
         [--opt-mode {light|lbfgs|dimer|simple|simpledimer|hessian_dimer| \
                      heavy|rfo|rsirfo|rs-i-rfo}] \
         [--freeze-links {True|False}] [--max-cycles <int>] [--dump {True|False}] \
@@ -16,17 +16,17 @@ Usage (CLI)
 Examples
 --------
     # Minimal (recommended: always specify charge and spin)
-    pdb2reaction tsopt -i ts_cand.pdb -q 0 -s 1 --opt-mode light \
+    pdb2reaction tsopt -i ts_cand.pdb -q 0 -m 1 --opt-mode light \
         --out-dir ./result_tsopt/
 
     # Light mode (Hessian Dimer) with YAML overrides and finite-difference Hessian
-    pdb2reaction tsopt -i ts_cand.pdb -q 0 -s 1 \
+    pdb2reaction tsopt -i ts_cand.pdb -q 0 -m 1 \
         --freeze-links True --opt-mode light --max-cycles 10000 --dump False \
         --out-dir ./result_tsopt/ --args-yaml ./args.yaml \
         --hessian-calc-mode FiniteDifference
 
     # Heavy mode (RS-I-RFO) using YAML
-    pdb2reaction tsopt -i ts_cand.pdb -q 0 -s 1 --opt-mode heavy \
+    pdb2reaction tsopt -i ts_cand.pdb -q 0 -m 1 --opt-mode heavy \
         --args-yaml ./args.yaml --out-dir ./result_tsopt/
 
 
@@ -99,7 +99,7 @@ out_dir/ (default: ./result_tsopt/)
 
 Notes
 -----
-- **Charge/spin**: `-q/--charge` and `-s/--spin` inherit `.gjf` template values when the input
+- **Charge/spin**: `-q/--charge` and `-m/--mult` inherit `.gjf` template values when the input
   is `.gjf`; otherwise they default to `0` and `1`. Override explicitly to avoid unphysical
   conditions.
 
@@ -167,7 +167,7 @@ from .utils import (
     resolve_charge_spin_or_raise,
     maybe_convert_xyz_to_gjf,
     charge_option,
-    spin_option,
+    multiplicity_option,
 )
 from .freq import (
     _torch_device,
@@ -1239,7 +1239,7 @@ RSIRFO_KW.update({
     help="Input structure (.pdb, .xyz, .trj, ...)",
 )
 @charge_option()
-@spin_option()
+@multiplicity_option()
 @click.option("--freeze-links", type=click.BOOL, default=True, show_default=True,
               help="Freeze parent atoms of link hydrogens (PDB only).")
 @click.option("--max-cycles", type=int, default=10000, show_default=True, help="Max cycles / steps cap")

--- a/pdb2reaction/utils.py
+++ b/pdb2reaction/utils.py
@@ -50,7 +50,7 @@ Description
   - CLI option decorators:
     - `charge_option(help_text=None)`: Reusable Click option decorator for total charge (inherits `.gjf`
       defaults when available).
-    - `spin_option(help_text=None)`: Reusable Click option decorator for spin multiplicity (inherits `.gjf`
+    - `multiplicity_option(help_text=None)`: Reusable Click option decorator for spin multiplicity (inherits `.gjf`
       defaults when available).
 
 - **Gaussian input (.gjf) helpers**
@@ -154,7 +154,7 @@ def charge_option(help_text: Optional[str] = None) -> Callable[[_ClickCallable],
     return decorator
 
 
-def spin_option(help_text: Optional[str] = None) -> Callable[[_ClickCallable], _ClickCallable]:
+def multiplicity_option(help_text: Optional[str] = None) -> Callable[[_ClickCallable], _ClickCallable]:
     """Reusable Click option decorator for spin multiplicity (inherits `.gjf` defaults when available)."""
 
     default_help = (
@@ -164,8 +164,8 @@ def spin_option(help_text: Optional[str] = None) -> Callable[[_ClickCallable], _
 
     def decorator(func: _ClickCallable) -> _ClickCallable:
         return click.option(
-            "-s",
-            "--spin",
+            "-m",
+            "--mult",
             type=int,
             default=None,
             show_default=False,


### PR DESCRIPTION
## Summary
- rename the shared spin Click option to a multiplicity option so every CLI now exposes `-m/--mult` instead of `-s/--spin`
- propagate the new flag through `pdb2reaction all` and all downstream commands, including generated subcommand invocations
- update README and the docs for each CLI to advertise `-m/--mult <multiplicity>` instead of the old spin flag

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cef7daf28832db237d190d0fb64b9)