### PR TITLE
Force DLC coordinates for GSM runs

### DIFF
--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -723,6 +723,8 @@ def cli(
 
         opt_kind = opt_mode.strip().lower()
         mep_mode_kind = mep_mode.strip().lower()
+        if mep_mode_kind == "gsm":
+            geom_cfg["coord_type"] = "dlc"
         if opt_kind == "light":
             sopt_kind = "lbfgs"
             sopt_cfg = lbfgs_cfg

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -2098,6 +2098,9 @@ def cli(
                 raise click.BadParameter(f"Unknown --refine-mode '{refine_mode_kind}'.")
         search_cfg["refine_mode"] = refine_mode_kind
 
+        if mep_mode_kind == "gsm":
+            geom_cfg["coord_type"] = "dlc"
+
         opt_kind = opt_mode.strip().lower()
         if opt_kind == "light":
             sopt_kind = "lbfgs"


### PR DESCRIPTION
## Summary
- force GSM runs in path-opt to use DLC coordinates regardless of defaults
- apply the same DLC override for GSM mode in recursive path-search

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f6c4be31c832d8b9f921c13742dc6)