### PR TITLE
Document charge override flag for all command

### DIFF
--- a/docs/all.md
+++ b/docs/all.md
@@ -82,6 +82,7 @@ pdb2reaction all -i reactant.pdb -c "GPP,MMT" \
 | `--add-linkH BOOLEAN` | Add link hydrogens for severed bonds (carbon-only). | `True` |
 | `--selected_resn TEXT` | Residues to force include (comma/space separated; chain/insertion codes allowed). | `""` |
 | `--ligand-charge TEXT` | Total charge or residue-specific mapping for unknown residues (recommended). | `None` |
+| `-q, --charge INT` | Force the total system charge, overriding extractor rounding / `.gjf` metadata / `--ligand-charge` (logs a warning). | _None_ |
 | `--verbose BOOLEAN` | Enable INFO-level extractor logging. | `True` |
 | `-m, --multiplicity INT` | Spin multiplicity forwarded to all downstream steps. | `1` |
 | `--freeze-links BOOLEAN` | Freeze link parents in pocket PDBs (reused by scan/tsopt/freq). | `True` |


### PR DESCRIPTION
## Summary
- document the `-q/--charge` override for the `all` workflow in README
- add the `-q/--charge` row to the `docs/all.md` option matrix to highlight the forced charge behavior

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69267f4b7b68832db618a8fb3d46542c)