### PR TITLE
Fix MEP trajectory energy units

### DIFF
--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -70,6 +70,7 @@ import time
 import click
 import numpy as np
 
+from pysisyphus.constants import AU2EV
 from pysisyphus.helpers import geom_loader
 from pysisyphus.cos.GrowingString import GrowingString
 from pysisyphus.optimizers.StringOptimizer import StringOptimizer
@@ -78,6 +79,8 @@ from pysisyphus.optimizers.LBFGS import LBFGS
 from pysisyphus.optimizers.RFOptimizer import RFOptimizer
 
 from .uma_pysis import uma_pysis, GEOM_KW_DEFAULT, CALC_KW as _UMA_CALC_KW
+
+EV2AU = 1.0 / AU2EV  # eV → Hartree
 from .utils import (
     convert_xyz_to_pdb,
     detect_freeze_links,
@@ -340,7 +343,7 @@ def _run_dmf_mep(
     mxflx.add_ipopt_options({"output_file": str(out_dir_path / "dmf_ipopt.out")})
     mxflx.solve(tol="tight")
 
-    energies = [float(img.get_potential_energy()) for img in mxflx.images]
+    energies = [float(img.get_potential_energy()) * EV2AU for img in mxflx.images]
     hei_idx = _select_hei_index(energies)
 
     final_trj = out_dir_path / "final_geometries.trj"


### PR DESCRIPTION
## Summary
- convert DMF MEP trajectory energies from eV to Hartree using AU2EV

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69288de465e4832dae1964fe8dd86a53)