### PR TITLE
Document default verbose logging for extract

### DIFF
--- a/docs/extract.md
+++ b/docs/extract.md
@@ -92,7 +92,7 @@ pdb2reaction extract -i complex1.pdb complex2.pdb -c A:123 \
 | `--add-linkH BOOL` | Add carbon-only link hydrogens at 1.09 Å along severed bonds. | `true` |
 | `--selected-resn TEXT` | Force-include residues (IDs with optional chains/insertion codes). | `""` |
 | `--ligand-charge TEXT` | Total charge or per-resname mapping (e.g., `GPP:-3,MMT:-1`). | `None` |
-| `-v, --verbose` | Emit INFO-level logging (`true`) or keep warnings only (`false`). | `false` |
+| `-v, --verbose` | Emit INFO-level logging (`true`) or keep warnings only (`false`). | `true` |
 
 ## Outputs
 - Pocket PDB(s) containing the extracted residues, with optional link hydrogens appended after a `TER` record.

--- a/pdb2reaction/extract.py
+++ b/pdb2reaction/extract.py
@@ -126,6 +126,7 @@ Notes
   - ``--include-H2O`` default: **true**.
   - ``--exclude-backbone`` default: **true**.
   - ``--add-linkH`` default: **true**.
+  - ``--verbose`` default: **true** (INFO logging enabled; set to ``false`` to keep warnings only).
   - ``--ligand-charge`` default: **None** (unknown residues counted as 0 unless set).
   - Output default: single input → ``pocket.pdb``; multiple inputs → ``pocket_{original_filename}.pdb``.
 - **Geometry thresholds and tolerances:**


### PR DESCRIPTION
## Summary
- note the default INFO-level logging for extract in the module docstring
- align the CLI option table to show verbose logging defaults to true

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693320b822e4832daa1f151ef45aa379)