### PR TITLE
Document convert-file toggle in scan workflows

### DIFF
--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -9,6 +9,7 @@ Usage (CLI)
     pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} -q CHARGE -m MULT \
                         [--mep-mode {gsm|dmf}] [--freeze-links BOOL] [--max-nodes N] [--max-cycles N] \
                         [--climb BOOL] [--dump BOOL] [--thresh PRESET] \
+                        [--convert-files/--no-convert-files] \
                         [--out-dir DIR] [--args-yaml FILE]
 
 Examples
@@ -39,10 +40,10 @@ Outputs (& Directory Layout)
 ----------------------------
 out_dir/ (default: ./result_path_opt/)
   ├─ final_geometries.trj        # XYZ trajectory of the optimized path; comment line carries per-image energy when available
-  ├─ final_geometries.pdb        # Converted from .trj when the *first* endpoint is a PDB
+  ├─ final_geometries.pdb        # Converted from .trj when the *first* endpoint is a PDB and conversion is enabled
   ├─ hei.xyz                     # Highest-energy image with energy on the comment line
-  ├─ hei.pdb                     # HEI converted to PDB when the *first* endpoint is a PDB
-  ├─ hei.gjf                     # HEI written using a detected .gjf template, when available
+  ├─ hei.pdb                     # HEI converted to PDB when the *first* endpoint is a PDB and conversion is enabled
+  ├─ hei.gjf                     # HEI written using a detected .gjf template when available and conversion is enabled
   ├─ align_refine/               # Files from external alignment/refinement
   └─ <optimizer dumps / restarts>  # Emitted when dumping is enabled (e.g., via `--dump` and/or YAML `dump_restart` settings)
 
@@ -53,6 +54,7 @@ Notes
 - `--max-nodes` sets the number of internal nodes; the string has (max_nodes + 2) images including endpoints.
 - `--max-cycles` limits optimization; after full growth, the same bound applies to additional refinement.
 - `--preopt-max-cycles` limits only the optional endpoint single-structure preoptimization (LBFGS or RFO, selected via `--opt-mode`) and does not affect `--max-cycles`.
