### PR TITLE
Restore missing output details in docs

### DIFF
--- a/docs/add_elem_info.md
+++ b/docs/add_elem_info.md
@@ -46,8 +46,9 @@ pdb2reaction add-elem-info -i 1abc.pdb -o 1abc_fixed.pdb --overwrite
 | `--overwrite` | Re-infer elements even if the original fields are present. | `False` |
 
 ## Outputs
-- A PDB with element symbols populated (`--out` destination or the input file in
-  place).
+```
+<output>.pdb  # Element symbols populated; defaults to overwriting the input when --out is omitted
+```
 - Console report with totals for processed/assigned/kept/overwritten atoms,
   per-element counts, and up to 50 unresolved atoms.
 

--- a/docs/all.md
+++ b/docs/all.md
@@ -124,13 +124,15 @@ pdb2reaction all -i reactant.pdb -c "GPP,MMT" \
 | `--scan-endopt BOOLEAN` | Override the scan end-of-stage optimisation toggle. | _None_ |
 
 ## Outputs
-- `<out-dir>/summary.log`: Human-readable run digest (CLI invocation, MEP/segment stats, post-processing energies, key files);
-  also stored per GSM/TSOPT branch in `<out-dir>/path_search/*/summary.log`.
-- `<out-dir>/pockets/`: Per-input pocket PDBs when extraction runs.
-- `<out-dir>/scan/`: Present when `--scan-lists` is used; contains staged pocket scan results (`stage_XX/result.pdb`).
-- `<out-dir>/path_search/`: GSM results (trajectory, merged full-system PDBs, energy diagrams, `summary.yaml`, per-segment folders).
-- `<out-dir>/path_search/tsopt_seg_XX/`: Present when post-processing is enabled; includes TS optimisation, pseudo-IRC, freq, and DFT outputs plus diagrams.
-- `<out-dir>/tsopt_single/`: Present only in TSOPT-only mode; contains TS optimisation outputs, IRC endpoints, and optional freq/DFT directories.
+```
+out_dir/ (default: ./result_all/)
+├─ summary.log               # Human-readable digest (also mirrored under path_search/*/summary.log)
+├─ pockets/                  # Per-input pocket PDBs when extraction runs
+├─ scan/                     # Staged pocket scan results (present when --scan-lists is provided)
+├─ path_search/              # GSM results: trajectories, merged PDBs, diagrams, summary.yaml, per-segment folders
+├─ path_search/tsopt_seg_XX/ # Post-processing outputs (TS optimisation, pseudo-IRC, freq, DFT, diagrams)
+├─ tsopt_single/             # TSOPT-only outputs with IRC endpoints and optional freq/DFT directories
+```
 - Console logs summarising pocket charge resolution, YAML contents, scan stages, GSM progress, and per-stage timing.
 
 ## Notes

--- a/docs/dft.md
+++ b/docs/dft.md
@@ -44,12 +44,19 @@ pdb2reaction dft -i input.pdb -q 0 -m 2 --func-basis "wb97m-v/def2-tzvpd" \
 | `--args-yaml FILE` | YAML overrides (see below). | _None_ |
 
 ## Outputs
