### PR TITLE
Add trj2fig plotting for DMF segments

### DIFF
--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -775,6 +775,12 @@ def _run_dmf_between(
     _write_ase_trj_with_energy(dmf_res.images, energies, final_trj)
     _maybe_convert_to_pdb(final_trj, ref_pdb_path)
 
+    try:
+        run_trj2fig(final_trj, [seg_dir / "mep_plot.png"], unit="kcal", reference="init", reverse_x=False)
+        click.echo(f"[{tag}] Saved energy plot → '{seg_dir / 'mep_plot.png'}'")
+    except Exception as e:
+        click.echo(f"[{tag}] WARNING: Failed to plot energy: {e}", err=True)
+
     imgs: List[Any] = []
     for atoms in dmf_res.images:
         imgs.append(


### PR DESCRIPTION
## Summary
- generate segment energy plots with trj2fig when running DMF-based MEP searches, matching GSM behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692941279648832dac7c1d880efaef29)