### PR TITLE
Handle unsupported DIIS kwargs in RSIRFO

### DIFF
--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -1572,6 +1572,13 @@ def cli(
 
             rsirfo_kwargs = {**opt_base, **rs_args}
 
+            # Compatibility: pysisyphus' RSIRFOptimizer does not accept DIIS-related
+            # keyword arguments that are used by the internal RFO implementation of
+            # pdb2reaction. Strip them here to avoid forwarding unsupported kwargs
+            # such as `gediis` that would otherwise raise a TypeError.
+            for diis_kw in ("gediis", "gdiis", "gdiis_thresh", "gediis_thresh", "gdiis_test_direction"):
+                rsirfo_kwargs.pop(diis_kw, None)
+
             optimizer = RSIRFOptimizer(geometry, **rsirfo_kwargs)
 
             click.echo("\n=== TS optimization (RS-I-RFO) started ===\n")


### PR DESCRIPTION
## Summary
- strip DIIS-related optimizer kwargs before constructing RSIRFOptimizer to match pysisyphus signature

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926589a9c34832d964234107473955b)