### PR TITLE
Update freq documentation to match CLI defaults

### DIFF
--- a/docs/freq.md
+++ b/docs/freq.md
@@ -59,7 +59,7 @@ pdb2reaction freq -i a.xyz -q -1 --args-yaml ./args.yaml --out-dir ./result_freq
 | `-q, --charge INT` | Total charge. Required unless the input is a `.gjf` template with charge metadata. | Required when not in template |
 | `-m, --multiplicity INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--freeze-links BOOL` | PDB-only. Freeze parents of link hydrogens and merge with `geom.freeze_atoms`. | `True` |
-| `--max-write INT` | Number of modes to export. | `20` |
+| `--max-write INT` | Number of modes to export. | `10` |
 | `--amplitude-ang FLOAT` | Mode animation amplitude (Å). | `0.8` |
 | `--n-frames INT` | Frames per mode animation. | `20` |
 | `--sort CHOICE` | Mode ordering: `value` (cm⁻¹) or `abs`. | `value` |
@@ -109,6 +109,6 @@ calc:
 freq:
   amplitude_ang: 0.8
   n_frames: 20
-  max_write: 20
+  max_write: 10
   sort: value
 ```

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -6,12 +6,13 @@ freq — Vibrational frequency analysis, mode export, and PHVA-based thermochemi
 
 Usage (CLI)
 -----------
-    pdb2reaction freq -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [-s <spin>] \
+    pdb2reaction freq -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [-m <spin>] \
         [--freeze-links {True|False}] [--max-write <int>] \
         [--amplitude-ang <float>] [--n-frames <int>] [--sort {value|abs}] \
         [--out-dir <dir>] [--args-yaml <file>] [--temperature <K>] \
         [--pressure <atm>] [--dump {True|False}] \
-        [--hessian-calc-mode {Analytical|FiniteDifference}]
+        [--hessian-calc-mode {Analytical|FiniteDifference}] \
+        [--convert-files/--no-convert-files]
 
 Examples
 --------


### PR DESCRIPTION
## Summary
- update the freq docstring to use the current CLI options and include convert-file toggles
- correct the freq markdown docs to reflect the max-write default of 10 and align the YAML example

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69331d1bf898832dba70a157a9540668)