### PR TITLE
Ensure path-opt honors opt mode when refine-path disabled

### DIFF
--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -2946,6 +2946,8 @@ def cli(
                 str(int(max_cycles)),
                 "--climb",
                 "True" if climb else "False",
+                "--opt-mode",
+                str(opt_mode),
                 "--dump",
                 "True" if dump else "False",
                 "--out-dir",


### PR DESCRIPTION
## Summary
- forward the user-selected `--opt-mode` to path-opt when refine-path is disabled so light mode stays on LBFGS

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d7e0f57d4832d940fd6265975de70)