-- `<out-dir>/input_geometry.xyz`: Geometry snapshot passed to PySCF (identical coordinates to the input file). `.gjf` is emitted when the input had Gaussian metadata and conversion is enabled.
-- `<out-dir>/result.yaml`:
-  - `energy` block with Hartree/kcal·mol⁻¹ values, convergence flag, wall time, and engine metadata (`gpu4pyscf` vs `pyscf(cpu)`, `used_gpu`).
-  - `charges`: Mulliken, meta-Löwdin, and IAO atomic charges (IAO may be `null` if unavailable).
-  - `spin_densities`: Mulliken, meta-Löwdin, and IAO atomic spin densities (restricted cases report zero/`null` as appropriate).
-- Console pretty block summarising charge, multiplicity, spin (2S), functional, basis, convergence knobs, and resolved output directory.
+```
+out_dir/ (default: ./result_dft/)
+├─ input_geometry.xyz   # Geometry snapshot sent to PySCF
+├─ input_geometry.gjf   # Only when a Gaussian template exists and conversion is enabled
+└─ result.yaml          # Energy/charge/spin summaries with convergence/engine metadata
+```
+- `result.yaml` expands to:
+  - `energy`: Hartree/kcal·mol⁻¹ values, convergence flag, wall time, engine metadata
+    (`gpu4pyscf` vs `pyscf(cpu)`, `used_gpu`).
+  - `charges`: Mulliken, meta-Löwdin, and IAO atomic charges (`null` when a method fails).
+  - `spin_densities`: Mulliken, meta-Löwdin, and IAO spin densities (UKS-only for spins).
+- Console pretty block summarising charge, multiplicity, spin (2S), functional, basis,
+  convergence knobs, and resolved output directory.
 
 ## Notes
 - GPU4PySCF is used whenever available; CPU PySCF is built otherwise (unless `--engine cpu` forces CPU). `--engine auto` mirrors the GPU-first fallback logic, automatically retrying on the CPU backend when GPU import/runtime errors occur. Blackwell GPUs are detected and forced to CPU with a warning to avoid unsupported GPU4PySCF configurations.

--- a/docs/extract.md
+++ b/docs/extract.md
@@ -95,10 +95,12 @@ pdb2reaction extract -i complex1.pdb complex2.pdb -c A:123 \
 | `-v, --verbose` | Emit INFO-level logging (`true`) or keep warnings only (`false`). | `true` |
 
 ## Outputs
-- Pocket PDB(s) containing the extracted residues, with optional link hydrogens appended after a `TER` record.
-  - Single input: defaults to `pocket.pdb`.
-  - Multiple inputs + no `-o`: defaults to `pocket_<original_basename>.pdb` per structure.
-  - Supplying one `-o` path with multiple inputs writes a single multi-MODEL PDB.
+```
+<output>.pdb  # Pocket PDB(s) with optional link hydrogens after a TER record
+               # Single input → pocket.pdb by default
+               # Multiple inputs without -o → pocket_<original_basename>.pdb per structure
+               # One -o path with multiple inputs → single multi-MODEL PDB
+```
 - Charge summary (protein/ligand/ion/total) is logged for model #1 when verbose mode is enabled.
 - Programmatic use (`extract_api`) returns `{"outputs": [...], "counts": [...], "charge_summary": {...}}`.
 

--- a/docs/freq.md
+++ b/docs/freq.md
@@ -73,11 +73,13 @@ pdb2reaction freq -i a.xyz -q -1 --args-yaml ./args.yaml --out-dir ./result_freq
 | `--args-yaml FILE` | YAML overrides (sections: `geom`, `calc`, `freq`). | _None_ |
 
 ## Outputs
-- `<out-dir>/mode_XXXX_±freqcm-1.trj` animations for each written mode. `.pdb` companions are
-  produced only when a PDB template exists **and** `--convert-files` is enabled.
-- `<out-dir>/frequencies_cm-1.txt` listing every computed frequency according to the sort
-  order.
-- `<out-dir>/thermoanalysis.yaml` when both `thermoanalysis` is importable and `--dump True`.
+```
+out_dir/ (default: ./result_freq/)
+├─ mode_XXXX_±freqcm-1.trj  # Per-mode animations
+├─ mode_XXXX_±freqcm-1.pdb  # Only when a PDB template exists and conversion is enabled
+├─ frequencies_cm-1.txt     # Full frequency list using the selected sort order
+└─ thermoanalysis.yaml      # Present when `thermoanalysis` is importable and --dump is True
+```
 - Console blocks summarizing resolved `geom`, `calc`, `freq`, and thermochemistry settings.
 
 ## Notes

--- a/docs/irc.md
+++ b/docs/irc.md
@@ -49,9 +49,15 @@ pdb2reaction irc -i ts.pdb -q 0 -m 1 --max-cycles 50 --out-dir ./result_irc/
 | `--args-yaml FILE` | YAML overrides (see below). | _None_ |
 
 ## Outputs
