### PR TITLE
Clarify default path_search behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ Behaviour:
 
 - takes two or more **full systems** in reaction order,
 - extracts catalytic pockets for each structure,
-- performs a **single‑pass GSM / MEP search** via `path-opt` by default,
-- optionally switches to a recursive refiner (`path_search`) with `--refine-path True`,
+- performs a **recursive GSM / MEP search** via `path_search` by default,
+- optionally switches to a **single‑pass** `path-opt` run with `--refine-path False`,
 - when PDB templates are available, merges the pocket‑level MEP back into the **full system**,
 - optionally runs TS optimisation, vibrational analysis, and DFT single points for each segment.
 
@@ -213,8 +213,8 @@ Key points:
   - 1‑based indices taken from the original full PDB,
   - automatically remapped to the pocket indices.
 - Each stage writes a `stage_XX/result.pdb`, which is treated as a candidate intermediate or product.
-- The default `all` workflow then concatenates these stages using `path-opt`.
-- With `--refine-path True`, it instead runs the recursive `path_search` refiner and (when possible) writes merged full‑system `mep_w_ref*.pdb` files under `<outdir>/path_search/`.
+- The default `all` workflow refines the concatenated stages with recursive `path_search`.
+- With `--refine-path False`, it instead performs a single-pass `path-opt` chain and skips the recursive refiner (no merged `mep_w_ref*.pdb`).
 
 This mode is useful for building approximate reaction paths starting from a single experimental structure.
 
@@ -313,13 +313,13 @@ Below are the most commonly used options across workflows.
 - `--dft BOOLEAN`  
   Perform DFT single‑point calculations on UMA optimised structures via PySCF / gpu4pyscf. When combined with `--thermo True`, this adds DFT//UMA Gibbs diagrams.
 
-- `--refine-path BOOLEAN`  
+- `--refine-path BOOLEAN`
   Switch between:
 
-  - **single‑pass GSM** with `path-opt` (simple MEP),
-  - **recursive GSM / MEP refinement** with `path_search`.
+  - **recursive GSM / MEP refinement** with `path_search` (default),
+  - **single‑pass GSM** with `path-opt` (simple MEP) when set to `False`.
 
-  When `--refine-path True` and full‑system PDB templates are available, merged MEP snapshots (`mep_w_ref*.pdb`) are written under `<outdir>/path_search/`.
+  When `--refine-path True` (default) and full‑system PDB templates are available, merged MEP snapshots (`mep_w_ref*.pdb`) are written under `<outdir>/path_search/`.
 
 For a full matrix of options and YAML schemas, see `docs/all.md` in the repository.
 

--- a/docs/all.md
+++ b/docs/all.md
@@ -45,7 +45,8 @@ pdb2reaction all -i reactant.pdb -c "GPP,MMT" \
    - Stage endpoints (`stage_XX/result.pdb`) become the ordered intermediates that feed the subsequent GSM step.
 
 3. **MEP search on pockets (recursive GSM)**
-   - Executes `path_search` using the extracted pockets (or the original structures if extraction is skipped). Relevant options: `--multiplicity`, `--freeze-links`, `--max-nodes`, `--max-cycles`, `--climb`, `--opt-mode`, `--dump`, `--preopt`, `--args-yaml`, and `--out-dir`.
+   - Executes `path_search` by default using the extracted pockets (or the original structures if extraction is skipped). Relevant options: `--multiplicity`, `--freeze-links`, `--max-nodes`, `--max-cycles`, `--climb`, `--opt-mode`, `--dump`, `--preopt`, `--args-yaml`, and `--out-dir`.
+   - Use `--refine-path False` to switch to a single-pass `path-opt` GSM chain without the recursive refiner.
    - For multi-input PDB runs, the full-system templates are automatically passed to `path_search` for reference merging. Single-structure scan runs reuse the original full PDB template for every stage.
 
 4. **Merge pockets back to the full systems**

--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -2,9 +2,10 @@
 
 """
 all — SINGLE command to execute an end-to-end enzymatic reaction workflow:
-Extract pockets → (optional) staged scan on a single structure → MEP (path-opt by default; recursive
-GSM with ``--refine-path True``) → merge to full systems (when PDB templates are available), with
-optional TS optimization, IRC (EulerPC), thermochemistry, DFT, and DFT//UMA diagrams
+Extract pockets → (optional) staged scan on a single structure → MEP (recursive ``path_search`` by
+default; single-pass ``path-opt`` with ``--refine-path False``) → merge to full systems (when PDB
+templates are available), with optional TS optimization, IRC (EulerPC), thermochemistry, DFT, and
+DFT//UMA diagrams
 ================================================================================================================
 
 Usage (CLI)
@@ -72,15 +73,16 @@ Runs a one-shot pipeline centered on pocket models:
       `[initial pocket or full input, stage_01/result.pdb, stage_02/result.pdb, ...]`.
 
 (2) **MEP search on pocket inputs**
-    - By default runs **single-pass** `path-opt` GSM per adjacent pair and concatenates the segments.
-      With ``--refine-path True``, uses recursive `path_search` instead (options forwarded from this command).
+    - By default runs recursive `path_search` (options forwarded from this command). With
+      ``--refine-path False``, switches to a **single-pass** `path-opt` GSM per adjacent pair and
+      concatenates the segments.
     - For multi-input runs, the original **full** PDBs are supplied as **merge references** automatically
       **only when the original inputs are PDB files**. In the single-structure scan series, if the original
       full input is a PDB, the same template is reused for all pocket (or full-input) structures.
 
 (3) **Merge to full systems**
-    - With ``--refine-path True`` **and** reference full-system PDB templates (see (2)), the pocket MEP is
-      merged back into the original full-system template(s) within `<out-dir>/path_search/`.
+    - With ``--refine-path True`` (default) **and** reference full-system PDB templates (see (2)), the pocket
+      MEP is merged back into the original full-system template(s) within `<out-dir>/path_search/`.
     - When ``--refine-path False``, only pocket-level outputs are produced and no merged `mep_w_ref*.pdb`
       files are written.
     - If references are not supplied (e.g., inputs are not PDB or extraction is skipped), only pocket-level


### PR DESCRIPTION
## Summary
- update all-command docstring to reflect path_search as the default MEP method
- adjust all.md and README.md to document that path_search runs by default and path-opt requires --refine-path False

## Testing
- not run (documentation-only changes)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933254e0e88832d996fd873e5022eee)