### PR TITLE
Remove TRJ to GJF conversions

### DIFF
--- a/docs/freq.md
+++ b/docs/freq.md
@@ -72,7 +72,7 @@ pdb2reaction freq -i a.xyz -q -1 --args-yaml ./args.yaml --out-dir ./result_freq
 | `--args-yaml FILE` | YAML overrides (sections: `geom`, `calc`, `freq`). | _None_ |
 
 ## Outputs
-- `<out-dir>/mode_XXXX_±freqcm-1.trj` and `.pdb`/`.gjf` animations for each written mode (mirroring follows `--convert-files`).
+- `<out-dir>/mode_XXXX_±freqcm-1.trj` and `.pdb` animations for each written mode (mirroring follows `--convert-files`).
 - `<out-dir>/frequencies_cm-1.txt` listing every computed frequency according to the sort
   order.
 - `<out-dir>/thermoanalysis.yaml` when both `thermoanalysis` is importable and `--dump True`.

--- a/docs/irc.md
+++ b/docs/irc.md
@@ -29,7 +29,7 @@ pdb2reaction irc -i ts.pdb -q 0 -m 1 --max-cycles 50 --out-dir ./result_irc/
 1. **Input preparation** – Any format supported by `geom_loader` is accepted. If the source is `.pdb`, EulerPC trajectories are automatically converted to PDB using the original topology, and `--freeze-links` augments `geom.freeze_atoms` by freezing parents of link hydrogens.
 2. **Configuration merge** – Defaults → YAML (`geom`, `calc`, `irc`) → CLI overrides. Charge/multiplicity inherit `.gjf` template metadata when available; otherwise `-q/--charge` is required and multiplicity defaults to `1`. Always set them explicitly to remain on the intended PES.
 3. **IRC integration** – EulerPC integrates forward/backward branches according to `irc.forward/backward`, `irc.step_length`, `irc.root`, and the Hessian workflow configured through UMA (`calc.*`, `--hessian-calc-mode`). Hessians are updated with the configured scheme (`bofill` by default) and can be recalculated periodically.
-4. **Outputs** – Trajectories (`finished`, `forward`, `backward`) are written as `.trj` and, for PDB inputs, mirrored to `.pdb`; Gaussian templates also receive multi-geometry `.gjf` when `--convert-files` is enabled. Optional HDF5 dumps capture per-step frames when `dump_every` > 0.
+4. **Outputs** – Trajectories (`finished`, `forward`, `backward`) are written as `.trj` and, for PDB inputs, mirrored to `.pdb`. Optional HDF5 dumps capture per-step frames when `dump_every` > 0.
 
 ## CLI options
 | Option | Description | Default |

--- a/docs/opt.md
+++ b/docs/opt.md
@@ -24,7 +24,7 @@ pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} -q CHARGE -m MULT \
 - **Restraints**: `--dist-freeze` consumes Python-literal tuples `(i, j, target_A)`; omitting the third element restrains the starting distance. `--bias-k` sets a global harmonic strength (eV·Å⁻²). Indices default to 1-based but can be flipped to 0-based with `--zero-based`.
 - **Charge/spin resolution**: CLI `-q/-m` override `.gjf` template metadata, which in turn override the `calc` defaults. If no template exists, the fallback is `0/1`. Always pass the physically correct values explicitly.
 - **Freeze atoms**: CLI freeze-link logic is merged with YAML `geom.freeze_atoms`, then propagated to the UMA calculator (`calc.freeze_atoms`).
-- **Dumping & conversion**: `--dump True` mirrors `opt.dump=True` and writes `optimization.trj`; when conversion is enabled, trajectories are mirrored to `.pdb` (PDB inputs) or `.gjf` (Gaussian templates). `opt.dump_restart` can emit restart YAML snapshots.
+- **Dumping & conversion**: `--dump True` mirrors `opt.dump=True` and writes `optimization.trj`; when conversion is enabled, trajectories are mirrored to `.pdb` for PDB inputs. `opt.dump_restart` can emit restart YAML snapshots.
 - **Exit codes**: `0` success, `2` zero step (step norm < `min_step_norm`), `3` optimizer failure, `130` keyboard interrupt, `1` unexpected error.
 
 ## CLI options

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -61,7 +61,7 @@ pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--multiplicity 2S
 Bond-change detection relies on `bond_changes.compare_structures` with thresholds surfaced under the `bond` YAML section. UMA calculators are constructed once and shared across all structures for efficiency.
 
 ## Outputs
