### PR TITLE
Show freeze atoms in summary log headers

### DIFF
--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -627,6 +627,15 @@ def _get_freeze_atoms(pdb_path: Optional[Path], freeze_links_flag: bool) -> List
     return _FREEZE_ATOMS_GLOBAL
 
 
+def _freeze_atoms_for_log() -> List[int]:
+    """Return a sorted freeze_atoms list for summary logs (may be empty)."""
+
+    try:
+        return sorted({int(i) for i in (_FREEZE_ATOMS_GLOBAL or [])})
+    except Exception:
+        return []
+
+
 # ---------- Post-processing helpers ----------
 
 
@@ -2690,6 +2699,7 @@ def cli(
                     "command": command_str,
                     "charge": q_int,
                     "spin": spin,
+                    "freeze_atoms": _freeze_atoms_for_log(),
                     "mep": {"n_images": n_images, "n_segments": 1},
                     "segments": summary.get("segments", []),
                     "energy_diagrams": summary.get("energy_diagrams", []),
@@ -3225,6 +3235,7 @@ def cli(
                 "command": command_str,
                 "charge": q_int,
                 "spin": spin,
+                "freeze_atoms": _freeze_atoms_for_log(),
                 "mep": mep_info,
                 "segments": summary.get("segments", []),
                 "energy_diagrams": summary.get("energy_diagrams", []),
@@ -3404,6 +3415,7 @@ def cli(
                 "command": command_str,
                 "charge": q_int,
                 "spin": spin,
+                "freeze_atoms": _freeze_atoms_for_log(),
                 "mep": mep_info,
                 "segments": summary.get("segments", []),
                 "energy_diagrams": summary.get("energy_diagrams", []),

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -1986,6 +1986,7 @@ def cli(
         ref_pdb_paths = tuple(ref_parsed)
 
     time_start = time.perf_counter()
+    freeze_atoms_for_log: List[int] = []
     try:
         # --------------------------
         # 0) Input validation (multi‑structure)
@@ -2654,6 +2655,17 @@ def cli(
         click.echo(f"[write] Wrote '{out_dir_path / 'summary.yaml'}'.")
 
         try:
+            try:
+                freeze_atoms_for_log = sorted(
+                    {
+                        int(i)
+                        for g in getattr(combined_all, "images", [])
+                        for i in getattr(g, "freeze_atoms", [])
+                    }
+                )
+            except Exception:
+                pass
+
             diag_for_log: Dict[str, Any] = {}
             if diagram_payload is not None:
                 diag_for_log = dict(diagram_payload)
@@ -2679,6 +2691,7 @@ def cli(
                 "command": command_str,
                 "charge": calc_cfg.get("charge"),
                 "spin": calc_cfg.get("spin"),
+                "freeze_atoms": freeze_atoms_for_log,
                 "mep": mep_info,
                 "segments": summary.get("segments", []),
                 "energy_diagrams": summary.get("energy_diagrams", []),

--- a/pdb2reaction/summary_log.py
+++ b/pdb2reaction/summary_log.py
@@ -284,6 +284,16 @@ def write_summary_log(dest: Path, payload: Dict[str, Any]) -> None:
     lines.append(f"UMA model          : {uma_model}")
     lines.append(f"Total charge (ML)  : {charge if charge is not None else '-'}")
     lines.append(f"Multiplicity (2S+1): {spin if spin is not None else '-'}")
+
+    freeze_atoms_raw = payload.get("freeze_atoms") or []
+    try:
+        freeze_atoms_list = sorted({int(i) for i in freeze_atoms_raw})
+    except Exception:
+        freeze_atoms_list = []
+    if freeze_atoms_list:
+        lines.append(
+            "Freeze atoms (0-based): " + ",".join(map(str, freeze_atoms_list))
+        )
     lines.append("")
 
     mep = payload.get("mep", {}) or {}


### PR DESCRIPTION
## Summary
- include freeze atom indices in the opening section of generated summary.log files when available
- propagate freeze_atoms data from all/path_search runs into the summary log payload

## Testing
- python -m compileall pdb2reaction/summary_log.py pdb2reaction/all.py pdb2reaction/path_search.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f290a1a70832d85a4f44475a3ff5d)