### PR TITLE
Align docs with current CLI requirements

### DIFF
--- a/docs/dft.md
+++ b/docs/dft.md
@@ -23,7 +23,7 @@ pdb2reaction dft -i input.pdb -q 0 -m 2 --func-basis "wb97m-v/def2-tzvpd" \
 
 ## Workflow
 1. **Input handling** – Any file loadable by `geom_loader` (.pdb/.xyz/.trj/…) is accepted. Coordinates are re-exported as `input_geometry.xyz`, and when the source was a Gaussian template a matching `.gjf` snapshot is written for reference.
-2. **Configuration merge** – Defaults → YAML (`dft` block) → CLI. Charge/multiplicity inherit `.gjf` metadata when present, otherwise default to `0`/`1`. Always set them explicitly so the correct RKS/UKS solver is selected.
+2. **Configuration merge** – Defaults → YAML (`dft` block) → CLI. Charge/multiplicity inherit `.gjf` metadata when present; otherwise `-q/--charge` is required and multiplicity defaults to `1`. Always set them explicitly so the correct RKS/UKS solver is selected.
 3. **SCF build** – `--func-basis` is parsed into XC functional and orbital basis. Density fitting is enabled automatically and a practical JKFIT auxiliary basis is guessed from the orbital basis (def2, cc-pVXZ, Pople families). `--engine` controls GPU/CPU preference (`gpu` tries GPU4PySCF before falling back; `cpu` forces CPU; `auto` tries GPU then CPU). Nonlocal VV10 is activated for functionals whose names end in `-v` or contain `vv10`.
 4. **Population analysis & outputs** – After convergence (or failure) the command writes `result.yaml` summarising energy (Hartree/kcal·mol⁻¹), convergence metadata, timing, backend info, and per-atom Mulliken/meta-Löwdin/IAO charges and spin densities (UKS only for spins). Any failed analysis column is set to `null` with a warning.
 
@@ -31,7 +31,7 @@ pdb2reaction dft -i input.pdb -q 0 -m 2 --func-basis "wb97m-v/def2-tzvpd" \
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
-| `-q, --charge INT` | Total charge supplied to PySCF (`calc.charge`). | `.gjf` template value or `0` |
+| `-q, --charge INT` | Total charge supplied to PySCF (`calc.charge`). Required unless the input is a `.gjf` template that already stores charge. | Required when not in template |
 | `-m, --mult INT` | Spin multiplicity (2S+1). Converted to `2S` for PySCF. | `.gjf` template value or `1` |
 | `--func-basis TEXT` | Functional/basis pair in `FUNC/BASIS` form (quote strings with `*`). | `wb97m-v/6-31g**` |
 | `--max-cycle INT` | Maximum SCF iterations (`dft.max_cycle`). | `100` |
@@ -66,7 +66,7 @@ Accepts a mapping with top-level key `dft`. CLI overrides YAML values.
 - `verbose` (`4`): PySCF verbosity (0–9).
 - `out_dir` (`"./result_dft/"`): Output directory root.
 
