### PR TITLE
Format bond change summaries in summary.yaml

### DIFF
--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -2875,7 +2875,7 @@ def cli(
                     "kind": "seg",
                     "barrier_kcal": float(barrier),
                     "delta_kcal": float(delta),
-                    "bond_changes": bond_summary,
+                    "bond_changes": _path_search._bond_changes_block(bond_summary),
                 }
             )
 


### PR DESCRIPTION
## Summary
- add a YAML literal-string helper to preserve multi-line bond change summaries when writing summary.yaml
- apply the helper in path_search and all summary writers so bond changes display as readable blocks

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69281abb1e20832d8a1665e269d07d7b)