### PR TITLE
Set --thresh default to None across subcommands

### DIFF
--- a/docs/opt.md
+++ b/docs/opt.md
@@ -42,7 +42,7 @@ pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} -q CHARGE -m MULT \
 | `--dump BOOL` | Emit trajectory dumps (`optimization.trj`). | `False` |
 | `--convert-files/--no-convert-files` | Enable or disable XYZ/TRJ → PDB/GJF companions for inputs with PDB/Gaussian templates. | `--convert-files` |
 | `--out-dir TEXT` | Output directory for all files. | `./result_opt/` |
-| `--thresh TEXT` | Override convergence preset (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | `gau` |
+| `--thresh TEXT` | Override convergence preset (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | _None_ |
 | `--args-yaml FILE` | Supply YAML overrides (sections `geom`, `calc`, `opt`, `lbfgs`, `rfo`). | _None_ |
 
 ## Outputs

--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -44,7 +44,7 @@ pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} -q CHARGE -m MULT 
 | `--opt-mode TEXT` | Single-structure optimizer for endpoint preoptimization (`light` = LBFGS, `heavy` = RFO). | `light` |
 | `--convert-files/--no-convert-files` | Toggle XYZ/TRJ → PDB/GJF companions for PDB/Gaussian inputs. | `--convert-files` |
 | `--out-dir TEXT` | Output directory. | `./result_path_opt/` |
-| `--thresh TEXT` | Override convergence preset for GSM/string optimizer. | `gau` |
+| `--thresh TEXT` | Override convergence preset for GSM/string optimizer. | _None_ |
 | `--args-yaml FILE` | YAML overrides (sections `geom`, `calc`, `gs`, `opt`). | _None_ |
 | `--preopt BOOL` | Pre-optimise each endpoint with the selected single-structure optimizer before alignment/GSM. | `False` |
 | `--preopt-max-cycles INT` | Cap for endpoint preoptimization cycles. | `10000` |

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -44,7 +44,7 @@ pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--multiplicity 2S
 | `--dump BOOL` | Explicit `True`/`False`. Dump GSM and single-structure trajectories/restarts. | `False` |
 | `--convert-files/--no-convert-files` | Toggle XYZ/TRJ → PDB/GJF companions for PDB or Gaussian inputs. | `--convert-files` |
 | `--out-dir TEXT` | Output directory. | `./result_path_search/` |
-| `--thresh TEXT` | Override convergence preset for GSM and per-image optimizations (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | `gau` |
+| `--thresh TEXT` | Override convergence preset for GSM and per-image optimizations (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | _None_ |
 | `--args-yaml FILE` | YAML overrides (see below). | _None_ |
 | `--preopt BOOL` | Explicit `True`/`False`. Pre-optimise each endpoint before GSM (recommended). | `True` |
 | `--align / --no-align` | Flag toggle. Align all inputs to the first structure before searching. | `--align` |

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -63,7 +63,7 @@ pdb2reaction scan -i input.pdb -q 0 \
 | `--dump BOOL` | Dump concatenated biased trajectories (`scan.trj`/`scan.pdb`). | `False` |
 | `--convert-files/--no-convert-files` | Toggle XYZ/TRJ → PDB/GJF companions for PDB/Gaussian inputs. | `--convert-files` |
 | `--out-dir TEXT` | Output directory root. | `./result_scan/` |
-| `--thresh TEXT` | Convergence preset override (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | `gau` |
+| `--thresh TEXT` | Convergence preset override (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | _None_ |
 | `--args-yaml FILE` | YAML overrides for `geom`, `calc`, `opt`, `lbfgs`, `rfo`, `bias`, `bond`. | _None_ |
 | `--preopt BOOL` | Run an unbiased optimization before scanning. | `True` |
 | `--endopt BOOL` | Run an unbiased optimization after each stage. | `True` |

--- a/docs/scan2d.md
+++ b/docs/scan2d.md
@@ -65,7 +65,7 @@ pdb2reaction scan2d -i input.pdb -q 0 \
 | `--dump BOOL` | Write `inner_path_d1_###.trj` for each outer step. | `False` |
 | `--convert-files/--no-convert-files` | Toggle XYZ/TRJ → PDB/GJF companions for PDB/Gaussian inputs. | `--convert-files` |
 | `--out-dir TEXT` | Output directory root for grids and plots. | `./result_scan2d/` |
-| `--thresh TEXT` | Convergence preset override (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | `gau` |
+| `--thresh TEXT` | Convergence preset override (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | _None_ |
 | `--args-yaml FILE` | YAML overrides for `geom`, `calc`, `opt`, `lbfgs`, `rfo`, `bias`. | _None_ |
 | `--preopt BOOL` | Run an unbiased optimization before scanning. | `True` |
 | `--baseline {min,first}` | Shift kcal/mol energies so the global min or first grid point is zero. | `min` |

--- a/docs/scan3d.md
+++ b/docs/scan3d.md
@@ -74,7 +74,7 @@ pdb2reaction scan3d -i input.pdb -q 0 \
 | `--convert-files/--no-convert-files` | Toggle XYZ/TRJ → PDB/GJF companions for PDB/Gaussian inputs. | `--convert-files` |
 | `--out-dir TEXT` | Output directory root for grids and plots. | `./result_scan3d/` |
 | `--csv PATH` | Load an existing `surface.csv` and only plot it (no new scan). | _None_ |
-| `--thresh TEXT` | Convergence preset override (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | `gau` |
+| `--thresh TEXT` | Convergence preset override (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | _None_ |
 | `--args-yaml FILE` | YAML overrides for `geom`, `calc`, `opt`, `lbfgs`, `rfo`, `bias`. | _None_ |
 | `--preopt BOOL` | Run an unbiased optimization before scanning. | `True` |
 | `--baseline {min,first}` | Shift kcal/mol energies so the global min or `(i,j,k)=(0,0,0)` is zero. | `min` |

--- a/docs/tsopt.md
+++ b/docs/tsopt.md
@@ -79,7 +79,7 @@ pdb2reaction tsopt -i ts_cand.pdb -q 0 -m 1 --opt-mode heavy \
 | `--opt-mode TEXT` | Light/Heavy aliases listed above. | `light` |
 | `--dump BOOL` | Explicit `True`/`False`. Dump trajectories. | `False` |
 | `--out-dir TEXT` | Output directory. | `./result_tsopt/` |
-| `--thresh TEXT` | Override convergence preset (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | `gau` |
+| `--thresh TEXT` | Override convergence preset (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | _None_ |
 | `--hessian-calc-mode CHOICE` | UMA Hessian mode (`Analytical` or `FiniteDifference`). | _None_ (use YAML/default) |
 | `--convert-files/--no-convert-files` | Toggle XYZ/TRJ → PDB/GJF companions for PDB or Gaussian inputs. | `--convert-files` |
 | `--args-yaml FILE` | YAML overrides (`geom`, `calc`, `opt`, `hessian_dimer`, `rsirfo`). | _None_ |

--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -1777,8 +1777,8 @@ def _irc_and_match(
 @click.option(
     "--thresh",
     type=str,
-    default="gau",
-    show_default=True,
+    default=None,
+    show_default=False,
     help="Convergence preset (gau_loose|gau|gau_tight|gau_vtight|baker|never).",
 )
 @click.option(

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -546,8 +546,8 @@ def _maybe_convert_outputs(
 @click.option(
     "--thresh",
     type=str,
-    default="gau",
-    show_default=True,
+    default=None,
+    show_default=False,
     help="Convergence preset (gau_loose|gau|gau_tight|gau_vtight|baker|never).",
 )
 @click.option(

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -591,8 +591,8 @@ def _optimize_single(
 @click.option(
     "--thresh",
     type=str,
-    default="gau",
-    show_default=True,
+    default=None,
+    show_default=False,
     help="Convergence preset for the string optimizer, pre-alignment refinement, and endpoint preoptimization (gau_loose|gau|gau_tight|gau_vtight|baker|never).",
 )
 @click.option(

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -1877,8 +1877,8 @@ def _merge_final_and_write(final_images: List[Any],
 @click.option(
     "--thresh",
     type=str,
-    default="gau",
-    show_default=True,
+    default=None,
+    show_default=False,
     help="Convergence preset for GSM and single optimizations (gau_loose|gau|gau_tight|gau_vtight|baker|never).",
 )
 @click.option(

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -379,8 +379,8 @@ def _snapshot_geometry(g) -> Any:
 @click.option(
     "--thresh",
     type=str,
-    default="gau",
-    show_default=True,
+    default=None,
+    show_default=False,
     help="Convergence preset for relaxations (gau_loose|gau|gau_tight|gau_vtight|baker|never).",
 )
 @click.option(

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -382,8 +382,8 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
 @click.option(
     "--thresh",
     type=str,
-    default="gau",
-    show_default=True,
+    default=None,
+    show_default=False,
     help="Convergence preset (gau_loose|gau|gau_tight|gau_vtight|baker|never).",
 )
 @click.option(

--- a/pdb2reaction/scan3d.py
+++ b/pdb2reaction/scan3d.py
@@ -450,8 +450,8 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
 @click.option(
     "--thresh",
     type=str,
-    default="gau",
-    show_default=True,
+    default=None,
+    show_default=False,
     help="Convergence preset (gau_loose|gau|gau_tight|gau_vtight|baker|never).",
 )
 @click.option(

--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -1340,8 +1340,8 @@ RSIRFO_KW.update({
 @click.option(
     "--thresh",
     type=str,
-    default="gau",
-    show_default=True,
+    default=None,
+    show_default=False,
     help="Convergence preset for the active optimizer (gau_loose|gau|gau_tight|gau_vtight|baker|never).",
 )
 @click.option(


### PR DESCRIPTION
## Summary
- default --thresh to None for all CLI subcommands so convergence presets only override when provided
- update command documentation to reflect the None default

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f15024480832d82a14e5ae7927a49)