### PR TITLE
Force CPU backend for meta-GGA DFT runs

### DIFF
--- a/docs/dft.md
+++ b/docs/dft.md
@@ -52,7 +52,7 @@ pdb2reaction dft -i input.pdb -q 0 -m 2 --func-basis "wb97m-v/def2-tzvpd" \
 - Console pretty block summarising charge, multiplicity, spin (2S), functional, basis, convergence knobs, and resolved output directory.
 
 ## Notes
-- GPU4PySCF is used whenever available; CPU PySCF is built otherwise (unless `--engine cpu` forces CPU). `--engine auto` mirrors the CLI docstring behaviour (GPU attempt, then CPU).
+- GPU4PySCF is used whenever available; CPU PySCF is built otherwise (unless `--engine cpu` forces CPU). `--engine auto` mirrors the CLI docstring behaviour (GPU attempt, then CPU). **Meta-GGA functionals (e.g., `wb97m-v`, `scan`, `m06-2x`) are forced onto the CPU backend to avoid GPU4PySCF symbol errors such as `work_mgga` missing.**
 - Density fitting is always attempted; auxiliary bases are auto-selected for def2/cc-pVXZ/Pople families and silently skipped when unsupported.
 - The YAML file must contain a mapping root with top-level key `dft`; non-mapping roots raise an error via `load_yaml_dict`.
 - Exit codes: `0` (converged), `3` (not converged), `2` (PySCF import failure), `1` (other errors), `130` (interrupt).

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -545,6 +545,26 @@ def cli(
         using_gpu = False
         engine_label = "pyscf(cpu)"
         make_ks = (lambda mod: mod.RKS(mol) if spin2s == 0 else mod.UKS(mol))
+
+        # Guard against GPU4PySCF meta-GGA support gaps (e.g., "work_mgga" symbol errors)
+        is_meta_gga = False
+        try:
+            from pyscf.dft import libxc as pyscf_libxc
+
+            is_meta_gga = bool(pyscf_libxc.is_meta_gga(xc))
+        except Exception as xc_exc:
+            click.echo(
+                f"[gpu] WARNING: Could not classify functional '{xc}' for GPU compatibility ({xc_exc}); proceeding.",
+                err=True,
+            )
+
+        if is_meta_gga and engine in ("gpu", "auto"):
+            click.echo(
+                f"[gpu] INFO: meta-GGA functional '{xc}' detected; forcing CPU backend to avoid unsupported GPU kernels.",
+                err=True,
+            )
+            engine = "cpu"
+
         if engine in ("gpu", "auto"):
             try:
                 from gpu4pyscf import dft as gdf


### PR DESCRIPTION
## Summary
- detect meta-GGA functionals and force CPU PySCF to avoid GPU4PySCF missing symbol errors
- update DFT documentation to describe the meta-GGA CPU fallback

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69292d9f4c50832dacac6dee763829dd)