### PR TITLE
Update path-search documentation defaults

### DIFF
--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -37,7 +37,7 @@ pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--multiplicity 2S
 | `--max-nodes INT` | Internal nodes for GSM segments (`String` has `max_nodes + 2` images). | `10` |
 | `--max-cycles INT` | Maximum GSM optimization cycles. | `300` |
 | `--climb BOOL` | Explicit `True`/`False`. Enable climbing image for the first segment in each pair. | `True` |
-| `--opt-mode TEXT` | Single-structure optimizer for HEI±1/kink nodes. `light` maps to LBFGS; `heavy` maps to RFO. | `heavy` |
+| `--opt-mode TEXT` | Single-structure optimizer for HEI±1/kink nodes. `light` maps to LBFGS; `heavy` maps to RFO. | `light` |
 | `--mep-mode {gsm\|dmf}` | Segment generator: GSM (string-based) or DMF (direct flux). | `dmf` |
 | `--dump BOOL` | Explicit `True`/`False`. Dump GSM and single-structure trajectories/restarts. | `False` |
 | `--convert-files/--no-convert-files` | Toggle XYZ/TRJ → PDB/GJF companions for PDB or Gaussian inputs. | `--convert-files` |

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -10,6 +10,7 @@ Usage (CLI)
                             [--mep-mode {gsm|dmf}] [--freeze-links BOOL] [--thresh PRESET]
                             [--max-nodes N] [--max-cycles N] [--climb BOOL]
                             [--opt-mode light|heavy] [--dump BOOL]
+                            [--convert-files/--no-convert-files]
                             [--out-dir DIR] [--preopt BOOL]
                             [--align/--no-align] [--ref-pdb FILE ...]
                             [--args-yaml FILE]
@@ -26,9 +27,9 @@ Recommended/common:
         Spin multiplicity (2S+1); defaults to a .gjf template value when available,
         otherwise 1 when omitted.
     --opt-mode
-        Single-structure optimizer: light (=LBFGS) or heavy (=RFO); default heavy.
+        Single-structure optimizer: light (=LBFGS) or heavy (=RFO); default light.
     --mep-mode
-        Segment generator: GSM (string) or DMF (direct max flux); default gsm.
+        Segment generator: GSM (string) or DMF (direct max flux); default dmf.
     --max-nodes
         Internal nodes for segment GSM; default 10.
     --max-cycles
@@ -50,6 +51,8 @@ Recommended/common:
         Output directory; default ./result_path_search/
     --dump {True|False}
         Save optimizer dumps; default False.
+    --convert-files/--no-convert-files
+        Convert XYZ/TRJ outputs into format-aware PDB/GJF companions; default on.
     --freeze-links {True|False}
         Freeze parents of link hydrogens for PDB input; default True.
 


### PR DESCRIPTION
## Summary
- align the path-search module docstring with current CLI defaults including dmf default, light optimizer default, and convert-files flag
- correct the path-search markdown documentation to list the light optimizer default

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dda0ff0e0832da49385057cdd0902)