-_Functional/basis selection must be supplied on the CLI. Charge/spin inherit `.gjf` template metadata when present and otherwise default to `0`/`1`; set them explicitly for non-default states._
+_Functional/basis selection must be supplied on the CLI. Charge/spin inherit `.gjf` template metadata when present; otherwise `-q/--charge` is required and spin defaults to `1`. Set them explicitly for non-default states._
 
 ```yaml
 dft:

--- a/docs/freq.md
+++ b/docs/freq.md
@@ -55,7 +55,7 @@ pdb2reaction freq -i a.xyz -q -1 --args-yaml ./args.yaml --out-dir ./result_freq
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
-| `-q, --charge INT` | Total charge. | `.gjf` template value or `0` |
+| `-q, --charge INT` | Total charge. Required unless the input is a `.gjf` template with charge metadata. | Required when not in template |
 | `-m, --mult INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--freeze-links BOOL` | PDB-only. Freeze parents of link hydrogens and merge with `geom.freeze_atoms`. | `True` |
 | `--max-write INT` | Number of modes to export. | `20` |
@@ -80,8 +80,8 @@ pdb2reaction freq -i a.xyz -q -1 --args-yaml ./args.yaml --out-dir ./result_freq
 - Imaginary modes are reported as negative frequencies. `freq` prints how many were detected
   and dumps details when `--dump True`.
 - `--hessian-calc-mode` overrides `calc.hessian_calc_mode` after YAML merging.
-- Charge/spin inherit `.gjf` metadata when available; otherwise the CLI defaults (`0`/`1`)
-  are used. Override them explicitly to ensure the intended state.
+- Charge/spin inherit `.gjf` metadata when available; otherwise `-q/--charge` is required
+  and multiplicity defaults to `1`. Override them explicitly to ensure the intended state.
 
 ## YAML configuration (`--args-yaml`)
 Provide a mapping; CLI values override YAML. Shared sections reuse

--- a/docs/irc.md
+++ b/docs/irc.md
@@ -26,7 +26,7 @@ pdb2reaction irc -i ts.pdb -q 0 -m 1 --max-cycles 50 --out-dir ./result_irc/
 
 ## Workflow
 1. **Input preparation** – Any format supported by `geom_loader` is accepted. If the source is `.pdb`, EulerPC trajectories are automatically converted to PDB using the original topology, and `--freeze-links` augments `geom.freeze_atoms` by freezing parents of link hydrogens.
-2. **Configuration merge** – Defaults → YAML (`geom`, `calc`, `irc`) → CLI overrides. Charge/multiplicity inherit `.gjf` template metadata when available; otherwise they default to `0`/`1`. Always set them explicitly to remain on the intended PES.
+2. **Configuration merge** – Defaults → YAML (`geom`, `calc`, `irc`) → CLI overrides. Charge/multiplicity inherit `.gjf` template metadata when available; otherwise `-q/--charge` is required and multiplicity defaults to `1`. Always set them explicitly to remain on the intended PES.
 3. **IRC integration** – EulerPC integrates forward/backward branches according to `irc.forward/backward`, `irc.step_length`, `irc.root`, and the Hessian workflow configured through UMA (`calc.*`, `--hessian-calc-mode`). Hessians are updated with the configured scheme (`bofill` by default) and can be recalculated periodically.
 4. **Outputs** – Trajectories (`finished`, `forward`, `backward`) are written as `.trj` and, for PDB inputs, mirrored to `.pdb`. Optional HDF5 dumps capture per-step frames when `dump_every` > 0.
 
@@ -34,7 +34,7 @@ pdb2reaction irc -i ts.pdb -q 0 -m 1 --max-cycles 50 --out-dir ./result_irc/
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH` | Transition-state structure accepted by `geom_loader`. | Required |
-| `-q, --charge INT` | Total charge; overrides `calc.charge`. | `.gjf` template value or `0` |
+| `-q, --charge INT` | Total charge; overrides `calc.charge`. Required unless the input is a `.gjf` template with charge metadata. | Required when not in template |
 | `-m, --mult INT` | Spin multiplicity (2S+1); overrides `calc.spin`. | `.gjf` template value or `1` |
 | `--max-cycles INT` | Maximum IRC steps; overrides `irc.max_cycles`. | _None_ (use YAML/default `125`) |
 | `--step-size FLOAT` | Step length in mass-weighted coordinates; overrides `irc.step_length`. | _None_ (default `0.10`) |

--- a/docs/opt.md
+++ b/docs/opt.md
@@ -30,7 +30,7 @@ pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} -q CHARGE -m MULT \
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH` | Input structure accepted by `geom_loader`. | Required |
-| `-q, --charge INT` | Total charge. Falls back to `.gjf` template or `0`. | Template/`0` |
+| `-q, --charge INT` | Total charge. Required unless the input is a `.gjf` template that already encodes charge. | Required when not in template |
 | `-m, --mult INT` | Spin multiplicity (2S+1). Falls back to `.gjf` template or `1`. | Template/`1` |
 | `--dist-freeze TEXT` | Repeatable string parsed as Python literal describing `(i,j,target_A)` tuples for harmonic restraints. | _None_ |
 | `--one-based / --zero-based` | Interpret `--dist-freeze` indices as 1-based (default) or 0-based. | `--one-based` |

--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -32,16 +32,19 @@ pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} -q CHARGE -m MULT 
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH PATH` | Reactant and product structures (`.pdb`/`.xyz`). | Required |
-| `-q, --charge INT` | Total charge (`calc.charge`). | Template/`0` |
+| `-q, --charge INT` | Total charge (`calc.charge`). Required unless the input is a `.gjf` template that already encodes charge. | Required when not in template |
 | `-m, --mult INT` | Spin multiplicity (`calc.spin`). | Template/`1` |
 | `--freeze-links BOOL` | PDB-only: freeze link-H parents (merged with YAML). | `True` |
