### PR TITLE
Add guardrail for consecutive kink segments in path_search

### DIFF
--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -89,7 +89,7 @@ The YAML root must be a mapping. YAML parameters override the CLI values. Shared
 
 `bond` carries the UMA-based bond-change detection parameters shared with [`scan`](scan.md#section-bond): `device`, `bond_factor`, `margin_fraction`, and `delta_fraction`.
 
-`search` governs the recursion logic: `max_depth`, `stitch_rmsd_thresh`, `bridge_rmsd_thresh`, `max_nodes_segment`, `max_nodes_bridge`, `kink_max_nodes`, and `refine_mode` (auto-selects `peak` for GSM or `minima` for DMF when left `null`). The legacy `rmsd_align` flag is ignored but kept for compatibility.
+`search` governs the recursion logic: `max_depth`, `stitch_rmsd_thresh`, `bridge_rmsd_thresh`, `max_nodes_segment`, `max_nodes_bridge`, `kink_max_nodes`, `max_seq_kink`, and `refine_mode` (auto-selects `peak` for GSM or `minima` for DMF when left `null`). The legacy `rmsd_align` flag is ignored but kept for compatibility.
 
 `dmf` bundles Direct Max Flux + (C)FB-ENM controls applied whenever `--mep-mode dmf` is selected. The defaults mirror the shared `DMF_KW` dictionary and can be overridden per run:
 
@@ -243,4 +243,5 @@ search:
   max_nodes_segment: 10
   max_nodes_bridge: 5
   kink_max_nodes: 3
+  max_seq_kink: 2
 ```


### PR DESCRIPTION
## Summary
- add a configurable `max_seq_kink` limit (default 2) to stop path-search when kink segments repeat
- reuse the max-depth fallback when the limit is hit and surface a detailed guidance message
- document the new search parameter alongside existing path_search YAML defaults

## Testing
- python -m compileall pdb2reaction

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933088c54f0832da9172c49bb964838)