### PR TITLE
Log freeze atoms in summary header

### DIFF
--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -627,6 +627,19 @@ def _get_freeze_atoms(pdb_path: Optional[Path], freeze_links_flag: bool) -> List
     return _FREEZE_ATOMS_GLOBAL
 
 
+def _freeze_atoms_for_log(freeze_links_flag: bool) -> List[int]:
+    if not freeze_links_flag:
+        return []
+
+    if _FREEZE_ATOMS_GLOBAL is not None:
+        try:
+            return sorted({int(i) for i in _FREEZE_ATOMS_GLOBAL})
+        except Exception:
+            return []
+
+    return []
+
+
 # ---------- Post-processing helpers ----------
 
 
@@ -2689,6 +2702,7 @@ def cli(
                     "command": command_str,
                     "charge": q_int,
                     "spin": spin,
+                    "freeze_atoms": _freeze_atoms_for_log(freeze_links_flag),
                     "mep": {"n_images": n_images, "n_segments": 1},
                     "segments": summary.get("segments", []),
                     "energy_diagrams": summary.get("energy_diagrams", []),
@@ -3222,6 +3236,7 @@ def cli(
                 "command": command_str,
                 "charge": q_int,
                 "spin": spin,
+                "freeze_atoms": _freeze_atoms_for_log(freeze_links_flag),
                 "mep": mep_info,
                 "segments": summary.get("segments", []),
                 "energy_diagrams": summary.get("energy_diagrams", []),
@@ -3401,6 +3416,7 @@ def cli(
                 "command": command_str,
                 "charge": q_int,
                 "spin": spin,
+                "freeze_atoms": _freeze_atoms_for_log(freeze_links_flag),
                 "mep": mep_info,
                 "segments": summary.get("segments", []),
                 "energy_diagrams": summary.get("energy_diagrams", []),

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -2508,6 +2508,18 @@ def cli(
                 "mep_plot": str(out_dir_path / "mep_plot.png") if (out_dir_path / "mep_plot.png").exists() else None,
                 "diagram": diag_for_log,
             }
+            freeze_for_log: List[int] = []
+            try:
+                freeze_for_log = sorted(
+                    {
+                        int(idx)
+                        for g in geoms
+                        for idx in getattr(g, "freeze_atoms", []) or []
+                    }
+                )
+            except Exception:
+                freeze_for_log = []
+
             summary_payload = {
                 "root_out_dir": str(out_dir_path),
                 "path_dir": str(out_dir_path),
@@ -2523,6 +2535,7 @@ def cli(
                 "command": command_str,
                 "charge": calc_cfg.get("charge"),
                 "spin": calc_cfg.get("spin"),
+                "freeze_atoms": freeze_for_log,
                 "mep": mep_info,
                 "segments": summary.get("segments", []),
                 "energy_diagrams": summary.get("energy_diagrams", []),

--- a/pdb2reaction/summary_log.py
+++ b/pdb2reaction/summary_log.py
@@ -25,6 +25,19 @@ def _fmt_bool(val: Optional[Any]) -> str:
 
 
 
+def _format_freeze_atoms(indices: Optional[Iterable[Any]]) -> str:
+    if indices is None:
+        return "-"
+
+    try:
+        normalized = sorted({int(i) for i in indices})
+    except Exception:
+        return "-"
+
+    return f"[{','.join(map(str, normalized))}]" if normalized else "[]"
+
+
+
 def _shorten_path(path: Optional[Path], root_out: Optional[Path]) -> str:
     """Return a User-friendly path string relative to ``root_out`` when possible."""
 
@@ -284,6 +297,9 @@ def write_summary_log(dest: Path, payload: Dict[str, Any]) -> None:
     lines.append(f"UMA model          : {uma_model}")
     lines.append(f"Total charge (ML)  : {charge if charge is not None else '-'}")
     lines.append(f"Multiplicity (2S+1): {spin if spin is not None else '-'}")
+    lines.append(
+        f"Freeze atoms (0-based): {_format_freeze_atoms(payload.get('freeze_atoms'))}"
+    )
     lines.append("")
 
     mep = payload.get("mep", {}) or {}


### PR DESCRIPTION
## Summary
- add freeze atom list formatting to summary.log header for visibility
- propagate freeze atom indices from path_search and all pipelines into summary payloads

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d49b6a038832d945017e135641988)