-| `--max-nodes INT` | Number of internal nodes (string images = `max_nodes + 2`). | `30` |
-| `--max-cycles INT` | Optimizer macro-iteration cap (`opt.max_cycles`). | `100` |
+| `--max-nodes INT` | Number of internal nodes (string images = `max_nodes + 2`). | `10` |
+| `--max-cycles INT` | Optimizer macro-iteration cap (`opt.max_cycles`). | `300` |
 | `--climb BOOL` | Enable climbing-image refinement (and Lanczos tangent). | `True` |
 | `--dump BOOL` | Dump GSM trajectories/restarts. | `False` |
 | `--out-dir TEXT` | Output directory. | `./result_path_opt/` |
 | `--thresh TEXT` | Override convergence preset for GSM/string optimizer. | YAML/default |
 | `--args-yaml FILE` | YAML overrides (sections `geom`, `calc`, `gs`, `opt`). | _None_ |
+| `--preopt BOOL` | Pre-optimise each endpoint with the selected single-structure optimizer before alignment/GSM. | `False` |
+| `--preopt-max-cycles INT` | Cap for endpoint preoptimization cycles. | `10000` |
+| `--fix-ends BOOL` | Keep the endpoint geometries fixed during GSM growth/refinement. | `False` |
 
 ## Outputs
 ```

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -30,11 +30,11 @@ pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--mult 2S+1]
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH...` | Two or more structures in reaction order (reactant → product). Repeat `-i` or pass multiple paths after one flag. | Required |
-| `-q, --charge INT` | Total charge. | `.gjf` template value or `0` |
+| `-q, --charge INT` | Total charge. Required unless the first input is a `.gjf` template that already stores charge. | Required when not in template |
 | `-m, --mult INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--freeze-links BOOL` | Explicit `True`/`False`. When loading PDB pockets, freeze the parent atoms of link hydrogens. | `True` |
 | `--max-nodes INT` | Internal nodes for GSM segments (`String` has `max_nodes + 2` images). | `10` |
-| `--max-cycles INT` | Maximum GSM optimization cycles. | `100` |
+| `--max-cycles INT` | Maximum GSM optimization cycles. | `300` |
 | `--climb BOOL` | Explicit `True`/`False`. Enable climbing image for the first segment in each pair. | `True` |
 | `--opt-mode TEXT` | Single-structure optimizer for HEI±1/kink nodes. `light` maps to LBFGS; `heavy` maps to RFO. | `light` |
 | `--dump BOOL` | Explicit `True`/`False`. Dump GSM and single-structure trajectories/restarts. | `False` |
@@ -72,8 +72,8 @@ Bond-change detection relies on `bond_changes.compare_structures` with threshold
 - `--ref-pdb` can be given once followed by multiple filenames; with `--align`, only the first template is reused for merges.
 - All UMA calculators are shared across structures for efficiency.
 - When `--dump` is set, GSM and single-structure optimizations emit trajectories and restart YAML files.