-- `<out-dir>/irc_data.h5` (written every `dump_every` steps).
-- `<out-dir>/<prefix>finished_irc.trj` plus optional forward/backward `.trj` files.
-- When the input is PDB or Gaussian, matching `.pdb`/`.gjf` trajectories are emitted using the original templates when `--convert-files` is enabled.
+```
+out_dir/ (default: ./result_irc/)
+├─ irc_data.h5                # Written every `dump_every` steps when enabled
+├─ <prefix>finished_irc.trj   # Complete IRC trajectory
+├─ <prefix>forward_irc.trj    # Present when the forward branch runs
+├─ <prefix>backward_irc.trj   # Present when the backward branch runs
+├─ *.pdb                      # Trajectory companions for PDB inputs (when conversion is enabled)
+└─ *.gjf                      # Gaussian companions when a template exists and conversion is enabled
+```
 - Console summaries of resolved `geom`, `calc`, and `irc` configurations plus wall-clock timing.
 
 ## Notes

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -63,13 +63,18 @@ pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--multiplicity 2S
 Bond-change detection relies on `bond_changes.compare_structures` with thresholds surfaced under the `bond` YAML section. UMA calculators are constructed once and shared across all structures for efficiency.
 
 ## Outputs
-- `<out-dir>/mep.trj` (and `.pdb` companions when the inputs were PDB templates and conversion is enabled).
-- `<out-dir>/mep_w_ref.pdb` merged full-system MEP (requires `--ref-pdb` or auto-provided templates; obeys conversion flag for generated companions).
-- `<out-dir>/mep_w_ref_seg_XX.pdb` merged per-segment paths for segments with covalent changes (requires `--ref-pdb`).
-- `<out-dir>/summary.yaml` summarising barriers and classification for every recursive segment.
-- `<out-dir>/mep_plot.png` ΔE profile generated via `trj2fig` (`kcal/mol`, reference = reactant).
-- `<out-dir>/energy_diagram.html` and `.png` Plotly diagrams of state energies (relative to reactant, kcal/mol).
-- Per-segment folders (`segments/seg_000_*`) containing GSM dumps, HEI snapshots, merged HEI files, linear kink optimisations, and diagnostic energy plots.
+```
+out_dir/ (default: ./result_path_search/)
+├─ mep.trj                  # Primary MEP trajectory
+├─ mep.pdb                  # PDB companion when inputs were PDB templates and conversion is enabled
+├─ mep_w_ref.pdb            # Merged full-system MEP (requires ref PDB/template)
+├─ mep_w_ref_seg_XX.pdb     # Merged per-segment paths when covalent changes exist (requires ref PDB)
+├─ summary.yaml             # Barrier and classification summary for every recursive segment
+├─ mep_plot.png             # ΔE profile generated via `trj2fig` (kcal/mol, reactant reference)
+├─ energy_diagram.html      # Plotly state-energy diagram (relative to reactant)
+├─ energy_diagram.png       # Static export of the energy diagram
+└─ segments/seg_000_*/      # GSM dumps, HEI snapshots, kink/refinement diagnostics per segment
+```
 - Console reports covering resolved configuration blocks (`geom`, `calc`, `gs`, `opt`, `sopt.*`, `bond`, `search`).
 
 ## Notes

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -84,16 +84,20 @@ UMA-based bond-change detection mirrored from `path_search`:
 - `delta_fraction` (`0.05`): Minimum relative change to flag formation/breaking.
 
 ## Outputs
