### PR TITLE
Document summary.log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ to build UMA, Gibbs, DFT, and DFT//UMA diagrams. This TSOPT-only pocket mode sti
 Single-input runs require either `--scan-lists` (staged scan feeding GSM) or `--tsopt True` (TSOPT-only mode). Refer to
 [`docs/all.md`](docs/all.md) for a full option matrix, YAML schemas, and output details.
 
+### Run summaries (`summary.log`)
+
+Every `pdb2reaction all` run writes a human-readable `summary.log` to the top-level `--outdir` (and to each `path_search`
+segment directory). The log mirrors the machine-friendly `summary.yaml` but is formatted for quick inspection: it records the
+invoked CLI, global MEP statistics, per-segment barriers and bond changes, post-processing energies (UMA/thermo/DFT), and a
+cheat sheet of key output files.
+
 ### CLI subcommands
 
 | Subcommand | Summary | Documentation |

--- a/docs/all.md
+++ b/docs/all.md
@@ -123,6 +123,8 @@ pdb2reaction all -i reactant.pdb -c "GPP,MMT" \
 | `--scan-endopt BOOLEAN` | Override the scan end-of-stage optimisation toggle. | _None_ |
 
 ## Outputs
+- `<out-dir>/summary.log`: Human-readable run digest (CLI invocation, MEP/segment stats, post-processing energies, key files);
+  also stored per GSM/TSOPT branch in `<out-dir>/path_search/*/summary.log`.
 - `<out-dir>/pockets/`: Per-input pocket PDBs when extraction runs.
 - `<out-dir>/scan/`: Present when `--scan-lists` is used; contains staged pocket scan results (`stage_XX/result.pdb`).
 - `<out-dir>/path_search/`: GSM results (trajectory, merged full-system PDBs, energy diagrams, `summary.yaml`, per-segment folders).


### PR DESCRIPTION
## Summary
- add README section describing summary.log run summaries
- document summary.log output path and contents in all command docs

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ac216efcc832dbc4642cad0f177b6)