### PR TITLE
Fix CLI docstrings to reference multiplicity flag

### DIFF
--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -17,7 +17,7 @@ Usage (CLI)
 Examples
 --------
     # Minimal frequency run with explicit charge and spin
-    pdb2reaction freq -i a.pdb -q 0 -s 1
+    pdb2reaction freq -i a.pdb -q 0 -m 1
 
     # PHVA with YAML overrides and a custom output directory
     pdb2reaction freq -i a.xyz -q -1 --args-yaml ./args.yaml --out-dir ./result_freq/

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -7,7 +7,7 @@ scan — Bond‑length–driven staged scan with harmonic distance restraints an
 Usage (CLI)
 -----------
     pdb2reaction scan -i INPUT.{pdb|xyz|trj|...} [-q <charge>] \
-        [--scan-lists "[(I,J,TARGET_ANG), ...]" ...] [-s <spin>] \
+        [--scan-lists "[(I,J,TARGET_ANG), ...]" ...] [-m <spin>] \
         [--one-based|--zero-based] [--max-step-size <float>] \
         [--bias-k <float>] [--relax-max-cycles <int>] \
         [--opt-mode {light|heavy}] [--freeze-links {True|False}] \


### PR DESCRIPTION
## Summary
- correct frequency and scan docstrings to reference the -m/--multiplicity flag instead of the removed -s shorthand

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693320b822e4832daa1f151ef45aa379)