-- `<out-dir>/preopt/` when `--preopt True`:
-  - `result.xyz`, `result.gjf` (if the input provided a Gaussian template and conversion is enabled), and
-    `result.pdb` (for PDB inputs when conversion is enabled).
-- `<out-dir>/stage_XX/` for each stage:
-  - `result.xyz` and optional `result.gjf`/`result.pdb` mirrors of the final
-    structure (after `--endopt`, conversion enabled).
-  - `scan.trj` when `--dump True` plus `scan.pdb` companions for
-    PDB inputs when conversion is enabled.
-- Console summaries of the resolved `geom`, `calc`, `opt`, `bias`, `bond`, and
-  optimizer blocks plus per-stage bond-change reports.
+```
+out_dir/ (default: ./result_scan/)
+├─ preopt/                   # Present when --preopt is True
+│  ├─ result.xyz
+│  ├─ result.pdb             # PDB companion for PDB inputs when conversion is enabled
+│  └─ result.gjf             # When a Gaussian template exists and conversion is enabled
+├─ stage_XX/                 # One folder per stage
+│  ├─ result.xyz
+│  ├─ result.pdb             # PDB mirror of the final structure (conversion enabled)
+│  ├─ result.gjf             # Gaussian mirror when templates exist and conversion is enabled
+│  ├─ scan.trj               # Written when --dump is True
+│  └─ scan.pdb               # Trajectory companion for PDB inputs when conversion is enabled
+```
+- Console summaries of the resolved `geom`, `calc`, `opt`, `bias`, `bond`, and optimizer blocks plus per-stage bond-change reports.
 
 ## Notes
 - `--scan-lists` may be repeated; each literal becomes one stage. Tuples must

--- a/docs/scan2d.md
+++ b/docs/scan2d.md
@@ -80,12 +80,17 @@ pdb2reaction scan2d -i input.pdb -q 0 \
 - `k` (`100`): Harmonic strength in eV·Å⁻². Overridden by `--bias-k`.
 
 ## Outputs
-`<out-dir>/` (default `./result_scan2d/`):
-- `surface.csv` — structured grid table.
-- `scan2d_map.png` (or `.html` fallback) and `scan2d_landscape.html`
-  — 2D contour and 3D surface visualizations.
-- `grid/point_i###_j###.xyz` — relaxed geometries for every `(i, j)` pair (with `.pdb`/`.gjf` companions when conversion is enabled and templates exist).
-- `grid/inner_path_d1_###.trj` — written only when `--dump True` (mirrored to `.pdb` when conversion is enabled for PDB inputs).
+```
+out_dir/ (default: ./result_scan2d/)
+├─ surface.csv                # Structured grid table
+├─ scan2d_map.png             # 2D contour (falls back to HTML when static export fails)
+├─ scan2d_map.html            # HTML contour fallback
+├─ scan2d_landscape.html      # 3D surface visualization
+├─ grid/point_i###_j###.xyz   # Relaxed geometries for every (i, j) pair
+├─ grid/point_i###_j###.pdb   # PDB companions when conversion is enabled and templates exist
+├─ grid/point_i###_j###.gjf   # Gaussian companions when templates exist and conversion is enabled
+└─ grid/inner_path_d1_###.trj # Present only when --dump is True (mirrored to .pdb for PDB inputs with conversion)
+```
 
 ## Notes
 - UMA via `uma_pysis` is the only calculator backend and reuses the same

--- a/docs/scan3d.md
+++ b/docs/scan3d.md
@@ -89,17 +89,16 @@ pdb2reaction scan3d -i input.pdb -q 0 \
 - `k` (`100`): Harmonic strength in eV·Å⁻². Overridden by `--bias-k`.
 
 ## Outputs
-`<out-dir>/` (default `./result_scan3d/`):
-- `surface.csv` — grid metadata: `i,j,k,d1_A,d2_A,d3_A,energy_hartree,energy_kcal,bias_converged`; may include a reference row
-  with `i=j=k=-1` for the starting structure (preoptimized when `--preopt True`).
-- `scan3d_density.html` — 3D energy isosurface visualization.
-- `grid/point_i###_j###_k###.xyz` — relaxed geometries for every grid point
-  (with `.pdb`/`.gjf` companions when conversion is enabled and templates exist);
-  tags are integer Å×100, e.g., 1.25 Å → `125`.
-- `grid/preopt_i###_j###_k###.xyz` — starting structure saved before scanning
-  (preoptimized when `--preopt True`).
-- `grid/inner_path_d1_###_d2_###.trj` — written only when `--dump True` (mirrored
-  to `.pdb`/`.gjf` when conversion is enabled for PDB/Gaussian inputs).
+```
+out_dir/ (default: ./result_scan3d/)
+├─ surface.csv                     # Grid metadata; may include a reference row (i=j=k=-1)
+├─ scan3d_density.html             # 3D energy isosurface visualization
+├─ grid/point_i###_j###_k###.xyz   # Relaxed geometry for each grid point (Å×100 tags)
+├─ grid/point_i###_j###_k###.pdb   # PDB companions when conversion is enabled and templates exist
+├─ grid/point_i###_j###_k###.gjf   # Gaussian companions when templates exist and conversion is enabled
+├─ grid/preopt_i###_j###_k###.xyz  # Starting structure saved before scanning (preoptimized when --preopt is True)
+└─ grid/inner_path_d1_###_d2_###.trj # Present only when --dump is True (mirrored to .pdb/.gjf with conversion)
+```
 
 ## Notes
 - UMA via `uma_pysis` is the only calculator backend and reuses the same