-- Charge/spin inherit `.gjf` template metadata when available; otherwise the CLI defaults to `0`/`1`. Override them explicitly
-  when you need a different electronic state.
+- Charge/spin inherit `.gjf` template metadata when available; otherwise `-q/--charge` is required and multiplicity defaults to
+  `1`. Override them explicitly when you need a different electronic state.
 
 ## YAML configuration (`--args-yaml`)
 The YAML root must be a mapping. CLI parameters override YAML values. Shared sections reuse [`opt`](opt.md#yaml-configuration-args-yaml): `geom`/`calc` mirror single-structure options (with `--freeze-links` augmenting `geom.freeze_atoms` for PDBs), and `opt` inherits the StringOptimizer knobs documented for `path_opt`.

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -99,8 +99,8 @@ UMA-based bond-change detection mirrored from `path_search`:
   atoms in PDB files so pockets stay rigid.
 - UMA is the only supported calculator; energies are not re-queried for every
   biased frame to avoid redundant evaluations.
-- Charge and spin default to the Gaussian template metadata (when available) or
-  to `0/1`; override them explicitly when needed.
+- Charge and spin inherit Gaussian template metadata when available; otherwise
+  `-q/--charge` is required and spin defaults to `1`.
 - Trajectories are written only when `--dump` is `True`; this also triggers PDB
   conversion for PDB inputs.
 

--- a/docs/tsopt.md
+++ b/docs/tsopt.md
@@ -16,30 +16,30 @@ settings from YAML, and always write the final imaginary mode in `.trj` and `.pd
 pdb2reaction tsopt -i INPUT.{pdb|xyz|trj|...} [-q CHARGE] [-m 2S+1] \
                     [--opt-mode light|heavy] \
                     [--freeze-links {True|False}] [--max-cycles N] [--thresh PRESET] \
-                    [--dump {True|False}] [--outdir DIR] [--args-yaml FILE] \
+                    [--dump {True|False}] [--out-dir DIR] [--args-yaml FILE] \
                     [--hessian-calc-mode Analytical|FiniteDifference]
 ```
 
 ### Examples
 ```bash
 # Recommended baseline: specify charge/multiplicity and pick the light workflow
-pdb2reaction tsopt -i ts_cand.pdb -q 0 -m 1 --opt-mode light --outdir ./result_tsopt/
+pdb2reaction tsopt -i ts_cand.pdb -q 0 -m 1 --opt-mode light --out-dir ./result_tsopt/
 
 # Light mode with YAML overrides, finite-difference Hessian, and freeze-links handling
 pdb2reaction tsopt -i ts_cand.pdb -q 0 -m 1 --freeze-links True \
     --opt-mode light --max-cycles 10000 --dump False \
-    --outdir ./result_tsopt/ --args-yaml ./args.yaml \
+    --out-dir ./result_tsopt/ --args-yaml ./args.yaml \
     --hessian-calc-mode FiniteDifference
 
 # Heavy mode (RS-I-RFO) driven entirely by YAML
 pdb2reaction tsopt -i ts_cand.pdb -q 0 -m 1 --opt-mode heavy \
-    --args-yaml ./args.yaml --outdir ./result_tsopt/
+    --args-yaml ./args.yaml --out-dir ./result_tsopt/
 ```
 
 ## Workflow
 - **Charge/spin resolution**: when the input is `.gjf`, charge and multiplicity inherit the
-  template values; otherwise they default to `0`/`1`. Override them explicitly to ensure UMA
-  runs on the intended state.
+  template values; otherwise `-q/--charge` is required and multiplicity defaults to `1`.
+  Override them explicitly to ensure UMA runs on the intended state.
 - **Geometry loading & freeze-links**: structures are read via
   `pysisyphus.helpers.geom_loader`. On PDB inputs, `--freeze-links True` finds link hydrogens
   and freezes their parent atoms. The merged set is echoed, stored in `geom.freeze_atoms`, and
@@ -68,20 +68,20 @@ pdb2reaction tsopt -i ts_cand.pdb -q 0 -m 1 --opt-mode heavy \
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
-| `-q, --charge INT` | Total charge. | `.gjf` template value or `0` |
+| `-q, --charge INT` | Total charge. Required unless the input is a `.gjf` template with charge metadata. | Required when not in template |
 | `-m, --mult INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--freeze-links BOOL` | PDB-only. Freeze parents of link hydrogens (merged into `geom.freeze_atoms`). | `True` |
 | `--max-cycles INT` | Macro-cycle cap forwarded to `opt.max_cycles`. | `10000` |
 | `--opt-mode TEXT` | Light/Heavy aliases listed above. | `light` |
 | `--dump BOOL` | Explicit `True`/`False`. Dump trajectories. | `False` |
-| `--outdir TEXT` | Output directory. | `./result_tsopt/` |
+| `--out-dir TEXT` | Output directory. | `./result_tsopt/` |
 | `--thresh TEXT` | Override convergence preset (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | _None_ (use YAML/default) |
 | `--hessian-calc-mode CHOICE` | UMA Hessian mode (`Analytical` or `FiniteDifference`). | _None_ (use YAML/default) |
 | `--args-yaml FILE` | YAML overrides (`geom`, `calc`, `opt`, `hessian_dimer`, `rsirfo`). | _None_ |
 
 ## Outputs (& directory layout)
 ```
-outdir/ (default: ./result_tsopt/)
+out-dir/ (default: ./result_tsopt/)
   ├─ final_geometry.xyz                # Always written
   ├─ final_geometry.pdb                # When the input was PDB
   ├─ optimization_all.trj/.pdb         # Light-mode dump (requires --dump True)
@@ -142,7 +142,7 @@ opt:
   dump: false
   dump_restart: false
   prefix: ""
-  outdir: ./result_tsopt/
+  out_dir: ./result_tsopt/
 hessian_dimer:
   thresh_loose: gau_loose
   thresh: gau
@@ -191,7 +191,7 @@ hessian_dimer:
     dump: false
     dump_restart: false
     prefix: ""
-    outdir: ./result_opt/
+    out_dir: ./result_opt/
     keep_last: 7
     beta: 1.0
     gamma_mult: false
@@ -217,7 +217,7 @@ rsirfo:
   dump: false
   dump_restart: false
   prefix: ""
-  outdir: ./result_opt/
+  out_dir: ./result_opt/
   roots: [0]
   hessian_ref: null
   rx_modes: null


### PR DESCRIPTION
## Summary
- Update documentation to clarify charge requirements across CLI tools and align wording with actual behavior
- Correct default values and option names for path-opt, path-search, tsopt, and related commands
- Adjust additional notes to match current CLI configurations

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692665656b80832d8ad89f5f270dff77)