### PR TITLE
Set finite-difference Hessian as default

### DIFF
--- a/docs/all.md
+++ b/docs/all.md
@@ -94,7 +94,7 @@ pdb2reaction all -i reactant.pdb -c "GPP,MMT" \
 | `--convert-files/--no-convert-files` | Global toggle for XYZ/TRJ → PDB/GJF companions when templates are available. | `--convert-files` |
 | `--args-yaml FILE` | YAML forwarded unchanged to `path_search`, `scan`, `tsopt`, `freq`, and `dft`. | _None_ |
 | `--preopt BOOLEAN` | Pre-optimise pocket endpoints before GSM (also the default for scan preopt). | `True` |
-| `--hessian-calc-mode [Analytical\|FiniteDifference]` | Shared UMA Hessian engine forwarded to tsopt and freq. | _None_ |
+| `--hessian-calc-mode [Analytical\|FiniteDifference]` | Shared UMA Hessian engine forwarded to tsopt and freq. | _None_ (uses YAML/default of `FiniteDifference`) |
 | `--tsopt BOOLEAN` | Run TS optimisation + pseudo-IRC per reactive segment, or enable TSOPT-only mode (single input). | `False` |
 | `--thermo BOOLEAN` | Run vibrational analysis (`freq`) on R/TS/P and build UMA Gibbs diagram. | `False` |
 | `--dft BOOLEAN` | Run single-point DFT on R/TS/P and build DFT energy + optional DFT//UMA diagrams. | `False` |
@@ -157,7 +157,7 @@ geom:
   coord_type: cart
 calc:
   model: uma-s-1p1
-  hessian_calc_mode: Analytical
+  hessian_calc_mode: FiniteDifference
 gs:
   max_nodes: 12
 freq:
@@ -181,7 +181,7 @@ calc:
   r_edges: false
   out_hess_torch: true
   freeze_atoms: null
-  hessian_calc_mode: Analytical
+  hessian_calc_mode: FiniteDifference
   return_partial_hessian: true
 gs:
   max_nodes: 10

--- a/docs/freq.md
+++ b/docs/freq.md
@@ -67,7 +67,7 @@ pdb2reaction freq -i a.xyz -q -1 --args-yaml ./args.yaml --out-dir ./result_freq
 | `--temperature FLOAT` | Thermochemistry temperature (K). | `298.15` |
 | `--pressure FLOAT` | Thermochemistry pressure (atm). | `1.0` |
 | `--dump BOOL` | Explicit `True`/`False`. Write `thermoanalysis.yaml`. | `False` |
-| `--hessian-calc-mode CHOICE` | UMA Hessian mode (`Analytical` or `FiniteDifference`). | _None_ (use YAML/default) |
+| `--hessian-calc-mode CHOICE` | UMA Hessian mode (`Analytical` or `FiniteDifference`). | _None_ (uses YAML/default of `FiniteDifference`) |
 | `--convert-files/--no-convert-files` | Toggle XYZ/TRJ → PDB/GJF companions for PDB/Gaussian inputs. | `--convert-files` |
 | `--args-yaml FILE` | YAML overrides (sections: `geom`, `calc`, `freq`). | _None_ |
 
@@ -104,7 +104,7 @@ calc:
   r_edges: false
   out_hess_torch: true
   freeze_atoms: null
-  hessian_calc_mode: Analytical
+  hessian_calc_mode: FiniteDifference
   return_partial_hessian: true
 freq:
   amplitude_ang: 0.8

--- a/docs/irc.md
+++ b/docs/irc.md
@@ -86,7 +86,7 @@ calc:
   r_edges: false
   out_hess_torch: true
   freeze_atoms: null
-  hessian_calc_mode: Analytical
+  hessian_calc_mode: FiniteDifference
   return_partial_hessian: true
 irc:
   step_length: 0.1

--- a/docs/opt.md
+++ b/docs/opt.md
@@ -97,7 +97,7 @@ calc:
   r_edges: false
   out_hess_torch: true
   freeze_atoms: null
