### PR TITLE
Document trj2fig charge and multiplicity options

### DIFF
--- a/docs/trj2fig.md
+++ b/docs/trj2fig.md
@@ -13,7 +13,7 @@ lines.
 
 ## Usage
 ```bash
-pdb2reaction trj2fig -i TRAJECTORY.xyz [-o OUTPUTS...] [options]
+pdb2reaction trj2fig -i TRAJECTORY.xyz [-o OUTPUTS...] [-q CHARGE] [-m MULT] [options]
 ```
 
 ### Examples
@@ -26,6 +26,9 @@ pdb2reaction trj2fig -i traj.xyz -o energy.csv energy.svg -r 5 --unit hartree
 
 # Multiple figure formats with the x-axis reversed (reference becomes last frame)
 pdb2reaction trj2fig -i traj.xyz --reverse-x -o energy.png energy.html energy.pdf
+
+# Recompute all frame energies with UMA before plotting
+pdb2reaction trj2fig -i traj.xyz -q 0 -m 1 -o energy.png
 ```
 
 ## Workflow

--- a/pdb2reaction/trj2fig.py
+++ b/pdb2reaction/trj2fig.py
@@ -7,12 +7,15 @@ trj2fig — Energy-profile utility for XYZ trajectories
 Usage (CLI)
 -----------
     pdb2reaction trj2fig -i traj.xyz [-o OUTPUT ...] [-r {init|None|INT}] \
-        [--unit {kcal|hartree}] [--reverse-x]
+        [-q CHARGE] [-m MULT] [--unit {kcal|hartree}] [--reverse-x]
 
 Examples
 --------
     # High-resolution PNG with x-axis reversed (reference is the last frame)
     pdb2reaction trj2fig -i traj.xyz --reverse-x
+
+    # Recompute energies with explicit charge/spin before plotting (kcal/mol)
+    pdb2reaction trj2fig -i traj.xyz -q 0 -m 1
 
     # CSV + figure (reference frame #5; output values in hartree)
     pdb2reaction trj2fig -i traj.xyz -o energy.csv energy.svg -r 5 --unit hartree


### PR DESCRIPTION
## Summary
- update trj2fig CLI docstring to include charge and multiplicity flags and example
- clarify docs/trj2fig.md usage/examples to show energy recomputation via UMA

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69331d18c17c832d83fc4c1cead4eb07)