### PR TITLE
Make align_refine outputs conditional

### DIFF
--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -51,7 +51,7 @@ out_dir/
 ├─ gsm_hei.xyz                 # Highest-energy image with its energy on the comment line
 ├─ gsm_hei.pdb                 # HEI converted to PDB when the first endpoint was a PDB
 ├─ gsm_hei.gjf                 # HEI written using a detected Gaussian template
-├─ align_refine/               # Intermediate files from the rigid alignment/refinement stage
+├─ align_refine/               # Intermediate files from the rigid alignment/refinement stage (created only when scan output exists)
 └─ <optimizer dumps/restarts>  # Present when dumping is enabled
 ```
 Console output echoes the resolved YAML blocks and prints cycle-by-cycle GSM progress with timing information.

--- a/pdb2reaction/align_freeze_atoms.py
+++ b/pdb2reaction/align_freeze_atoms.py
@@ -64,11 +64,13 @@ Provided functionality (concise):
 
 Outputs (& Directory Layout)
 ----------------------------
+When the scan stage runs (i.e., union(`freeze_atoms`) is non-empty):
+
 out_dir/ (default: ./result_align_refine/)
   ├─ <pair>/                         # Pair API writes stepwise and final LBFGS artifacts directly under out_dir
   └─ pair_00/, pair_01/, ...         # Sequence API creates one subdirectory per adjacent pair
 
-Directories are created even when optimizer dumping is disabled; LBFGS always runs with ``dump=False``.
+Directories are only created when scan/relaxation artifacts are produced (``dump=False`` is still used for LBFGS).
 
 Notes
 -----
@@ -596,14 +598,12 @@ def align_and_refine_sequence_inplace(
         return []
 
     out_dir = Path(out_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
 
     results: List[Dict[str, Any]] = []
     for i in range(len(geoms) - 1):
         g_ref = geoms[i]
         g_mob = geoms[i + 1]
         pair_out = out_dir / f"pair_{i:02d}"
-        pair_out.mkdir(parents=True, exist_ok=True)
 
         if verbose:
             print(f"\n[align+scan] Pair {i:02d}: image {i} (ref) ← image {i+1} (mobile)")


### PR DESCRIPTION
## Summary
* avoid creating align_refine directories when the scan stage has no output
* update docs to clarify align_refine is only emitted when scan artifacts exist

## Testing
* Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925b96b9a18832db26f0d5c568fcf94)