### PR TITLE
Clarify DFT GPU fallback documentation

### DIFF
--- a/docs/dft.md
+++ b/docs/dft.md
@@ -1,7 +1,7 @@
 # `dft` subcommand
 
 ## Overview
-Run single-point DFT calculations with a GPU-first policy (GPU4PySCF when available, CPU PySCF otherwise). In addition to total energies the command reports Mulliken, meta-Löwdin, and IAO atomic charges/spin densities so users can reuse the results downstream without reprocessing the PySCF objects.
+Run single-point DFT calculations with a GPU-first policy (GPU4PySCF when available, CPU PySCF otherwise). If the GPU backend is unavailable or fails during setup/SCF, the run automatically falls back to CPU PySCF; Blackwell GPUs are forced to CPU with a warning. In addition to total energies the command reports Mulliken, meta-Löwdin, and IAO atomic charges/spin densities so users can reuse the results downstream without reprocessing the PySCF objects.
 
 ## Usage
 ```bash
@@ -52,7 +52,7 @@ pdb2reaction dft -i input.pdb -q 0 -m 2 --func-basis "wb97m-v/def2-tzvpd" \
 - Console pretty block summarising charge, multiplicity, spin (2S), functional, basis, convergence knobs, and resolved output directory.
 
 ## Notes
-- GPU4PySCF is used whenever available; CPU PySCF is built otherwise (unless `--engine cpu` forces CPU). `--engine auto` mirrors the CLI docstring behaviour (GPU attempt, then CPU). GPU runs that fail will automatically retry on the CPU backend.
+- GPU4PySCF is used whenever available; CPU PySCF is built otherwise (unless `--engine cpu` forces CPU). `--engine auto` mirrors the GPU-first fallback logic, automatically retrying on the CPU backend when GPU import/runtime errors occur. Blackwell GPUs are detected and forced to CPU with a warning to avoid unsupported GPU4PySCF configurations.
 - Density fitting is always attempted; auxiliary bases are auto-selected for def2/cc-pVXZ/Pople families and silently skipped when unsupported.
 - The YAML file must contain a mapping root with top-level key `dft`; non-mapping roots raise an error via `load_yaml_dict`.
 - Exit codes: `0` (converged), `3` (not converged), `2` (PySCF import failure), `1` (other errors), `130` (interrupt).

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -24,10 +24,10 @@ Description
 -----------
 - Single-point DFT engine with optional GPU acceleration (GPU4PySCF) and a CPU PySCF backend.
   The backend policy is controlled by --engine:
-  * gpu  (default): use GPU4PySCF only. If the GPU backend is unavailable or the SCF fails,the run stops.
+  * gpu  (default): try GPU4PySCF first; on import/runtime errors, automatically fall back to CPU PySCF.
+                    Blackwell GPUs are forced to CPU with a warning.
   * cpu           : use CPU PySCF only.
-  * auto          : try GPU4PySCF; if the GPU backend is not available at import time,
-                    fall back to CPU PySCF before starting SCF. No CPU fallback during/after SCF.
+  * auto          : try GPU4PySCF first and fall back to CPU PySCF if unavailable (same behaviour as "gpu").
 - RKS/UKS is selected automatically from the spin multiplicity (2S+1).
 - Inputs: any structure format supported by pysisyphus.helpers.geom_loader (.pdb, .xyz, .trj, …).
   The geometry is written back unchanged as input_geometry.xyz. If a Gaussian .gjf template


### PR DESCRIPTION
## Summary
- align the dft module docstring with the GPU-first flow that falls back to CPU and handles Blackwell GPUs
- update docs/dft.md overview and notes to describe the automatic CPU fallback behaviour

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69331d1bf898832dba70a157a9540668)