### PR TITLE
Prefer loader-friendly TS outputs

### DIFF
--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -1310,14 +1310,14 @@ def _run_tsopt_on_hei(
 
     if needs_pdb and ts_pdb.exists():
         ts_geom_path = ts_pdb
-    elif needs_gjf and ts_gjf.exists():
-        ts_geom_path = ts_gjf
-    elif ts_pdb.exists():
-        ts_geom_path = ts_pdb
-    elif ts_gjf.exists():
-        ts_geom_path = ts_gjf
     elif ts_xyz.exists():
         ts_geom_path = ts_xyz
+    elif ts_pdb.exists():
+        ts_geom_path = ts_pdb
+    elif needs_gjf and ts_gjf.exists():
+        ts_geom_path = ts_gjf
+    elif ts_gjf.exists():
+        ts_geom_path = ts_gjf
     else:
         raise click.ClickException("[tsopt] TS outputs not found.")
 


### PR DESCRIPTION
## Summary
- prioritize TSOPT XYZ or PDB outputs when selecting final geometries so geom_loader receives supported formats
- retain existing fallbacks to GJF outputs only when no loader-friendly files are available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69292eb05f90832d92b50d38958b819d)