-  hessian_calc_mode: Analytical
+  hessian_calc_mode: FiniteDifference
   return_partial_hessian: true
 opt:
   thresh: gau

--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -97,7 +97,7 @@ calc:
   r_edges: false
   out_hess_torch: true
   freeze_atoms: null
-  hessian_calc_mode: Analytical
+  hessian_calc_mode: FiniteDifference
   return_partial_hessian: true
 gs:
   max_nodes: 30

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -109,7 +109,7 @@ calc:
   r_edges: false
   out_hess_torch: true
   freeze_atoms: null
-  hessian_calc_mode: Analytical
+  hessian_calc_mode: FiniteDifference
   return_partial_hessian: true
 gs:
   max_nodes: 10

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -126,7 +126,7 @@ calc:
   r_edges: false
   out_hess_torch: true
   freeze_atoms: null
-  hessian_calc_mode: Analytical
+  hessian_calc_mode: FiniteDifference
   return_partial_hessian: true
 opt:
   thresh: gau

--- a/docs/tsopt.md
+++ b/docs/tsopt.md
@@ -80,7 +80,7 @@ pdb2reaction tsopt -i ts_cand.pdb -q 0 -m 1 --opt-mode heavy \
 | `--dump BOOL` | Explicit `True`/`False`. Dump trajectories. | `False` |
 | `--out-dir TEXT` | Output directory. | `./result_tsopt/` |
 | `--thresh TEXT` | Override convergence preset (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | _None_ |
-| `--hessian-calc-mode CHOICE` | UMA Hessian mode (`Analytical` or `FiniteDifference`). | _None_ (use YAML/default) |
+| `--hessian-calc-mode CHOICE` | UMA Hessian mode (`Analytical` or `FiniteDifference`). | _None_ (uses YAML/default of `FiniteDifference`) |
 | `--convert-files/--no-convert-files` | Toggle XYZ/TRJ → PDB/GJF companions for PDB or Gaussian inputs. | `--convert-files` |
 | `--args-yaml FILE` | YAML overrides (`geom`, `calc`, `opt`, `hessian_dimer`, `rsirfo`). | _None_ |
 
@@ -129,7 +129,7 @@ calc:
   r_edges: false
   out_hess_torch: true
   freeze_atoms: null
-  hessian_calc_mode: Analytical
+  hessian_calc_mode: FiniteDifference
   return_partial_hessian: true
 opt:
   thresh: gau

--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -1821,9 +1821,9 @@ def _irc_and_match(
 )
 @click.option(
     "--hessian-calc-mode",
-    type=click.Choice(["Analytical", "FiniteDifference"], case_sensitive=False),
+    type=click.Choice(["FiniteDifference", "Analytical"], case_sensitive=False),
     default=None,
-    help="Common UMA Hessian calculation mode forwarded to tsopt and freq.",
+    help="Common UMA Hessian calculation mode forwarded to tsopt and freq. Defaults to 'FiniteDifference'.",
 )
 # ===== Post-processing toggles =====
 @click.option(

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -45,7 +45,7 @@ Notes
 - Input geometry: .pdb, .xyz, .trj (via pysisyphus ``geom_loader``). For PDB, ``--freeze-links`` (default: True)
   detects parent atoms of link hydrogens and merges them with any ``geom.freeze_atoms``; the merged list is echoed.
 - UMA settings:
-  - ``--hessian-calc-mode``: ``Analytical`` (default) or ``FiniteDifference``; may also be set in YAML.
+  - ``--hessian-calc-mode``: ``FiniteDifference`` (default) or ``Analytical``; may also be set in YAML.
   - ``return_partial_hessian`` defaults to True so PHVA can use a reduced active‑block Hessian when possible.
   - Device: ``auto`` selects CUDA if available; otherwise CPU.
 - PHVA and projections:
@@ -548,7 +548,7 @@ THERMO_KW = {
 @click.option("--hessian-calc-mode",
               type=click.Choice(["FiniteDifference", "Analytical"]),
               default=None,
-              help="How UMA computes Hessian. Defaults to 'Analytical' (can also be set via YAML).")
+              help="How UMA computes Hessian. Defaults to 'FiniteDifference' (can also be set via YAML).")
 def cli(
     input_path: Path,
     charge: Optional[int],

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -207,9 +207,9 @@ def _echo_convert_trj_if_exists(
 @click.option("--out-dir", type=str, default="./result_irc/", show_default=True, help="Output directory; overrides irc.out_dir from YAML.")
 @click.option(
     "--hessian-calc-mode",
-    type=click.Choice(["Analytical", "FiniteDifference"], case_sensitive=False),
+    type=click.Choice(["FiniteDifference", "Analytical"], case_sensitive=False),
     default=None,
-    help="How UMA builds the Hessian (Analytical or FiniteDifference); overrides calc.hessian_calc_mode from YAML.",
+    help="How UMA builds the Hessian (Analytical or FiniteDifference); overrides calc.hessian_calc_mode from YAML. Defaults to 'FiniteDifference'.",
 )
 @click.option(
     "--args-yaml",

--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -1352,9 +1352,9 @@ RSIRFO_KW.update({
 )
 @click.option(
     "--hessian-calc-mode",
-    type=click.Choice(["Analytical", "FiniteDifference"], case_sensitive=False),
+    type=click.Choice(["FiniteDifference", "Analytical"], case_sensitive=False),
     default=None,
-    help="Choose UMA Hessian evaluation mode (overrides YAML/calc.hessian_calc_mode).",
+    help="Choose UMA Hessian evaluation mode (overrides YAML/calc.hessian_calc_mode). Defaults to 'FiniteDifference'.",
 )
 def cli(
     input_path: Path,

--- a/pdb2reaction/uma_pysis.py
+++ b/pdb2reaction/uma_pysis.py
@@ -46,7 +46,7 @@ Description
   the batch; charge/spin are stored in `Atoms.info`.
 - Robustness: analytical path catches CUDA out‑of‑memory and advises switching to
   finite differences.
-- Default Hessian mode at construction is `"Analytical"`. If `hessian_calc_mode`
+- Default Hessian mode at construction is `"FiniteDifference"`. If `hessian_calc_mode`
   is falsy *or unrecognized* in `get_hessian`, `"FiniteDifference"` is used.
 - Units: UMA runs in Å and eV; PySisyphus public API converts to Hartree/Bohr:
   energy eV→Hartree, forces eV·Å⁻¹→Hartree·Bohr⁻¹, Hessian eV·Å⁻²→Hartree·Bohr⁻².
@@ -127,7 +127,7 @@ CALC_KW: Dict[str, Any] = {
     "freeze_atoms": None,     # Optional[Sequence[int]], list of freeze atoms
 
     # Hessian interfaces to UMA
-    "hessian_calc_mode": "Analytical",        # "Analytical" (default) | "FiniteDifference"
+    "hessian_calc_mode": "FiniteDifference",        # "FiniteDifference" (default) | "Analytical"
     "return_partial_hessian": True,           # receive only the active-DOF Hessian block
 
     # Hessian precision (energy/forces are always returned as float64)
@@ -321,7 +321,7 @@ class uma_pysis(Calculator):
         """
         Parameters
         ----------
-        hessian_calc_mode : {"Analytical", "FiniteDifference"}, default "Analytical"
+        hessian_calc_mode : {"Analytical", "FiniteDifference"}, default "FiniteDifference"
             Select how to compute the Hessian in `get_hessian()`.
             - "Analytical": autograd-based analytical Hessian.
             - "FiniteDifference": central-difference Hessian; the matrix is


### PR DESCRIPTION
## Summary
- switch UMA calculator default Hessian mode to FiniteDifference and update CLI help
- refresh documentation to reflect the new default across commands and YAML examples

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930b79fd150832d9fb8dfed59287ebf)