### PR TITLE
Fix docs to match CLI defaults and opt-mode choices

### DIFF
--- a/docs/dft.md
+++ b/docs/dft.md
@@ -33,7 +33,7 @@ pdb2reaction dft -i input.pdb -q 0 -m 2 --func-basis "wb97m-v/def2-tzvpd" \
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
 | `-q, --charge INT` | Total charge supplied to PySCF (`calc.charge`). Required unless the input is a `.gjf` template that already stores charge. | Required when not in template |
 | `-m, --mult INT` | Spin multiplicity (2S+1). Converted to `2S` for PySCF. | `.gjf` template value or `1` |
-| `--func-basis TEXT` | Functional/basis pair in `FUNC/BASIS` form (quote strings with `*`). | `wb97m-v/6-31g**` |
+| `--func-basis TEXT` | Functional/basis pair in `FUNC/BASIS` form (quote strings with `*`). | `wb97m-v/def2-tzvpd` |
 | `--max-cycle INT` | Maximum SCF iterations (`dft.max_cycle`). | `100` |
 | `--conv-tol FLOAT` | SCF convergence tolerance in Hartree (`dft.conv_tol`). | `1e-9` |
 | `--grid-level INT` | PySCF numerical integration grid level (`dft.grid_level`). | `3` |
@@ -66,7 +66,7 @@ Accepts a mapping with top-level key `dft`. CLI overrides YAML values.
 - `verbose` (`4`): PySCF verbosity (0–9).
 - `out_dir` (`"./result_dft/"`): Output directory root.
 
-_Functional/basis selection must be supplied on the CLI. Charge/spin inherit `.gjf` template metadata when present; otherwise `-q/--charge` is required and spin defaults to `1`. Set them explicitly for non-default states._
+_Functional/basis selection defaults to `wb97m-v/def2-tzvpd` but can be overridden on the CLI. Charge/spin inherit `.gjf` template metadata when present; otherwise `-q/--charge` is required and spin defaults to `1`. Set them explicitly for non-default states._
 
 ```yaml
 dft:

--- a/docs/opt.md
+++ b/docs/opt.md
@@ -37,7 +37,7 @@ pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} -q CHARGE -m MULT \
 | `--bias-k FLOAT` | Harmonic bias strength applied to every `--dist-freeze` tuple (eV·Å⁻²). | `10.0` |
 | `--freeze-links BOOL` | Toggle link-hydrogen parent freezing (PDB inputs only). | `True` |
 | `--max-cycles INT` | Hard limit on optimization iterations (`opt.max_cycles`). | `10000` |
-| `--opt-mode TEXT` | Choose optimizer: `light`/`lbfgs` or `heavy`/`rfo`. | `light` |
+| `--opt-mode TEXT` | Choose optimizer: `light` (LBFGS) or `heavy` (RFO). | `light` |
 | `--dump BOOL` | Emit trajectory dumps (`optimization.trj`). | `False` |
 | `--out-dir TEXT` | Output directory for all files. | `./result_opt/` |
 | `--thresh TEXT` | Override convergence preset (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | YAML/default |

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -4,10 +4,10 @@
 `scan` performs a staged, bond-length–driven scan using the UMA calculator and
 harmonic restraints. Each tuple `(i, j, targetÅ)` defines a distance target. At
 every integration step the temporary targets are updated, the restraint wells
-are applied, and the entire structure is relaxed with LBFGS (`--opt-mode` light
-or lbfgs) or RFOptimizer (`--opt-mode` heavy or rfo). After the biased walk, you
-can optionally run unbiased pre-/post-optimizations to clean up the geometries
-that get written to disk.
+are applied, and the entire structure is relaxed with LBFGS (`--opt-mode` light)
+or RFOptimizer (`--opt-mode` heavy). After the biased walk, you can optionally
+run unbiased pre-/post-optimizations to clean up the geometries that get written
+to disk.
 
 ## Usage
 ```bash
@@ -24,7 +24,7 @@ pdb2reaction scan -i input.pdb -q 0 --scan-lists "[(12,45,1.35)]"
 pdb2reaction scan -i input.pdb -q 0 \
     --scan-lists "[(12,45,1.35)]" \
     --scan-lists "[(10,55,2.20),(23,34,1.80)]" \
-    --max-step-size 0.20 --dump True --out-dir ./result_scan/ --opt-mode lbfgs \
+    --max-step-size 0.20 --dump True --out-dir ./result_scan/ --opt-mode light \
     --preopt True --endopt True
 ```
 

--- a/docs/scan2d.md
+++ b/docs/scan2d.md
@@ -7,7 +7,8 @@ quadruples `(i, j, lowÅ, highÅ)`; the tool constructs linear grids for both
 ranges using `--max-step-size`, nests the loops (outer d₁, inner d₂), and writes
 both the PES samples and a ready-to-plot CSV/figure bundle. Energies reported in
 `surface.csv` are always evaluated **without bias** so you can compare grid
-points directly.
+points directly. Optimizations use LBFGS when `--opt-mode light` (default) or
+RFO when `--opt-mode heavy`.
 
 ## Usage
 ```bash
@@ -24,7 +25,7 @@ pdb2reaction scan2d -i input.pdb -q 0 \
 # LBFGS, dumped inner trajectories, and Plotly outputs
 pdb2reaction scan2d -i input.pdb -q 0 \
     --scan-list "[(12,45,1.30,3.10),(10,55,1.20,3.20)]" \
-    --max-step-size 0.20 --dump True --out-dir ./result_scan2d/ --opt-mode lbfgs \
+    --max-step-size 0.20 --dump True --out-dir ./result_scan2d/ --opt-mode light \
     --preopt True --baseline min
 ```
 


### PR DESCRIPTION
## Summary
- update documentation to reflect current DFT default functional/basis
- clarify valid opt-mode choices for scan and scan2d examples
- align opt documentation with actual CLI options

## Testing
- not run (documentation changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926684382f4832d88d37d8daa361083)