+- Format-aware XYZ/TRJ → PDB/GJF conversions respect the global `--convert-files/--no-convert-files` toggle (default: enabled).
 - Exit codes: 0 (success); 3 (optimization failed); 4 (final trajectory write error); 5 (HEI dump error); 130 (keyboard interrupt); 1 (unhandled error).
 """
 

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -11,8 +11,9 @@ Usage (CLI)
         [--one-based|--zero-based] [--max-step-size <float>] \
         [--bias-k <float>] [--relax-max-cycles <int>] \
         [--opt-mode {light|heavy}] [--freeze-links {True|False}] \
-        [--dump {True|False}] [--out-dir <dir>] [--thresh <preset>] \
-        [--args-yaml <file>] [--preopt {True|False}] [--endopt {True|False}]
+        [--dump {True|False}] [--convert-files/--no-convert-files] \
+        [--out-dir <dir>] [--thresh <preset>] [--args-yaml <file>] \
+        [--preopt {True|False}] [--endopt {True|False}]
 
 Examples
 --------
@@ -64,20 +65,22 @@ Outputs (& Directory Layout)
 out_dir/ (default: ./result_scan/)
   ├─ preopt/                      # Created when --preopt True; holds the unbiased starting optimization
   │   ├─ result.xyz
-  │   ├─ result.gjf               # Present when the original input provided a GJF template
-  │   └─ result.pdb               # Present when the input was PDB
+  │   ├─ result.gjf               # When a GJF template is available **and** conversion is enabled
+  │   └─ result.pdb               # When the input was PDB **and** conversion is enabled
   └─ stage_{k:02d}/               # One directory per stage (k = 1..K)
       ├─ result.xyz               # Final structure for the stage (after optional endopt)
-      ├─ result.gjf               # Present when the original input provided a GJF template
-      ├─ result.pdb               # Present when the input was PDB
+      ├─ result.gjf               # When a GJF template is available **and** conversion is enabled
+      ├─ result.pdb               # When the input was PDB **and** conversion is enabled
       ├─ scan.trj                 # Written only when --dump True (concatenated biased frames)
-      └─ scan.pdb                 # Written only when --dump True and the input was PDB
+      └─ scan.pdb                 # Written only when --dump True, the input was PDB, and conversion is enabled
 
 Notes
 -----
 - UMA only: `uma_pysis` is the sole supported calculator.
 - Optimizers: `--opt-mode light` (default) selects LBFGS; `--opt-mode heavy` selects RFOptimizer.
   Step/trust radii are capped in Bohr based on `--max-step-size` (Å).
+- Format-aware XYZ/TRJ → PDB/GJF conversions honor the global
+  `--convert-files/--no-convert-files` toggle (default: enabled).
 - Indexing: (i, j) are 1‑based by default; use `--zero-based` if your tuples are 0‑based.
 - Units: Distances in CLI/YAML are Å; the bias is applied internally in a.u. (Hartree/Bohr) with
   k converted from eV/Å² to Hartree/Bohr².

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -15,6 +15,7 @@ Usage (CLI)
         --opt-mode {light,heavy} \
         --freeze-links {True|False} \
         --dump {True|False} \
+        [--convert-files/--no-convert-files] \
         --out-dir PATH \
         [--args-yaml FILE] \
         [--preopt {True|False}] \
@@ -60,13 +61,13 @@ out_dir/ (default: ./result_scan2d/)
   ├─ scan2d_landscape.html        # 3D surface with a base-plane projection
   └─ grid/
       ├─ point_i125_j324.xyz      # Constrained, relaxed geometries; i/j tags are 100×distance in Å (rounded)
-      ├─ point_i125_j324.pdb      # Same, when the input was a PDB
-      ├─ point_i125_j324.gjf      # Same, when the input provided a GJF template
+      ├─ point_i125_j324.pdb      # Same, when the input was a PDB and conversion is enabled
+      ├─ point_i125_j324.gjf      # Same, when the input provided a GJF template and conversion is enabled
       ├─ preopt_i126_j326.xyz     # Preoptimized unbiased structure; tags from its d1/d2 distances
-      ├─ preopt_i126_j326.pdb     # Optional PDB version (for PDB input)
-      ├─ preopt_i126_j326.gjf     # Optional GJF version (for GJF input)
+      ├─ preopt_i126_j326.pdb     # Optional PDB version (for PDB input and conversion enabled)
+      ├─ preopt_i126_j326.gjf     # Optional GJF version (for GJF input and conversion enabled)
       ├─ inner_path_d1_###.trj    # Written only when --dump True; captures inner d2 trajectories per outer step
-      └─ inner_path_d1_###.pdb    # PDB conversion of inner_path_d1_###.trj when the input was a PDB
+      └─ inner_path_d1_###.pdb    # PDB conversion of inner_path_d1_###.trj when the input was a PDB and conversion is enabled
 
 Optimizer scratch artifacts live in temporary directories; only the files above persist under ``out_dir``.
 
@@ -77,6 +78,7 @@ Notes
 - Ångström limits are converted to Bohr to cap LBFGS step and RFO trust radii.
 - The `-m/--multiplicity` option sets the spin multiplicity (2S+1) for the ML region.
 - `-q/--charge` is required for non-`.gjf` inputs; `.gjf` templates supply charge/spin when available.
+- Format-aware XYZ/TRJ → PDB/GJF conversions respect the global `--convert-files/--no-convert-files` toggle (default: enabled).
 - `--baseline min|first`:
   - `min`   : shift PES so that the global minimum is 0 kcal/mol (**default**)
   - `first` : shift so that the first grid point (i=0, j=0) is 0 kcal/mol

--- a/pdb2reaction/scan3d.py
+++ b/pdb2reaction/scan3d.py
@@ -16,6 +16,7 @@ Usage (CLI)
         [--opt-mode {light,heavy}] \
         [--freeze-links {True|False}] \
         [--dump {True|False}] \
+        [--convert-files/--no-convert-files] \
         [--out-dir PATH] \
         [--csv PATH] \
         [--args-yaml FILE] \
@@ -88,10 +89,15 @@ out_dir/ (default: ./result_scan3d/)
   └─ grid/
       ├─ point_iXXX_jYYY_kZZZ.xyz     # Constrained, relaxed geometries for each grid point
   │                                   # XXX,YYY,ZZZ = int(round(d(Å)*100)), e.g. d=1.25Å → "125"
+      ├─ point_iXXX_jYYY_kZZZ.pdb     # PDB companion when the input was PDB and conversion is enabled
+      ├─ point_iXXX_jYYY_kZZZ.gjf     # GJF companion when a template is available and conversion is enabled
       ├─ preopt_iXXX_jYYY_kZZZ.xyz    # Starting structure used for the scan:
   │                                   # pre-optimized when --preopt True, otherwise the input structure;
   │                                   # same naming convention as above.
+      ├─ preopt_iXXX_jYYY_kZZZ.pdb    # PDB companion for the starting structure when conversion is enabled
+      ├─ preopt_iXXX_jYYY_kZZZ.gjf    # GJF companion for the starting structure when conversion is enabled
       └─ inner_path_d1_###_d2_###.trj # When --dump True; captures inner d3 paths per (d1,d2)
+         inner_path_d1_###_d2_###.pdb  # PDB conversion of the inner-path trajectory when input was PDB and conversion enabled
 
 Notes
 -----
@@ -102,6 +108,7 @@ Notes
   - `min`   : shift PES so that the global minimum is 0 kcal/mol (**default**)
   - `first` : shift so that the grid point with `(i,j,k) = (0,0,0)` is 0 kcal/mol;
               if that point is missing, the global minimum is used instead.
+- Format-aware XYZ/TRJ → PDB/GJF conversions respect the global `--convert-files/--no-convert-files` toggle (default: enabled).
 - The 3D visualization:
   - 3D RBF interpolation on a **50×50×50 grid** in (d1,d2,d3)-space.
   - Several semi-transparent isosurfaces (mesh) at discrete energy levels with **step color bands**


### PR DESCRIPTION
## Summary
- document the convert-files/--no-convert-files toggle in scan, scan2d, scan3d, and path-opt docstrings
- clarify output listings so PDB/GJF companions are tied to the conversion flag

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69331d1bf898832dba70a157a9540668)