--- a/docs/trj2fig.md
+++ b/docs/trj2fig.md
@@ -61,11 +61,14 @@ pdb2reaction trj2fig -i traj.xyz -q 0 -m 1 -o energy.png
 | `--reverse-x` | Reverse the x-axis so the last frame appears on the left (and `init` becomes the last frame). | `False` |
 
 ## Outputs
-- Plotly figure(s) written to the requested extensions. When no `-o` is
-  supplied, a single `energy.png` is written to the current directory.
-- Optional CSV with `frame`, `energy_hartree`, and either `delta_kcal`,
-  `energy_kcal`, `delta_hartree`, or `energy_hartree` depending on the unit and
-  reference.
+```
+<output>.[png|jpg|jpeg|html|svg|pdf]  # Plotly export for every requested extension (defaults to energy.png)
+<output>.csv                          # Optional energy table when CSV is requested
+```
+- When no `-o` or positional outputs are provided, a single `energy.png` is written
+  to the current directory. CSV exports include `frame`, `energy_hartree`, and either
+  a ΔE column (`delta_kcal`/`delta_hartree`) or absolute column (`energy_kcal`/`energy_hartree`
+  when no reference is applied).
 - Console diagnostics describing parsing failures or unsupported extensions.
 
 ## Notes

--- a/docs/tsopt.md
+++ b/docs/tsopt.md
@@ -86,16 +86,18 @@ pdb2reaction tsopt -i ts_cand.pdb -q 0 -m 1 --opt-mode heavy \
 
 ## Outputs (& directory layout)
 ```
-out-dir/ (default: ./result_tsopt/)
-  ├─ final_geometry.xyz                # Always written
-  ├─ final_geometry.pdb                # When the input was PDB (conversion enabled)
-  ├─ final_geometry.gjf                # When the input was Gaussian (conversion enabled)
-  ├─ optimization_all.trj/.pdb         # Light-mode dump (requires --dump True)
-  ├─ optimization.trj/.pdb             # Heavy-mode trajectory
-  ├─ vib/
-  │   ├─ final_imag_mode_±XXXX.Xcm-1.trj
-  │   └─ final_imag_mode_±XXXX.Xcm-1.pdb/.gjf
-  └─ .dimer_mode.dat                   # Light-mode orientation seed
+out_dir/ (default: ./result_tsopt/)
+├─ final_geometry.xyz            # Always written
+├─ final_geometry.pdb            # When the input was PDB (conversion enabled)
+├─ final_geometry.gjf            # When the input was Gaussian (conversion enabled)
+├─ optimization_all.trj          # Light-mode dump when --dump is True
+├─ optimization_all.pdb          # Light-mode companion for PDB inputs (conversion enabled)
+├─ optimization.trj              # Heavy-mode trajectory
+├─ optimization.pdb              # Heavy-mode PDB companion when conversion is enabled
+├─ vib/
+│  ├─ final_imag_mode_±XXXX.Xcm-1.trj
+│  └─ final_imag_mode_±XXXX.Xcm-1.pdb/.gjf
+└─ .dimer_mode.dat               # Light-mode orientation seed
 ```
 
 ## Notes


### PR DESCRIPTION
## Summary
- reintroduce the result.yaml contents description in the dft output section
- note default behavior and CSV columns for trj2fig outputs
- add the default all-command output directory to the consolidated tree

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69332c8db80c832da8a70ac774d63cda)