### PR TITLE
Set GSM and Baker as CLI defaults

### DIFF
--- a/docs/all.md
+++ b/docs/all.md
@@ -212,7 +212,7 @@ opt:
   print_every: 10
 sopt:
   lbfgs:
-    thresh: gau
+    thresh: baker
     max_cycles: 10000
     print_every: 100
     min_step_norm: 1.0e-08
@@ -238,7 +238,7 @@ sopt:
     mu_reg: null
     max_mu_reg_adaptions: 10
   rfo:
-    thresh: gau
+    thresh: baker
     max_cycles: 10000
     print_every: 100
     min_step_norm: 1.0e-08

--- a/docs/opt.md
+++ b/docs/opt.md
@@ -42,7 +42,7 @@ pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} -q CHARGE -m MULT \
 | `--dump BOOL` | Emit trajectory dumps (`optimization.trj`). | `False` |
 | `--convert-files/--no-convert-files` | Enable or disable XYZ/TRJ → PDB/GJF companions for inputs with PDB/Gaussian templates. | `--convert-files` |
 | `--out-dir TEXT` | Output directory for all files. | `./result_opt/` |
-| `--thresh TEXT` | Override convergence preset (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | YAML/default |
+| `--thresh TEXT` | Override convergence preset (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | `baker` |
 | `--args-yaml FILE` | Supply YAML overrides (sections `geom`, `calc`, `opt`, `lbfgs`, `rfo`). | _None_ |
 
 ## Outputs
@@ -100,7 +100,7 @@ calc:
   hessian_calc_mode: Analytical
   return_partial_hessian: true
 opt:
-  thresh: gau
+  thresh: baker
   max_cycles: 10000
   print_every: 100
   min_step_norm: 1.0e-08
@@ -118,7 +118,7 @@ opt:
   prefix: ""
   out_dir: ./result_opt/
 lbfgs:
-  thresh: gau
+  thresh: baker
   max_cycles: 10000
   print_every: 100
   min_step_norm: 1.0e-08
@@ -144,7 +144,7 @@ lbfgs:
   mu_reg: null
   max_mu_reg_adaptions: 10
 rfo:
-  thresh: gau
+  thresh: baker
   max_cycles: 10000
   print_every: 10
   min_step_norm: 1.0e-08

--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -1,7 +1,7 @@
 # `path-opt` subcommand
 
 ## Overview
-`pdb2reaction path-opt` searches for a minimum-energy path (MEP) between two endpoint structures using pysisyphus' Growing String method (GSM) or Direct Max Flux (DMF) selected via `--mep-mode`. UMA supplies energies/gradients/Hessians for every image, while an external rigid-body alignment routine keeps the string well behaved before the optimizer begins. Configuration follows the precedence **CLI > `--args-yaml` > defaults** across the `geom`, `calc`, `gs`, and `opt` sections. When `--convert-files` is enabled (default), outputs are mirrored to `.pdb` or multi-geometry `.gjf` companions when the endpoints originate from PDBs or Gaussian templates. DMF is the default path generator, and single-structure optimizations default to the `light` (LBFGS) preset.
+`pdb2reaction path-opt` searches for a minimum-energy path (MEP) between two endpoint structures using pysisyphus' Growing String method (GSM) or Direct Max Flux (DMF) selected via `--mep-mode`. UMA supplies energies/gradients/Hessians for every image, while an external rigid-body alignment routine keeps the string well behaved before the optimizer begins. Configuration follows the precedence **CLI > `--args-yaml` > defaults** across the `geom`, `calc`, `gs`, and `opt` sections. When `--convert-files` is enabled (default), outputs are mirrored to `.pdb` or multi-geometry `.gjf` companions when the endpoints originate from PDBs or Gaussian templates. GSM is the default path generator, and single-structure optimizations default to the `light` (LBFGS) preset.
 
 ## Usage
 ```bash
@@ -37,14 +37,14 @@ pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} -q CHARGE -m MULT 
 | `-m, --multiplicity INT` | Spin multiplicity (`calc.spin`). | Template/`1` |
 | `--freeze-links BOOL` | PDB-only: freeze link-H parents (merged with YAML). | `True` |
 | `--max-nodes INT` | Number of internal nodes (string images = `max_nodes + 2`). | `10` |
-| `--mep-mode {gsm\|dmf}` | Select GSM (string-based) or DMF (direct flux) path generator. | `dmf` |
+| `--mep-mode {gsm\|dmf}` | Select GSM (string-based) or DMF (direct flux) path generator. | `gsm` |
 | `--max-cycles INT` | Optimizer macro-iteration cap (`opt.max_cycles`). | `300` |
 | `--climb BOOL` | Enable climbing-image refinement (and Lanczos tangent). | `True` |
 | `--dump BOOL` | Dump GSM trajectories/restarts. | `False` |
 | `--opt-mode TEXT` | Single-structure optimizer for endpoint preoptimization (`light` = LBFGS, `heavy` = RFO). | `light` |
 | `--convert-files/--no-convert-files` | Toggle XYZ/TRJ → PDB/GJF companions for PDB/Gaussian inputs. | `--convert-files` |
 | `--out-dir TEXT` | Output directory. | `./result_path_opt/` |
-| `--thresh TEXT` | Override convergence preset for GSM/string optimizer. | YAML/default |
+| `--thresh TEXT` | Override convergence preset for GSM/string optimizer. | `baker` |
 | `--args-yaml FILE` | YAML overrides (sections `geom`, `calc`, `gs`, `opt`). | _None_ |
 | `--preopt BOOL` | Pre-optimise each endpoint with the selected single-structure optimizer before alignment/GSM. | `False` |
 | `--preopt-max-cycles INT` | Cap for endpoint preoptimization cycles. | `10000` |

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -1,7 +1,7 @@
 # `path-search` subcommand
 
 ## Overview
-Construct a continuous minimum-energy path (MEP) across **two or more** structures ordered along a reaction coordinate. `path-search` chains together Growing String Method (GSM) segments, selectively refines only those regions with covalent changes, and (optionally) merges PDB pockets back into full-size templates. With `--mep-mode dmf`, the same recursive workflow runs using DMF-generated segments instead of GSM, and **DMF is now the default**. Format-aware conversions mirror trajectories and HEI snapshots into `.pdb` or multi-geometry `.gjf` companions when `--convert-files` is enabled (default) and matching templates exist.
+Construct a continuous minimum-energy path (MEP) across **two or more** structures ordered along a reaction coordinate. `path-search` chains together Growing String Method (GSM) segments, selectively refines only those regions with covalent changes, and (optionally) merges PDB pockets back into full-size templates. With `--mep-mode dmf`, the same recursive workflow runs using DMF-generated segments instead of GSM, and **GSM is now the default**. Format-aware conversions mirror trajectories and HEI snapshots into `.pdb` or multi-geometry `.gjf` companions when `--convert-files` is enabled (default) and matching templates exist.
 
 ## Usage
 ```bash
@@ -38,11 +38,11 @@ pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--multiplicity 2S
 | `--max-cycles INT` | Maximum GSM optimization cycles. | `300` |
 | `--climb BOOL` | Explicit `True`/`False`. Enable climbing image for the first segment in each pair. | `True` |
 | `--opt-mode TEXT` | Single-structure optimizer for HEI±1/kink nodes. `light` maps to LBFGS; `heavy` maps to RFO. | `light` |
-| `--mep-mode {gsm\|dmf}` | Segment generator: GSM (string-based) or DMF (direct flux). | `dmf` |
+| `--mep-mode {gsm\|dmf}` | Segment generator: GSM (string-based) or DMF (direct flux). | `gsm` |
 | `--dump BOOL` | Explicit `True`/`False`. Dump GSM and single-structure trajectories/restarts. | `False` |
 | `--convert-files/--no-convert-files` | Toggle XYZ/TRJ → PDB/GJF companions for PDB or Gaussian inputs. | `--convert-files` |
 | `--out-dir TEXT` | Output directory. | `./result_path_search/` |
-| `--thresh TEXT` | Override convergence preset for GSM and per-image optimizations (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | _None_ (use YAML/default) |
+| `--thresh TEXT` | Override convergence preset for GSM and per-image optimizations (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | `baker` |
 | `--args-yaml FILE` | YAML overrides (see below). | _None_ |
 | `--preopt BOOL` | Explicit `True`/`False`. Pre-optimise each endpoint before GSM (recommended). | `True` |
 | `--align / --no-align` | Flag toggle. Align all inputs to the first structure before searching. | `--align` |
@@ -166,7 +166,7 @@ dmf:
   k_fix: 100.0
 sopt:
   lbfgs:
-    thresh: gau
+    thresh: baker
     max_cycles: 10000
     print_every: 100
     min_step_norm: 1.0e-08
@@ -192,7 +192,7 @@ sopt:
     mu_reg: null
     max_mu_reg_adaptions: 10
   rfo:
-    thresh: gau
+    thresh: baker
     max_cycles: 10000
     print_every: 100
     min_step_norm: 1.0e-08

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -63,7 +63,7 @@ pdb2reaction scan -i input.pdb -q 0 \
 | `--dump BOOL` | Dump concatenated biased trajectories (`scan.trj`/`scan.pdb`). | `False` |
 | `--convert-files/--no-convert-files` | Toggle XYZ/TRJ → PDB/GJF companions for PDB/Gaussian inputs. | `--convert-files` |
 | `--out-dir TEXT` | Output directory root. | `./result_scan/` |
-| `--thresh TEXT` | Convergence preset override (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | Inherit YAML |
+| `--thresh TEXT` | Convergence preset override (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | `baker` |
 | `--args-yaml FILE` | YAML overrides for `geom`, `calc`, `opt`, `lbfgs`, `rfo`, `bias`, `bond`. | _None_ |
 | `--preopt BOOL` | Run an unbiased optimization before scanning. | `True` |
 | `--endopt BOOL` | Run an unbiased optimization after each stage. | `True` |
@@ -129,7 +129,7 @@ calc:
   hessian_calc_mode: Analytical
   return_partial_hessian: true
 opt:
-  thresh: gau
+  thresh: baker
   max_cycles: 10000
   print_every: 100
   min_step_norm: 1.0e-08
@@ -147,7 +147,7 @@ opt:
   prefix: ""
   out_dir: ./result_scan/
 lbfgs:
-  thresh: gau
+  thresh: baker
   max_cycles: 10000
   print_every: 100
   min_step_norm: 1.0e-08
@@ -173,7 +173,7 @@ lbfgs:
   mu_reg: null
   max_mu_reg_adaptions: 10
 rfo:
-  thresh: gau
+  thresh: baker
   max_cycles: 10000
   print_every: 100
   min_step_norm: 1.0e-08

--- a/docs/scan2d.md
+++ b/docs/scan2d.md
@@ -65,7 +65,7 @@ pdb2reaction scan2d -i input.pdb -q 0 \
 | `--dump BOOL` | Write `inner_path_d1_###.trj` for each outer step. | `False` |
 | `--convert-files/--no-convert-files` | Toggle XYZ/TRJ → PDB/GJF companions for PDB/Gaussian inputs. | `--convert-files` |
 | `--out-dir TEXT` | Output directory root for grids and plots. | `./result_scan2d/` |
-| `--thresh TEXT` | Convergence preset override (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | Inherit YAML |
+| `--thresh TEXT` | Convergence preset override (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | `baker` |
 | `--args-yaml FILE` | YAML overrides for `geom`, `calc`, `opt`, `lbfgs`, `rfo`, `bias`. | _None_ |
 | `--preopt BOOL` | Run an unbiased optimization before scanning. | `True` |
 | `--baseline {min,first}` | Shift kcal/mol energies so the global min or first grid point is zero. | `min` |
@@ -111,7 +111,7 @@ calc:
   model: uma-s-1p1
   device: auto
 opt:
-  thresh: gau
+  thresh: baker
   max_cycles: 10000
   out_dir: ./result_scan2d/
 lbfgs:

--- a/docs/scan3d.md
+++ b/docs/scan3d.md
@@ -74,7 +74,7 @@ pdb2reaction scan3d -i input.pdb -q 0 \
 | `--convert-files/--no-convert-files` | Toggle XYZ/TRJ → PDB/GJF companions for PDB/Gaussian inputs. | `--convert-files` |
 | `--out-dir TEXT` | Output directory root for grids and plots. | `./result_scan3d/` |
 | `--csv PATH` | Load an existing `surface.csv` and only plot it (no new scan). | _None_ |
-| `--thresh TEXT` | Convergence preset override (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | Inherit YAML |
+| `--thresh TEXT` | Convergence preset override (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | `baker` |
 | `--args-yaml FILE` | YAML overrides for `geom`, `calc`, `opt`, `lbfgs`, `rfo`, `bias`. | _None_ |
 | `--preopt BOOL` | Run an unbiased optimization before scanning. | `True` |
 | `--baseline {min,first}` | Shift kcal/mol energies so the global min or `(i,j,k)=(0,0,0)` is zero. | `min` |

--- a/docs/tsopt.md
+++ b/docs/tsopt.md
@@ -79,7 +79,7 @@ pdb2reaction tsopt -i ts_cand.pdb -q 0 -m 1 --opt-mode heavy \
 | `--opt-mode TEXT` | Light/Heavy aliases listed above. | `heavy` |
 | `--dump BOOL` | Explicit `True`/`False`. Dump trajectories. | `False` |
 | `--out-dir TEXT` | Output directory. | `./result_tsopt/` |
-| `--thresh TEXT` | Override convergence preset (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | _None_ (use YAML/default) |
+| `--thresh TEXT` | Override convergence preset (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | `baker` |
 | `--hessian-calc-mode CHOICE` | UMA Hessian mode (`Analytical` or `FiniteDifference`). | _None_ (use YAML/default) |
 | `--convert-files/--no-convert-files` | Toggle XYZ/TRJ → PDB/GJF companions for PDB or Gaussian inputs. | `--convert-files` |
 | `--args-yaml FILE` | YAML overrides (`geom`, `calc`, `opt`, `hessian_dimer`, `rsirfo`). | _None_ |
@@ -132,7 +132,7 @@ calc:
   hessian_calc_mode: Analytical
   return_partial_hessian: true
 opt:
-  thresh: gau
+  thresh: baker
   max_cycles: 10000
   print_every: 100
   min_step_norm: 1.0e-08
@@ -151,7 +151,7 @@ opt:
   out_dir: ./result_tsopt/
 hessian_dimer:
   thresh_loose: gau_loose
-  thresh: gau
+  thresh: baker
   update_interval_hessian: 1000
   neg_freq_thresh_cm: 5.0
   flatten_amp_ang: 0.1
@@ -181,7 +181,7 @@ hessian_dimer:
     write_orientations: true
     forward_hessian: true
   lbfgs:
-    thresh: gau
+    thresh: baker
     max_cycles: 10000
     print_every: 100
     min_step_norm: 1.0e-08
@@ -207,7 +207,7 @@ hessian_dimer:
     mu_reg: null
     max_mu_reg_adaptions: 10
 rsirfo:
-  thresh: gau
+  thresh: baker
   max_cycles: 10000
   print_every: 100
   min_step_norm: 1.0e-08

--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -1711,7 +1711,7 @@ def _irc_and_match(
 @click.option(
     "--mep-mode",
     type=click.Choice(["gsm", "dmf"], case_sensitive=False),
-    default="dmf",
+    default="gsm",
     show_default=True,
     help="MEP optimizer: Growing String Method (gsm) or Direct Max Flux (dmf).",
 )
@@ -1777,7 +1777,8 @@ def _irc_and_match(
 @click.option(
     "--thresh",
     type=str,
-    default=None,
+    default="baker",
+    show_default=True,
     help="Convergence preset (gau_loose|gau|gau_tight|gau_vtight|baker|never).",
 )
 @click.option(

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -168,7 +168,7 @@ CALC_KW = dict(_UMA_CALC_KW)
 # Optimizer base (common to LBFGS & RFO)  (YAML key: opt)
 OPT_BASE_KW = {
     # Convergence threshold preset
-    "thresh": "gau",             # "gau_loose" | "gau" | "gau_tight" | "gau_vtight" | "baker" | "never"
+    "thresh": "baker",          # "gau_loose" | "gau" | "gau_tight" | "gau_vtight" | "baker" | "never"
 
     # Convergence criteria (forces in Hartree/bohr, steps in bohr)
     # +------------+------------------------------------------------------------+---------+--------+-----------+-------------+
@@ -546,7 +546,8 @@ def _maybe_convert_outputs(
 @click.option(
     "--thresh",
     type=str,
-    default=None,
+    default="baker",
+    show_default=True,
     help="Convergence preset (gau_loose|gau|gau_tight|gau_vtight|baker|never).",
 )
 @click.option(

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -28,7 +28,7 @@ Description
 - Inputs: two structures (.pdb or .xyz). If a PDB is provided and `--freeze-links=True` (default), parent atoms of link hydrogens are added to `freeze_atoms` (0-based indices).
 - Configuration via YAML with sections `geom`, `calc`, `gs`, `opt`, and single-structure optimizer sections such as `sopt.lbfgs` / `sopt.rfo` (also accepting `opt.lbfgs` / `opt.rfo` and top-level `lbfgs` / `rfo`). Precedence: YAML > CLI > built-in defaults.
 - Optional endpoint pre-optimization: with `--preopt=True` (default False), each endpoint is relaxed individually via single-structure LBFGS ("light", default) or RFO ("heavy") before alignment and GSM. The iteration limit for this pre-optimization is controlled independently by `--preopt-max-cycles` (default: 10000) for whichever optimizer is selected.
-- Path generator: `--mep-mode` accepts GSM or DMF, with DMF enabled by default to match the CLI default.
+- Path generator: `--mep-mode` accepts GSM or DMF, with GSM enabled by default to match the CLI default.
 - Alignment: before optimization, all inputs after the first are rigidly Kabsch-aligned to the first structure using an external routine with a short relaxation. `StringOptimizer.align` is disabled. If either endpoint specifies `freeze_atoms`, the RMSD fit uses only those atoms and the resulting rigid transform is applied to all atoms.
 - With `--climb=True` (default), a climbing-image step refines the highest-energy image. Lanczos-based tangent estimation (`gs.climb_lanczos`) is available via YAML but is disabled by default; the CLI does not toggle it.
 - `--thresh` sets the convergence preset used by the string optimizer, the optional endpoint pre-optimization, and the pre-alignment refinement (e.g., `gau_loose|gau|gau_tight|gau_vtight|baker|never`).
@@ -516,7 +516,7 @@ def _optimize_single(
 @click.option(
     "--mep-mode",
     type=click.Choice(["gsm", "dmf"], case_sensitive=False),
-    default="dmf",
+    default="gsm",
     show_default=True,
     help="MEP optimizer: Growing String Method (gsm) or Direct Max Flux (dmf).",
 )
@@ -591,7 +591,8 @@ def _optimize_single(
 @click.option(
     "--thresh",
     type=str,
-    default=None,
+    default="baker",
+    show_default=True,
     help="Convergence preset for the string optimizer, pre-alignment refinement, and endpoint preoptimization (gau_loose|gau|gau_tight|gau_vtight|baker|never).",
 )
 @click.option(

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -29,7 +29,7 @@ Recommended/common:
     --opt-mode
         Single-structure optimizer: light (=LBFGS) or heavy (=RFO); default light.
     --mep-mode
-        Segment generator: GSM (string) or DMF (direct max flux); default dmf.
+        Segment generator: GSM (string) or DMF (direct max flux); default gsm.
     --max-nodes
         Internal nodes for segment GSM; default 10.
     --max-cycles
@@ -1765,7 +1765,7 @@ def _merge_final_and_write(final_images: List[Any],
 @click.option(
     "--mep-mode",
     type=click.Choice(["gsm", "dmf"], case_sensitive=False),
-    default="dmf",
+    default="gsm",
     show_default=True,
     help="MEP optimizer: Growing String Method (gsm) or Direct Max Flux (dmf).",
 )
@@ -1814,7 +1814,8 @@ def _merge_final_and_write(final_images: List[Any],
 @click.option(
     "--thresh",
     type=str,
-    default=None,
+    default="baker",
+    show_default=True,
     help="Convergence preset for GSM and single optimizations (gau_loose|gau|gau_tight|gau_vtight|baker|never).",
 )
 @click.option(

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -379,7 +379,8 @@ def _snapshot_geometry(g) -> Any:
 @click.option(
     "--thresh",
     type=str,
-    default=None,
+    default="baker",
+    show_default=True,
     help="Convergence preset for relaxations (gau_loose|gau|gau_tight|gau_vtight|baker|never).",
 )
 @click.option(

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -382,7 +382,8 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
 @click.option(
     "--thresh",
     type=str,
-    default=None,
+    default="baker",
+    show_default=True,
     help="Convergence preset (gau_loose|gau|gau_tight|gau_vtight|baker|never).",
 )
 @click.option(

--- a/pdb2reaction/scan3d.py
+++ b/pdb2reaction/scan3d.py
@@ -450,7 +450,8 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
 @click.option(
     "--thresh",
     type=str,
-    default=None,
+    default="baker",
+    show_default=True,
     help="Convergence preset (gau_loose|gau|gau_tight|gau_vtight|baker|never).",
 )
 @click.option(

--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -1266,7 +1266,7 @@ LBFGS_TS_KW: Dict[str, Any] = dict(_LBFGS_KW)
 # HessianDimer defaults (CLI-level)
 hessian_dimer_KW = {
     "thresh_loose": "gau_loose",      # loose threshold preset for first pass
-    "thresh": "gau",                  # main threshold preset for TS search
+    "thresh": "baker",                # main threshold preset for TS search
     "update_interval_hessian": 1000,  # LBFGS cycles per Hessian refresh for direction
     "neg_freq_thresh_cm": 5.0,        # treat ν < -this as imaginary (cm^-1)
     "flatten_amp_ang": 0.10,          # mass-scaled displacement amplitude for flattening (Å)
@@ -1339,7 +1339,8 @@ RSIRFO_KW.update({
 @click.option(
     "--thresh",
     type=str,
-    default=None,
+    default="baker",
+    show_default=True,
     help="Convergence preset for the active optimizer (gau_loose|gau|gau_tight|gau_vtight|baker|never).",
 )
 @click.option(


### PR DESCRIPTION
## Summary
- set `--mep-mode` CLI defaults to `gsm` across path-related commands and documentation
- switch `--thresh` defaults to `baker` for all subcommands and align optimizer defaults/docs

## Testing
- python -m compileall pdb2reaction

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df862c750832db6286158b996a5b3)