### PR TITLE
Handle refined segment tags when loading IRC endpoints

### DIFF
--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -691,8 +691,9 @@ def _load_segment_endpoints(
 
     Uses seg_tag (e.g. 'seg_000') and returns (gL_ref, gR_ref).
     """
-    refine_trj = path_dir / f"{seg_tag}_refine_mep" / "final_geometries.trj"
-    gsm_trj = path_dir / f"{seg_tag}_mep" / "final_geometries.trj"
+    base_tag = _path_search._segment_base_id(seg_tag)
+    refine_trj = path_dir / f"{base_tag}_refine_mep" / "final_geometries.trj"
+    gsm_trj = path_dir / f"{base_tag}_mep" / "final_geometries.trj"
 
     if refine_trj.exists():
         trj_path = refine_trj


### PR DESCRIPTION
## Summary
- normalize segment tags before looking up refined or GSM endpoint trajectories
- ensure IRC mapping finds final_geometries.trj for refined segments instead of defaulting to raw orientation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692890d09a00832dafd2c372c2eefcdc)