### PR TITLE
Remove output cheat sheet from summary.log

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,7 @@ Single-input runs require either `--scan-lists` (staged scan feeding GSM) or `--
 
 Every `pdb2reaction all` run writes a human-readable `summary.log` to the top-level `--outdir` (and to each `path_search`
 segment directory). The log mirrors the machine-friendly `summary.yaml` but is formatted for quick inspection: it records the
-invoked CLI, global MEP statistics, per-segment barriers and bond changes, post-processing energies (UMA/thermo/DFT), and a
-cheat sheet of key output files.
+invoked CLI, global MEP statistics, per-segment barriers and bond changes, and post-processing energies (UMA/thermo/DFT).
 
 ### CLI subcommands
 

--- a/pdb2reaction/summary_log.py
+++ b/pdb2reaction/summary_log.py
@@ -453,23 +453,5 @@ def write_summary_log(dest: Path, payload: Dict[str, Any]) -> None:
             diag_payload = diag_by_method.get(method)
             lines.append(_format_diag_row(diag_payload, label, col_width, state_order))
 
-    lines.append("")
-    lines.append("[5] Output directories / key files (cheat sheet)")
-    lines.append(f"  Root out_dir : {root_out}")
-    if payload.get("path_dir"):
-        lines.append(
-            f"  Path outputs : {_shorten_path(payload.get('path_dir'), root_out_path)}"
-        )
-    key_files: Dict[str, Any] = payload.get("key_files", {}) or {}
-    if key_files:
-        lines.append("  Key files (root):")
-        for name, desc in key_files.items():
-            value = (
-                _shorten_path(desc, root_out_path)
-                if isinstance(desc, (str, Path))
-                else desc
-            )
-            lines.append(f"    {name:<18}: {value}")
-
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_text("\n".join(lines) + "\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- remove the output directory/key file cheat sheet section from generated summary.log files
- update README to describe the streamlined summary.log content

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b044ff77c832dbb70e0271db6abc6)