### PR TITLE
Clarify convert-files behavior for freq PDB outputs

### DIFF
--- a/docs/freq.md
+++ b/docs/freq.md
@@ -42,8 +42,9 @@ pdb2reaction freq -i a.xyz -q -1 --args-yaml ./args.yaml --out-dir ./result_freq
 - **Mode export**: `--max-write` limits how many modes are animated. Modes are sorted by
   value (or absolute value with `--sort abs`). The sinusoidal animation amplitude
   (`--amplitude-ang`) and frame count (`--n-frames`) match the YAML defaults. `.trj`
-  animations are produced for every input; `.pdb` animations mirror them when a PDB template
-  is available (ASE conversion is used as a fallback).
+  animations are produced for every input; `.pdb` animations are written only when a PDB
+  template exists **and** `--convert-files` remains enabled (ASE conversion is used as a
+  fallback).
 - **Thermochemistry**: if `thermoanalysis` is installed, a QRRHO-like summary (EE, ZPE, E/H/G
   corrections, heat capacities, entropies) is printed using PHVA frequencies. CLI pressure in
   atm is converted internally to Pa. When `--dump True`, a `thermoanalysis.yaml` snapshot is
@@ -68,11 +69,12 @@ pdb2reaction freq -i a.xyz -q -1 --args-yaml ./args.yaml --out-dir ./result_freq
 | `--pressure FLOAT` | Thermochemistry pressure (atm). | `1.0` |
 | `--dump BOOL` | Explicit `True`/`False`. Write `thermoanalysis.yaml`. | `False` |
 | `--hessian-calc-mode CHOICE` | UMA Hessian mode (`Analytical` or `FiniteDifference`). | _None_ (uses YAML/default of `FiniteDifference`) |
-| `--convert-files/--no-convert-files` | Toggle XYZ/TRJ → PDB/GJF companions for PDB/Gaussian inputs. | `--convert-files` |
+| `--convert-files/--no-convert-files` | Toggle XYZ/TRJ → PDB companions when a PDB template is available (GJF is not written). | `--convert-files` |
 | `--args-yaml FILE` | YAML overrides (sections: `geom`, `calc`, `freq`). | _None_ |
 
 ## Outputs
-- `<out-dir>/mode_XXXX_±freqcm-1.trj` and `.pdb` animations for each written mode (mirroring follows `--convert-files`).
+- `<out-dir>/mode_XXXX_±freqcm-1.trj` animations for each written mode. `.pdb` companions are
+  produced only when a PDB template exists **and** `--convert-files` is enabled.
 - `<out-dir>/frequencies_cm-1.txt` listing every computed frequency according to the sort
   order.
 - `<out-dir>/thermoanalysis.yaml` when both `thermoanalysis` is importable and `--dump True`.

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -26,7 +26,7 @@ Description
 -----------
 - Computes vibrational frequencies and normal modes using the UMA calculator.
 - Supports Partial Hessian Vibrational Analysis (PHVA) when atoms are frozen.
-- Exports animated modes (.trj; .pdb only when the input is PDB) and prints a Gaussian-style thermochemistry summary.
+- Exports animated modes (.trj; .pdb only when the input is PDB **and** ``--convert-files`` is enabled) and prints a Gaussian-style thermochemistry summary.
 - Configuration can be provided via YAML (sections: ``geom``, ``calc``, ``freq``); YAML values override CLI.
 - Thermochemistry uses the PHVA frequencies (respecting ``freeze_atoms``). CLI pressure (atm) is converted internally to Pa.
 - The thermochemistry summary is printed when the optional ``thermoanalysis`` package is available; writing a YAML summary is controlled by ``--dump``.
@@ -37,7 +37,7 @@ Outputs (& Directory Layout)
 ----------------------------
 out_dir/ (default: ./result_freq/)
   ├─ mode_XXXX_{±freq}cm-1.trj    # XYZ-like trajectory (Å) with sinusoidal motion per mode
-  ├─ mode_XXXX_{±freq}cm-1.pdb    # Multi-MODEL PDB animation (written only for PDB inputs)
+  ├─ mode_XXXX_{±freq}cm-1.pdb    # Multi-MODEL PDB animation (PDB inputs only, when --convert-files is enabled)
   ├─ frequencies_cm-1.txt         # All computed frequencies (cm^-1), sorted according to --sort
   └─ thermoanalysis.yaml          # Thermochemistry summary (written only when --dump True and thermoanalysis is available)
 


### PR DESCRIPTION
## Summary
- document that freq writes PDB animations only when convert-files is enabled for PDB inputs
- update CLI option description to reflect PDB-only conversions rather than PDB/Gaussian

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933225e00cc832d8483e335e29bb172)