-- `<out-dir>/mep.trj` (and `.pdb`/`.gjf` companions when the inputs were PDB/Gaussian templates and conversion is enabled).
+- `<out-dir>/mep.trj` (and `.pdb` companions when the inputs were PDB templates and conversion is enabled).
 - `<out-dir>/mep_w_ref.pdb` merged full-system MEP (requires `--ref-pdb` or auto-provided templates; obeys conversion flag for generated companions).
 - `<out-dir>/mep_w_ref_seg_XX.pdb` merged per-segment paths for segments with covalent changes (requires `--ref-pdb`).
 - `<out-dir>/summary.yaml` summarising barriers and classification for every recursive segment.

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -90,8 +90,8 @@ UMA-based bond-change detection mirrored from `path_search`:
 - `<out-dir>/stage_XX/` for each stage:
   - `result.xyz` and optional `result.gjf`/`result.pdb` mirrors of the final
     structure (after `--endopt`, conversion enabled).
-  - `scan.trj` when `--dump True` plus `scan.pdb`/`scan.gjf` companions for
-    PDB/Gaussian inputs when conversion is enabled.
+  - `scan.trj` when `--dump True` plus `scan.pdb` companions for
+    PDB inputs when conversion is enabled.
 - Console summaries of the resolved `geom`, `calc`, `opt`, `bias`, `bond`, and
   optimizer blocks plus per-stage bond-change reports.
 

--- a/docs/scan2d.md
+++ b/docs/scan2d.md
@@ -85,7 +85,7 @@ pdb2reaction scan2d -i input.pdb -q 0 \
 - `plots/scan2d_map.png` (or `.html` fallback) and `plots/scan2d_landscape.html`
   — 2D contour and 3D surface visualizations.
 - `grid/point_i###_j###.xyz` — relaxed geometries for every `(i, j)` pair (with `.pdb`/`.gjf` companions when conversion is enabled and templates exist).
