### PR TITLE
Align scan2d docs with CLI defaults and outputs

### DIFF
--- a/docs/scan2d.md
+++ b/docs/scan2d.md
@@ -46,8 +46,8 @@ pdb2reaction scan2d -i input.pdb -q 0 \
 5. After all points are visited, write `<out-dir>/surface.csv` with columns
    `i,j,d1_A,d2_A,energy_hartree,energy_kcal,bias_converged`, shifting the kcal
    reference via `--baseline {min|first}`. Generate `scan2d_map.png` (2D contour)
-   and `scan2d_landscape.html` (3D surface) inside `<out-dir>/plots/`. Use
-   `--zmin/--zmax` to clamp the color scale.
+   and `scan2d_landscape.html` (3D surface) in `<out-dir>/`. Use `--zmin/--zmax`
+   to clamp the color scale.
 
 ## CLI options
 | Option | Description | Default |
@@ -82,7 +82,7 @@ pdb2reaction scan2d -i input.pdb -q 0 \
 ## Outputs
 `<out-dir>/` (default `./result_scan2d/`):
 - `surface.csv` — structured grid table.
-- `plots/scan2d_map.png` (or `.html` fallback) and `plots/scan2d_landscape.html`
+- `scan2d_map.png` (or `.html` fallback) and `scan2d_landscape.html`
   — 2D contour and 3D surface visualizations.
 - `grid/point_i###_j###.xyz` — relaxed geometries for every `(i, j)` pair (with `.pdb`/`.gjf` companions when conversion is enabled and templates exist).
 - `grid/inner_path_d1_###.trj` — written only when `--dump True` (mirrored to `.pdb` when conversion is enabled for PDB inputs).

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -9,14 +9,14 @@ Usage (CLI)
     pdb2reaction scan2d -i INPUT.{pdb,xyz,trj,...} [-q <charge>] [-m <multiplicity>] \
         --scan-list "[(I1,J1,LOW1,HIGH1),(I2,J2,LOW2,HIGH2)]" \
         [--one-based|--zero-based] \
-        --max-step-size FLOAT \
-        --bias-k FLOAT \
-        --relax-max-cycles INT \
-        --opt-mode {light,heavy} \
-        --freeze-links {True|False} \
-        --dump {True|False} \
+        [--max-step-size FLOAT] \
+        [--bias-k FLOAT] \
+        [--relax-max-cycles INT] \
+        [--opt-mode {light,heavy}] \
+        [--freeze-links {True|False}] \
+        [--dump {True|False}] \
         [--convert-files/--no-convert-files] \
-        --out-dir PATH \
+        [--out-dir PATH] \
         [--args-yaml FILE] \
         [--preopt {True|False}] \
         [--baseline {first|min}] \


### PR DESCRIPTION
## Summary
- mark optional scan2d CLI flags as optional in the module docstring
- correct docs/scan2d.md to reflect output locations and formatting that match the script

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933225e00cc832d8483e335e29bb172)