### PR TITLE
Sync path documentation with current defaults

### DIFF
--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -100,7 +100,7 @@ calc:
   hessian_calc_mode: FiniteDifference
   return_partial_hessian: true
 gs:
-  max_nodes: 30
+  max_nodes: 10
   perp_thresh: 0.005
   reparam_check: rms
   reparam_every: 1
@@ -116,16 +116,16 @@ gs:
   scheduler: null
 opt:
   type: string
-  stop_in_when_full: 100
+  stop_in_when_full: 300
   align: false
   scale_step: global
-  max_cycles: 100
+  max_cycles: 300
   dump: false
   dump_restart: false
-  reparam_thresh: 0.001
+  reparam_thresh: 0.0
   coord_diff_thresh: 0.0
   out_dir: ./result_path_opt/
-  print_every: 5
+  print_every: 10
 dmf:
   correlated: true
   sequential: true
@@ -144,7 +144,7 @@ dmf:
     pivotal: true
     single: true
     remove_fourmembered: true
-    two_hop_mode: dense
+    two_hop_mode: sparse
   dmf_options:
     remove_rotation_and_translation: false
     mass_weighted: false

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -128,13 +128,13 @@ gs:
   scheduler: null
 opt:
   type: string
-  stop_in_when_full: 100
+  stop_in_when_full: 300
   align: false
   scale_step: global
-  max_cycles: 100
+  max_cycles: 300
   dump: false
   dump_restart: false
-  reparam_thresh: 0.001
+  reparam_thresh: 0.0
   coord_diff_thresh: 0.0
   out_dir: ./result_path_search/
   print_every: 10
@@ -156,7 +156,7 @@ dmf:
     pivotal: true
     single: true
     remove_fourmembered: true
-    two_hop_mode: dense
+    two_hop_mode: sparse
   dmf_options:
     remove_rotation_and_translation: false
     mass_weighted: false

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -30,7 +30,7 @@ Description
 - Optional endpoint pre-optimization: with `--preopt=True` (default False), each endpoint is relaxed individually via single-structure LBFGS ("light", default) or RFO ("heavy") before alignment and GSM. The iteration limit for this pre-optimization is controlled independently by `--preopt-max-cycles` (default: 10000) for whichever optimizer is selected.
 - Path generator: `--mep-mode` accepts GSM or DMF, with GSM enabled by default to match the CLI default.
 - Alignment: before optimization, all inputs after the first are rigidly Kabsch-aligned to the first structure using an external routine with a short relaxation. `StringOptimizer.align` is disabled. If either endpoint specifies `freeze_atoms`, the RMSD fit uses only those atoms and the resulting rigid transform is applied to all atoms.
-- With `--climb=True` (default), a climbing-image step refines the highest-energy image. Lanczos-based tangent estimation (`gs.climb_lanczos`) is available via YAML but is disabled by default; the CLI does not toggle it.
+- With `--climb=True` (default), a climbing-image step refines the highest-energy image. Lanczos-based tangent estimation (`gs.climb_lanczos`) is enabled by default and follows the `--climb` flag; YAML can still override it.
 - `--thresh` sets the convergence preset used by the string optimizer, the optional endpoint pre-optimization, and the pre-alignment refinement (e.g., `gau_loose|gau|gau_tight|gau_vtight|baker|never`).
 - `--fix-ends=True` fixes both endpoint geometries during GSM (`fix_first=True`, `fix_last=True`).
 - After optimization, the highest-energy image (HEI) is identified as the highest-energy internal local maximum (preferring internal nodes). If none exist, the maximum among internal nodes is used; if there are no internal nodes, the global maximum is used. The selected HEI is exported.
@@ -172,7 +172,7 @@ GS_KW: Dict[str, Any] = {
     "reset_dlc": True,          # bool, reset DLC coordinates when appropriate
     "climb": True,              # bool, enable climbing image
     "climb_rms": 5e-4,          # float, RMS force threshold to start climbing image
-    "climb_lanczos": True,      # bool, use Lanczos to estimate the HEI tangent (disabled by default)
+    "climb_lanczos": True,      # bool, use Lanczos to estimate the HEI tangent (enabled by default; tied to --climb)
     "climb_lanczos_rms": 5e-4,  # float, RMS force threshold for Lanczos tangent
     "climb_fixed": False,       # bool, fix the HEI image index instead of adapting it
     "scheduler": None,          # Optional[str], execution scheduler; None = serial (shared calculator)
@@ -691,8 +691,8 @@ def cli(
         gs_cfg["fix_first"] = bool(fix_ends)
         gs_cfg["fix_last"] = bool(fix_ends)
 
-        # Lanczos tangent estimation can be enabled via YAML (`gs.climb_lanczos`);
-        # the CLI does not modify this setting.
+        # Lanczos tangent estimation follows the CLI --climb flag by default but
+        # can still be overridden via YAML (`gs.climb_lanczos`).
         opt_cfg["dump"] = bool(dump)
         opt_cfg["out_dir"] = out_dir
         if thresh is not None:


### PR DESCRIPTION
## Summary
- clarify path-opt docstring to reflect default Lanczos tangent handling tied to `--climb`
- update path-opt and path-search documentation YAML defaults to match current CLI parameters and DMF settings

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69331d1bf898832dba70a157a9540668)