-- `grid/inner_path_d1_###.trj` — written only when `--dump True` (mirrored to `.pdb`/`.gjf` when conversion is enabled for PDB/Gaussian inputs).
+- `grid/inner_path_d1_###.trj` — written only when `--dump True` (mirrored to `.pdb` when conversion is enabled for PDB inputs).
 
 ## Notes
 - UMA via `uma_pysis` is the only calculator backend and reuses the same

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -401,8 +401,7 @@ def _write_mode_trj_and_pdb(geom,
                             ref_pdb: Optional[Path] = None,
                             write_pdb: bool = True,
                             prepared_input: Optional["PreparedInputStructure"] = None,
-                            out_pdb: Optional[Path] = None,
-                            out_gjf: Optional[Path] = None) -> None:
+                            out_pdb: Optional[Path] = None) -> None:
     """
     Write a single mode animation as .trj (XYZ-like) and optionally .pdb.
 
@@ -448,9 +447,8 @@ def _write_mode_trj_and_pdb(geom,
                         f.write(f"{sym:2s} {x: .8f} {y: .8f} {z: .8f}\n")
 
     needs_pdb = write_pdb and out_pdb is not None
-    needs_gjf = out_gjf is not None and prepared_input is not None and prepared_input.is_gjf
 
-    if not (needs_pdb or needs_gjf):
+    if not needs_pdb:
         return
 
     ref_for_conv = ref_pdb if (ref_pdb and ref_pdb.suffix.lower() == ".pdb") else None
@@ -460,7 +458,6 @@ def _write_mode_trj_and_pdb(geom,
             prepared_input,  # type: ignore[arg-type]
             ref_pdb_path=ref_for_conv,
             out_pdb_path=out_pdb if needs_pdb else None,
-            out_gjf_path=out_gjf if needs_gjf else None,
         )
     except Exception:
         if needs_pdb and ref_ang is not None and ref_pdb is not None:
@@ -703,7 +700,6 @@ def cli(
                 write_pdb=write_pdb,
                 prepared_input=prepared_input,
                 out_pdb=out_dir_path / f"mode_{k:04d}_{freq:+.2f}cm-1.pdb" if write_pdb else None,
-                out_gjf=out_dir_path / f"mode_{k:04d}_{freq:+.2f}cm-1.gjf" if prepared_input.is_gjf else None,
             )
         (out_dir_path / "frequencies_cm-1.txt").write_text(
             "\n".join(f"{i+1:4d}  {float(freqs_cm[j]):+12.4f}" for i, j in enumerate(order)),

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -149,7 +149,6 @@ def _echo_convert_trj_if_exists(
     prepared_input: "PreparedInputStructure",
     *,
     out_pdb: Optional[Path] = None,
-    out_gjf: Optional[Path] = None,
 ) -> None:
     if trj_path.exists():
         try:
@@ -159,9 +158,8 @@ def _echo_convert_trj_if_exists(
                 prepared_input,
                 ref_pdb_path=ref_pdb,
                 out_pdb_path=out_pdb,
-                out_gjf_path=out_gjf,
             )
-            targets = [p for p in (out_pdb, out_gjf) if p is not None and p.exists()]
+            targets = [p for p in (out_pdb,) if p is not None and p.exists()]
             if targets:
                 written = ", ".join(f"'{p.name}'" for p in targets)
                 click.echo(f"[convert] Wrote {written}.")
@@ -337,26 +335,23 @@ def cli(
         click.echo("\n=== IRC (EulerPC) finished ===\n")
 
         # --------------------------
-        # 4) Convert trajectories to PDB/GJF based on input type
+        # 4) Convert trajectories to PDB based on input type
         # --------------------------
         suffix_prefix = irc_cfg.get("prefix", "")
         _echo_convert_trj_if_exists(
             out_dir_path / f"{suffix_prefix}{'finished_irc.trj'}",
             prepared_input,
             out_pdb=out_dir_path / f"{suffix_prefix}{'finished_irc.pdb'}" if prepared_input.source_path.suffix.lower() == ".pdb" else None,
-            out_gjf=out_dir_path / f"{suffix_prefix}{'finished_irc.gjf'}" if prepared_input.is_gjf else None,
         )
         _echo_convert_trj_if_exists(
             out_dir_path / f"{suffix_prefix}{'forward_irc.trj'}",
             prepared_input,
             out_pdb=out_dir_path / f"{suffix_prefix}{'forward_irc.pdb'}" if prepared_input.source_path.suffix.lower() == ".pdb" else None,
-            out_gjf=out_dir_path / f"{suffix_prefix}{'forward_irc.gjf'}" if prepared_input.is_gjf else None,
         )
         _echo_convert_trj_if_exists(
             out_dir_path / f"{suffix_prefix}{'backward_irc.trj'}",
             prepared_input,
             out_pdb=out_dir_path / f"{suffix_prefix}{'backward_irc.pdb'}" if prepared_input.source_path.suffix.lower() == ".pdb" else None,
-            out_gjf=out_dir_path / f"{suffix_prefix}{'backward_irc.gjf'}" if prepared_input.is_gjf else None,
         )
 
         click.echo(format_elapsed("[time] Elapsed Time for IRC", time_start))

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -432,8 +432,8 @@ def _maybe_convert_outputs(
     except Exception as e:
         click.echo(f"[convert] WARNING: Failed to convert final geometry: {e}", err=True)
 
-    # optimization.trj → optimization.{pdb|gjf} (if dump)
-    if dump:
+    # optimization.trj → optimization.pdb (if dump)
+    if dump and needs_pdb:
         try:
             trj_path = get_trj_fn("optimization.trj")
             if trj_path.exists():
@@ -442,7 +442,6 @@ def _maybe_convert_outputs(
                     prepared_input,
                     ref_pdb_path=ref_pdb,
                     out_pdb_path=out_dir / "optimization.pdb" if needs_pdb else None,
-                    out_gjf_path=out_dir / "optimization.gjf" if needs_gjf else None,
                 )
                 click.echo("[convert] Wrote 'optimization' outputs.")
             else:

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -312,13 +312,12 @@ def _run_dmf_mep(
 
     initial_trj = out_dir_path / "dmf_initial.trj"
     ase_write(initial_trj, mxflx_fbenm.images, format="xyz")
-    if primary_prepared is not None and (needs_pdb or needs_gjf):
+    if primary_prepared is not None and needs_pdb:
         convert_xyz_like_outputs(
             initial_trj,
             primary_prepared,
             ref_pdb_path=ref_pdb,
             out_pdb_path=initial_trj.with_suffix(".pdb") if needs_pdb else None,
-            out_gjf_path=initial_trj.with_suffix(".gjf") if needs_gjf else None,
         )
     coefs = mxflx_fbenm.coefs.copy()
 
@@ -346,13 +345,12 @@ def _run_dmf_mep(
 
     final_trj = out_dir_path / "final_geometries.trj"
     _write_ase_trj_with_energy(mxflx.images, energies, final_trj)
-    if primary_prepared is not None and (needs_pdb or needs_gjf):
+    if primary_prepared is not None and needs_pdb:
         convert_xyz_like_outputs(
             final_trj,
             primary_prepared,
             ref_pdb_path=ref_pdb,
             out_pdb_path=final_trj.with_suffix(".pdb") if needs_pdb else None,
-            out_gjf_path=final_trj.with_suffix(".gjf") if needs_gjf else None,
         )
     if primary_prepared is not None and (needs_pdb or needs_gjf):
         hei_tmp = out_dir_path / "hei.xyz"

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -2123,18 +2123,6 @@ def cli(
             except Exception as e:
                 click.echo(f"[plot] WARNING: Failed to plot final energy: {e}", err=True)
 
-            if needs_gjf:
-                try:
-                    convert_xyz_like_outputs(
-                        final_trj,
-                        main_prepared,
-                        ref_pdb_path=None,
-                        out_gjf_path=out_dir_path / "mep.gjf",
-                        out_pdb_path=None,
-                    )
-                    click.echo("[convert] Wrote 'mep.gjf'.")
-                except Exception as e:
-                    click.echo(f"[convert] WARNING: Failed to convert final MEP to GJF: {e}", err=True)
         else:
             tmp_trj = tempfile.NamedTemporaryFile("w+", suffix=".trj", delete=False)
             tmp_trj_path = Path(tmp_trj.name)
@@ -2152,7 +2140,6 @@ def cli(
                         main_prepared,
                         ref_pdb_path=ref_pdb_for_segments,
                         out_pdb_path=out_dir_path / "mep.pdb",
-                        out_gjf_path=out_dir_path / "mep.gjf" if needs_gjf else None,
                     )
                     click.echo("[convert] Wrote final MEP outputs.")
                 except Exception as e:

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -835,11 +835,10 @@ def cli(
                             prepared_input,
                             ref_pdb_path=ref_pdb_path,
                             out_pdb_path=grid_dir / f"inner_path_d1_{i_idx:03d}.pdb",
-                            out_gjf_path=grid_dir / f"inner_path_d1_{i_idx:03d}.gjf",
                         )
                     except Exception as e:
                         click.echo(
-                            f"[convert] WARNING: failed to convert '{trj_path.name}' to PDB/GJF: {e}",
+                            f"[convert] WARNING: failed to convert '{trj_path.name}' to PDB: {e}",
                             err=True,
                         )
                 except Exception as e:

--- a/pdb2reaction/scan3d.py
+++ b/pdb2reaction/scan3d.py
@@ -951,11 +951,10 @@ def cli(
                                     prepared_input,
                                     ref_pdb_path=ref_pdb_path,
                                     out_pdb_path=grid_dir / f"inner_path_d1_{i_idx:03d}_d2_{j_idx:03d}.pdb",
-                                    out_gjf_path=grid_dir / f"inner_path_d1_{i_idx:03d}_d2_{j_idx:03d}.gjf",
                                 )
                             except Exception as e:
                                 click.echo(
-                                    f"[convert] WARNING: failed to convert '{trj_path.name}' to PDB/GJF: {e}",
+                                    f"[convert] WARNING: failed to convert '{trj_path.name}' to PDB: {e}",
                                     err=True,
                                 )
 

--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -1501,19 +1501,18 @@ def cli(
                 click.echo(f"[convert] WARNING: Failed to convert final geometry: {e}", err=True)
 
             all_trj = out_dir_path / "optimization_all.trj"
-            if all_trj.exists() and (needs_pdb or needs_gjf):
+            if all_trj.exists() and needs_pdb:
                 try:
                     convert_xyz_like_outputs(
                         all_trj,
                         prepared_input,
                         ref_pdb_path=ref_pdb,
                         out_pdb_path=out_dir_path / "optimization_all.pdb" if needs_pdb else None,
-                        out_gjf_path=out_dir_path / "optimization_all.gjf" if needs_gjf else None,
                     )
                     click.echo("[convert] Wrote 'optimization_all' outputs.")
                 except Exception as e:
                     click.echo(f"[convert] WARNING: Failed to convert optimization trajectory: {e}", err=True)
-            elif needs_pdb or needs_gjf:
+            elif needs_pdb:
                 click.echo("[convert] WARNING: 'optimization_all.trj' not found; skipping conversion.", err=True)
 
         else:
@@ -1575,19 +1574,18 @@ def cli(
                 click.echo(f"[convert] WARNING: Failed to convert final geometry: {e}", err=True)
 
             trj_path = out_dir_path / "optimization.trj"
-            if trj_path.exists() and (needs_pdb or needs_gjf):
+            if trj_path.exists() and needs_pdb:
                 try:
                     convert_xyz_like_outputs(
                         trj_path,
                         prepared_input,
                         ref_pdb_path=ref_pdb,
                         out_pdb_path=out_dir_path / "optimization.pdb" if needs_pdb else None,
-                        out_gjf_path=out_dir_path / "optimization.gjf" if needs_gjf else None,
                     )
                     click.echo("[convert] Wrote 'optimization' outputs.")
                 except Exception as e:
                     click.echo(f"[convert] WARNING: Failed to convert optimization trajectory: {e}", err=True)
-            elif needs_pdb or needs_gjf:
+            elif needs_pdb:
                 click.echo("[convert] WARNING: 'optimization.trj' not found; skipping conversion.", err=True)
 
             # --- RSIRFO: write final imaginary mode like HessianDimer (PHVA/in-place or active) ---

--- a/pdb2reaction/utils.py
+++ b/pdb2reaction/utils.py
@@ -837,7 +837,7 @@ def convert_xyz_like_outputs(
     out_pdb_path: Optional[Path] = None,
     out_gjf_path: Optional[Path] = None,
 ) -> None:
-    """Convert an XYZ/TRJ file to PDB/GJF outputs based on the original input type.
+    """Convert an XYZ/TRJ file to PDB outputs (and XYZ to GJF) based on the original input type.
 
     Parameters
     ----------
@@ -858,7 +858,12 @@ def convert_xyz_like_outputs(
 
     source_suffix = prepared_input.source_path.suffix.lower()
     needs_pdb = source_suffix == ".pdb" and out_pdb_path is not None and ref_pdb_path is not None
-    needs_gjf = prepared_input.is_gjf and prepared_input.gjf_template is not None and out_gjf_path is not None
+    needs_gjf = (
+        xyz_path.suffix.lower() == ".xyz"
+        and prepared_input.is_gjf
+        and prepared_input.gjf_template is not None
+        and out_gjf_path is not None
+    )
 
     if needs_pdb:
         convert_xyz_to_pdb(xyz_path, ref_pdb_path, out_pdb_path)


### PR DESCRIPTION
## Summary
- prevent TRJ outputs from being converted to GJF files and limit trajectory conversions to PDB mirroring
- adjust trajectory handling across path search, optimization, IRC, and scanning utilities to drop GJF requests
- update documentation to reflect the removal of TRJ to GJF conversions

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69288a3cf14c832db15d003a4e7dc04c)