### PR TITLE
Align opt documentation with current defaults

### DIFF
--- a/docs/opt.md
+++ b/docs/opt.md
@@ -1,7 +1,7 @@
 # `opt` subcommand
 
 ## Overview
-`pdb2reaction opt` performs a single-structure geometry optimization with the pysisyphus LBFGS ("light") or RFOptimizer ("heavy") engines while UMA provides energies, gradients, and Hessians. Input structures can be `.pdb`, `.xyz`, `.trj`, or any format supported by `geom_loader`. The command applies settings in the priority order **CLI > `--args-yaml` > built-in defaults**, making it easy to keep heavyweight defaults while selectively overriding options. The optimizer preset now defaults to the RFO-based **`heavy`** mode.
+`pdb2reaction opt` performs a single-structure geometry optimization with the pysisyphus LBFGS ("light") or RFOptimizer ("heavy") engines while UMA provides energies, gradients, and Hessians. Input structures can be `.pdb`, `.xyz`, `.trj`, or any format supported by `geom_loader`. Settings are applied in the order **built-in defaults → CLI overrides → `--args-yaml` overrides** (YAML has the highest precedence), making it easy to keep heavyweight defaults while selectively overriding options. The optimizer preset now defaults to the RFO-based **`heavy`** mode.
 
 When the starting structure is a PDB or Gaussian template, format-aware conversion mirrors outputs into `.pdb` or multi-geometry `.gjf` companions, controlled by `--convert-files/--no-convert-files` (enabled by default). PDB-specific conveniences include:
 - With `--freeze-links` (default `True`), parent atoms of link hydrogens are detected and merged into `geom.freeze_atoms` (0-based indices).
@@ -72,7 +72,7 @@ YAML values override CLI, which override the defaults below.
 ### `opt`
 Shared optimizer controls used by both LBFGS and RFO:
 - `thresh` presets (Gaussian-like or Baker rule). Presets translate to the force/step thresholds documented in `pdb2reaction/opt.py`.
-- `max_cycles`, `print_every` (`10`), `min_step_norm` (`1e-8`), `assert_min_step`, convergence toggles (`rms_force`, etc.), RMSD-based `converge_to_geom_rms_thresh`, `overachieve_factor`, `check_eigval_structure`, `line_search`.
+- `max_cycles`, `print_every` (`100`), `min_step_norm` (`1e-8`), `assert_min_step`, convergence toggles (`rms_force`, etc.), RMSD-based `converge_to_geom_rms_thresh`, `overachieve_factor`, `check_eigval_structure`, `line_search`.
 - Dumping/bookkeeping fields (`dump`, `dump_restart`, `prefix`, `out_dir`).
 
 ### `lbfgs`
@@ -102,7 +102,7 @@ calc:
 opt:
   thresh: gau
   max_cycles: 10000
-  print_every: 10
+  print_every: 100
   min_step_norm: 1.0e-08
   assert_min_step: true
   rms_force: null
@@ -120,7 +120,7 @@ opt:
 lbfgs:
   thresh: gau
   max_cycles: 10000
-  print_every: 10
+  print_every: 100
   min_step_norm: 1.0e-08
   assert_min_step: true
   rms_force: null
@@ -161,23 +161,23 @@ rfo:
   dump_restart: false
   prefix: ""
   out_dir: ./result_opt/
-  trust_radius: 0.3
+  trust_radius: 0.1
   trust_update: true
-  trust_min: 0.01
-  trust_max: 0.3
+  trust_min: 0.0
+  trust_max: 0.1
   max_energy_incr: null
   hessian_update: bfgs
   hessian_init: calc
-  hessian_recalc: 100
-  hessian_recalc_adapt: 2.0
+  hessian_recalc: 200
+  hessian_recalc_adapt: null
   small_eigval_thresh: 1.0e-08
   alpha0: 1.0
-  max_micro_cycles: 25
+  max_micro_cycles: 50
   rfo_overlaps: false
   gediis: false
   gdiis: true
   gdiis_thresh: 0.0025
   gediis_thresh: 0.01
   gdiis_test_direction: true
