### PR TITLE
Pass freeze_atoms through geom_loader in scripts

### DIFF
--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -726,8 +726,12 @@ def _load_segment_endpoints(
         return None
 
     base = str(trj_path)
-    gL_ref = geom_loader(base + "[0]", coord_type=DEFAULT_COORD_TYPE)
-    gR_ref = geom_loader(base + "[-1]", coord_type=DEFAULT_COORD_TYPE)
+    gL_ref = geom_loader(
+        base + "[0]", coord_type=DEFAULT_COORD_TYPE, freeze_atoms=freeze_atoms
+    )
+    gR_ref = geom_loader(
+        base + "[-1]", coord_type=DEFAULT_COORD_TYPE, freeze_atoms=freeze_atoms
+    )
 
     try:
         fa = np.array(freeze_atoms, dtype=int)
@@ -1082,7 +1086,11 @@ def _optimize_endpoint_geom(
         )
 
     final_xyz = Path(opt.final_fn) if isinstance(opt.final_fn, (str, Path)) else opt.final_fn
-    g_final = geom_loader(final_xyz, coord_type=DEFAULT_COORD_TYPE)
+    g_final = geom_loader(
+        final_xyz,
+        coord_type=DEFAULT_COORD_TYPE,
+        freeze_atoms=getattr(geom, "freeze_atoms", []),
+    )
     try:
         g_final.freeze_atoms = np.array(getattr(geom, "freeze_atoms", []), dtype=int)
     except Exception:
@@ -1385,7 +1393,11 @@ def _run_tsopt_on_hei(
     else:
         raise click.ClickException("[tsopt] TS outputs not found.")
 
-    g_ts = geom_loader(ts_geom_path, coord_type=DEFAULT_COORD_TYPE)
+    g_ts = geom_loader(
+        ts_geom_path,
+        coord_type=DEFAULT_COORD_TYPE,
+        freeze_atoms=_freeze_atoms_for_log(),
+    )
 
     calc_args = dict(calc_cfg)
     calc = uma_pysis(**calc_args)
@@ -3682,7 +3694,11 @@ def cli(
                 continue
 
             try:
-                g_ts = geom_loader(hei_pocket_path, coord_type=DEFAULT_COORD_TYPE)
+                g_ts = geom_loader(
+                    hei_pocket_path,
+                    coord_type=DEFAULT_COORD_TYPE,
+                    freeze_atoms=freeze_atoms,
+                )
                 if freeze_atoms:
                     fa = np.array(freeze_atoms, dtype=int)
                     g_ts.freeze_atoms = fa

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -208,7 +208,6 @@ def _load_two_endpoints(
     for prepared in inputs:
         geom_path = prepared.geom_path
         src_path = prepared.source_path
-        g = geom_loader(geom_path, coord_type=coord_type)
         cfg: Dict[str, Any] = {"freeze_atoms": list(base_freeze)}
         if auto_freeze_links and src_path.suffix.lower() == ".pdb":
             detected = detect_freeze_links_safe(src_path)
@@ -220,6 +219,7 @@ def _load_two_endpoints(
                 )
         else:
             freeze = merge_freeze_atom_indices(cfg)
+        g = geom_loader(geom_path, coord_type=coord_type, freeze_atoms=freeze)
         g.freeze_atoms = np.array(freeze, dtype=int)
         geoms.append(g)
     return geoms

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -169,7 +169,9 @@ def _snapshot_geometry(g) -> Any:
         tmp.flush()
         tmp.close()
         snap = geom_loader(
-            Path(tmp.name), coord_type=getattr(g, "coord_type", GEOM_KW_DEFAULT["coord_type"])
+            Path(tmp.name),
+            coord_type=getattr(g, "coord_type", GEOM_KW_DEFAULT["coord_type"]),
+            freeze_atoms=getattr(g, "freeze_atoms", []),
         )
         try:
             import numpy as _np
@@ -531,9 +533,6 @@ def cli(
 
         final_dir = out_dir_path
 
-        coord_type = geom_cfg.get("coord_type", GEOM_KW_DEFAULT["coord_type"])
-        geom_outer = geom_loader(geom_input_path, coord_type=coord_type)
-
         freeze = merge_freeze_atom_indices(geom_cfg)
         if freeze_links and input_path.suffix.lower() == ".pdb":
             detected = detect_freeze_links_safe(input_path)
@@ -543,6 +542,10 @@ def cli(
                     click.echo(
                         f"[freeze-links] Freeze atoms (0-based): {','.join(map(str, freeze))}"
                     )
+        coord_type = geom_cfg.get("coord_type", GEOM_KW_DEFAULT["coord_type"])
+        geom_outer = geom_loader(
+            geom_input_path, coord_type=coord_type, freeze_atoms=freeze
+        )
         if freeze:
             try:
                 import numpy as _np

--- a/pdb2reaction/scan3d.py
+++ b/pdb2reaction/scan3d.py
@@ -198,7 +198,9 @@ def _snapshot_geometry(g) -> Any:
         tmp.flush()
         tmp.close()
         snap = geom_loader(
-            Path(tmp.name), coord_type=getattr(g, "coord_type", GEOM_KW_DEFAULT["coord_type"])
+            Path(tmp.name),
+            coord_type=getattr(g, "coord_type", GEOM_KW_DEFAULT["coord_type"]),
+            freeze_atoms=getattr(g, "freeze_atoms", []),
         )
         try:
             import numpy as _np  # noqa: PLC0415
@@ -612,9 +614,6 @@ def cli(
             _ensure_dir(grid_dir)
             _ensure_dir(tmp_opt_dir)
 
-            coord_type = geom_cfg.get("coord_type", GEOM_KW_DEFAULT["coord_type"])
-            geom_outer = geom_loader(geom_input_path, coord_type=coord_type)
-
             freeze = merge_freeze_atom_indices(geom_cfg)
             if freeze_links and input_path.suffix.lower() == ".pdb":
                 detected = detect_freeze_links_safe(input_path)
@@ -622,6 +621,10 @@ def cli(
                     freeze = merge_freeze_atom_indices(geom_cfg, detected)
                     if freeze:
                         click.echo(f"[freeze-links] Freeze atoms (0-based): {','.join(map(str, freeze))}")
+            coord_type = geom_cfg.get("coord_type", GEOM_KW_DEFAULT["coord_type"])
+            geom_outer = geom_loader(
+                geom_input_path, coord_type=coord_type, freeze_atoms=freeze
+            )
             if freeze:
                 try:
                     import numpy as _np  # noqa: PLC0415


### PR DESCRIPTION
## Summary
- ensure geom_loader receives freeze_atoms across scan, path, and postprocessing scripts
- propagate detected freeze atom lists when loading geometries and snapshots
- preserve freeze settings when reloading endpoints and TS structures

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f439c3578832daf817d586042d208)