### PR TITLE
Align DFT documentation with current CLI behavior

### DIFF
--- a/docs/dft.md
+++ b/docs/dft.md
@@ -23,9 +23,9 @@ pdb2reaction dft -i input.pdb -q 0 -m 2 --func-basis "wb97m-v/def2-tzvpd" \
 ```
 
 ## Workflow
-1. **Input handling** – Any file loadable by `geom_loader` (.pdb/.xyz/.trj/…) is accepted. Coordinates are re-exported as `input_geometry.xyz`, and when the source was a Gaussian template a matching `.gjf` snapshot is written for reference.
+1. **Input handling** – Any file loadable by `geom_loader` (.pdb/.xyz/.trj/…) is accepted. Coordinates are re-exported as `input_geometry.xyz`, and when the source was a Gaussian template and conversion is enabled a matching `.gjf` snapshot is written for reference.
 2. **Configuration merge** – Defaults → YAML (`dft` block) → CLI. Charge/multiplicity inherit `.gjf` metadata when present; otherwise `-q/--charge` is required and multiplicity defaults to `1`. Always set them explicitly so the correct RKS/UKS solver is selected.
-3. **SCF build** – `--func-basis` is parsed into XC functional and orbital basis. Density fitting is enabled automatically and a practical JKFIT auxiliary basis is guessed from the orbital basis (def2, cc-pVXZ, Pople families). `--engine` controls GPU/CPU preference (`gpu` tries GPU4PySCF before falling back; `cpu` forces CPU; `auto` tries GPU then CPU). Nonlocal VV10 is activated for functionals whose names end in `-v` or contain `vv10`.
+3. **SCF build** – `--func-basis` is parsed into XC functional and orbital basis. Density fitting is enabled automatically with PySCF defaults. `--engine` controls GPU/CPU preference (`gpu` tries GPU4PySCF before falling back; `cpu` forces CPU; `auto` tries GPU then CPU). Nonlocal VV10 is activated for functionals whose names end in `-v` or contain `vv10`.
 4. **Population analysis & outputs** – After convergence (or failure) the command writes `result.yaml` summarising energy (Hartree/kcal·mol⁻¹), convergence metadata, timing, backend info, and per-atom Mulliken/meta-Löwdin/IAO charges and spin densities (UKS only for spins). Any failed analysis column is set to `null` with a warning.
 
 ## CLI options
@@ -53,7 +53,7 @@ pdb2reaction dft -i input.pdb -q 0 -m 2 --func-basis "wb97m-v/def2-tzvpd" \
 
 ## Notes
 - GPU4PySCF is used whenever available; CPU PySCF is built otherwise (unless `--engine cpu` forces CPU). `--engine auto` mirrors the GPU-first fallback logic, automatically retrying on the CPU backend when GPU import/runtime errors occur. Blackwell GPUs are detected and forced to CPU with a warning to avoid unsupported GPU4PySCF configurations.
-- Density fitting is always attempted; auxiliary bases are auto-selected for def2/cc-pVXZ/Pople families and silently skipped when unsupported.
+- Density fitting is always attempted with PySCF defaults (no auxiliary basis guessing is implemented).
 - The YAML file must contain a mapping root with top-level key `dft`; non-mapping roots raise an error via `load_yaml_dict`.
 - Exit codes: `0` (converged), `3` (not converged), `2` (PySCF import failure), `1` (other errors), `130` (interrupt).
 - IAO spin/charge analysis may fail for challenging systems; corresponding columns in `result.yaml` become `null` and a warning is printed.

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -9,7 +9,7 @@ Usage (CLI)
     pdb2reaction dft -i INPUT.{pdb|xyz|gjf|...} [-q <charge>] [-m <multiplicity>] \
         [--func-basis "FUNC/BASIS"] [--max-cycle <int>] [--conv-tol <hartree>] \
         [--grid-level <int>] [--out-dir <dir>] [--engine {gpu|cpu|auto}] \
-        [--args-yaml <file>]
+        [--convert-files/--no-convert-files] [--args-yaml <file>]
 
 Examples
 --------
@@ -31,7 +31,7 @@ Description
 - RKS/UKS is selected automatically from the spin multiplicity (2S+1).
 - Inputs: any structure format supported by pysisyphus.helpers.geom_loader (.pdb, .xyz, .trj, …).
   The geometry is written back unchanged as input_geometry.xyz. If a Gaussian .gjf template
-  is present, a convenience input_geometry.gjf is also written.
+  is present **and conversion is enabled**, a convenience input_geometry.gjf is also written.
 - Functional/basis specified as "FUNC/BASIS" via --func-basis (e.g., "wb97m-v/6-31g**", "wb97m-v/def2-svp", "wb97m-v/def2-tzvpd").
   Names are case-insensitive in PySCF.
 - Density fitting (DF) is enabled via PySCF's density_fit(); the auxiliary basis is left to
@@ -53,7 +53,7 @@ Outputs (& Directory Layout)
 out_dir/ (default: ./result_dft/)
   ├─ result.yaml                # Input metadata, SCF energy (Eh/kcal), convergence status, timing, and per-atom charge/spin tables
   ├─ input_geometry.xyz         # Geometry snapshot passed to PySCF (as read; unchanged)
-  └─ input_geometry.gjf         # Convenience GJF written when a Gaussian template is available
+  └─ input_geometry.gjf         # Convenience GJF when a Gaussian template is available and conversion is enabled
 
 Notes
 -----


### PR DESCRIPTION
## Summary
- document the convert-files toggle in the dft CLI usage and output description
- clarify that GJF snapshots depend on conversion being enabled
- update DFT docs to describe density fitting using PySCF defaults instead of auxiliary-basis guessing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933225e00cc832d8483e335e29bb172)