-  adapt_step_func: false
+  adapt_step_func: true
 ```

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -10,7 +10,8 @@ Usage (CLI)
         [--opt-mode {light|heavy}] [--freeze-links {True|False}] \
         [--dist-freeze "[(I,J,TARGET_A), ...]"] [--one-based|--zero-based] \
         [--bias-k <float>] [--dump {True|False}] [--out-dir <dir>] \
-        [--max-cycles <int>] [--thresh <preset>] [--args-yaml <file>]
+        [--max-cycles <int>] [--thresh <preset>] [--args-yaml <file>] \
+        [--convert-files | --no-convert-files]
 
 Examples
 --------
@@ -26,9 +27,11 @@ Description
 - Single-structure geometry optimization using pysisyphus with a UMA calculator.
 - Input formats: .pdb, .xyz, .trj, etc., via pysisyphus `geom_loader`.
 - Optimizers: LBFGS ("light") or RFOptimizer ("heavy", default).
-- Configuration via YAML sections `geom`, `calc`, `opt`, `lbfgs`, `rfo`. **Precedence:** YAML > CLI > built-in defaults.
+- Configuration via YAML sections `geom`, `calc`, `opt`, `lbfgs`, `rfo`. **Precedence:** defaults → CLI overrides → YAML overrides (highest).
 - PDB-aware post-processing: if the input is a PDB, convert `final_geometry.xyz` → `final_geometry.pdb` and, when
   `--dump True`, `optimization.trj` → `optimization.pdb` using the input PDB as the topology reference.
+- Format mirroring can be toggled with `--convert-files/--no-convert-files` (default: enabled); when a Gaussian template
+  is present, `.gjf` companions are emitted alongside `.xyz` and `.pdb` outputs.
 - Optional link-atom handling for PDBs: `--freeze-links True` (default) detects link hydrogen parents and freezes those
   (0‑based indices), merged with any `geom.freeze_atoms`.
 - Harmonic restraints: `--dist-freeze` accepts (i, j, target Å) tuples to apply harmonic wells during optimization.
@@ -65,20 +68,20 @@ Key options (YAML keys → meaning; defaults)
 - LBFGS-specific (`lbfgs`, used when `--opt-mode light|lbfgs`):
   - Memory: `keep_last` 7.
   - Scaling: `beta` 1.0; `gamma_mult` False.
-  - Step control: `max_step` 0.10; `control_step` True.
+  - Step control: `max_step` 0.30; `control_step` True.
   - Safeguards: `double_damp` True.
   - Regularized L‑BFGS: `mu_reg`; `max_mu_reg_adaptions` 10.
 
 - RFO-specific (`rfo`, used when `--opt-mode heavy|rfo`):
-  - Trust region: `trust_radius` 0.10; `trust_update` True; bounds: `trust_min` 0.01, `trust_max` 0.10;
+  - Trust region: `trust_radius` 0.10; `trust_update` True; bounds: `trust_min` 0.00, `trust_max` 0.10;
     `max_energy_incr` Optional[float].
   - Hessian: `hessian_update` "bfgs" | "bofill"; `hessian_init` "calc"; `hessian_recalc` 200;
-    `hessian_recalc_adapt` 2.0.
+    `hessian_recalc_adapt` None.
   - Numerics: `small_eigval_thresh` 1e-8.
-  - RFO/RS micro-iterations: `alpha0` 1.0; `max_micro_cycles` 25; `rfo_overlaps` False.
+  - RFO/RS micro-iterations: `alpha0` 1.0; `max_micro_cycles` 50; `rfo_overlaps` False.
   - DIIS helpers: `gdiis` True; `gediis` False; `gdiis_thresh` 2.5e-3 (vs RMS(step)); `gediis_thresh` 1.0e-2
     (vs RMS(force)); `gdiis_test_direction` True.
-  - Step model: `adapt_step_func` False.
+  - Step model: `adapt_step_func` True.
 
 Outputs (& Directory Layout)
 ----------------------------


### PR DESCRIPTION
## Summary
- update the opt module docstring to reflect current CLI switches and optimizer defaults
- refresh the opt command documentation to match the script’s precedence rules and default parameters

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dda0ff0e0832da49385057cdd0902)