### PR TITLE
Copy path outputs summary log to root output

### DIFF
--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -3145,6 +3145,7 @@ def cli(
                 "mep.pdb",
                 "mep_w_ref.pdb",
                 "summary.yaml",
+                "summary.log",
             ):
                 src = path_dir / name
                 if src.exists():
@@ -3281,6 +3282,7 @@ def cli(
                 "mep.pdb",
                 "mep_w_ref.pdb",
                 "summary.yaml",
+                "summary.log",
             ):
                 src = path_dir / name
                 if src.exists():


### PR DESCRIPTION
## Summary
- copy summary.log files from path-search/path-opt outputs into the root results directory
- ensure root outputs match other workflows even when post-processing is skipped

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b29bd727c832da306c8e7782b6d30)