### PR TITLE
Flatten freeze_atoms logging across CLI subcommands

### DIFF
--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -91,6 +91,7 @@ from .utils import (
     load_yaml_dict,
     apply_yaml_overrides,
     pretty_block,
+    format_geom_for_echo,
     format_elapsed,
     prepare_input_structure,
     resolve_charge_spin_or_raise,
@@ -456,7 +457,7 @@ def cli(
             "out_dir": str(out_dir_path),
             "engine": engine,
         }
-        click.echo(pretty_block("geom", geom_cfg))
+        click.echo(pretty_block("geom", format_geom_for_echo(geom_cfg)))
         click.echo(pretty_block("dft", echo_cfg))
 
         # --------------------------

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -96,6 +96,7 @@ from .utils import (
     convert_xyz_like_outputs,
     pretty_block,
     format_geom_for_echo,
+    format_freeze_atoms_for_echo,
     format_elapsed,
     merge_freeze_atom_indices,
     prepare_input_structure,
@@ -625,7 +626,7 @@ def cli(
 
     # Pretty-print config summary
     click.echo(pretty_block("geom", format_geom_for_echo(geom_cfg)))
-    click.echo(pretty_block("calc", calc_cfg))
+    click.echo(pretty_block("calc", format_freeze_atoms_for_echo(calc_cfg)))
     click.echo(pretty_block("freq", {**freq_cfg, "out_dir": str(out_dir_path)}))
     click.echo(pretty_block("thermo", {
         "temperature": thermo_cfg["temperature"],

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -96,6 +96,7 @@ from pdb2reaction.utils import (
     apply_yaml_overrides,
     pretty_block,
     format_geom_for_echo,
+    format_freeze_atoms_for_echo,
     format_elapsed,
     detect_freeze_links,
     merge_freeze_atom_indices,
@@ -307,7 +308,7 @@ def cli(
 
         # Pretty-print configuration (expand freeze_atoms for readability)
         click.echo(pretty_block("geom", format_geom_for_echo(geom_cfg)))
-        click.echo(pretty_block("calc", calc_cfg))
+        click.echo(pretty_block("calc", format_freeze_atoms_for_echo(calc_cfg)))
         click.echo(pretty_block("irc",  {**irc_cfg, "out_dir": str(out_dir_path)}))
 
         # --------------------------

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -143,6 +143,7 @@ from .utils import (
     apply_yaml_overrides,
     pretty_block,
     format_geom_for_echo,
+    format_freeze_atoms_for_echo,
     format_elapsed,
     merge_freeze_atom_indices,
     normalize_choice,
@@ -636,12 +637,12 @@ def cli(
             allowed_hint="light|heavy",
         )
 
-        # Pretty-print the resolved configuration
-        out_dir_path = Path(opt_cfg["out_dir"]).resolve()
-        click.echo(pretty_block("geom", format_geom_for_echo(geom_cfg)))
-        click.echo(pretty_block("calc", calc_cfg))
-        click.echo(pretty_block("opt", {**opt_cfg, "out_dir": str(out_dir_path)}))
-        click.echo(pretty_block(kind, (lbfgs_cfg if kind == "lbfgs" else rfo_cfg)))
+    # Pretty-print the resolved configuration
+    out_dir_path = Path(opt_cfg["out_dir"]).resolve()
+    click.echo(pretty_block("geom", format_geom_for_echo(geom_cfg)))
+    click.echo(pretty_block("calc", format_freeze_atoms_for_echo(calc_cfg)))
+    click.echo(pretty_block("opt", {**opt_cfg, "out_dir": str(out_dir_path)}))
+    click.echo(pretty_block(kind, (lbfgs_cfg if kind == "lbfgs" else rfo_cfg)))
         if dist_freeze:
             display_pairs = []
             for (i, j, target) in dist_freeze:

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -91,6 +91,7 @@ from .utils import (
     deep_update,
     pretty_block,
     format_geom_for_echo,
+    format_freeze_atoms_for_echo,
     format_elapsed,
     merge_freeze_atom_indices,
     prepare_input_structure,
@@ -740,7 +741,7 @@ def cli(
         # For display: resolved configuration
         out_dir_path = Path(opt_cfg["out_dir"]).resolve()
         echo_geom = format_geom_for_echo(geom_cfg)
-        echo_calc = dict(calc_cfg)
+        echo_calc = format_freeze_atoms_for_echo(calc_cfg)
         echo_gs = dict(gs_cfg)
         echo_opt = dict(opt_cfg)
         echo_opt["out_dir"] = str(out_dir_path)

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -190,6 +190,7 @@ from .utils import (
     apply_yaml_overrides,
     pretty_block,
     format_geom_for_echo,
+    format_freeze_atoms_for_echo,
     format_elapsed,
     merge_freeze_atom_indices,
     build_energy_diagram,
@@ -2178,7 +2179,7 @@ def cli(
 
         out_dir_path = Path(out_dir).resolve()
         echo_geom = format_geom_for_echo(geom_cfg)
-        echo_calc = dict(calc_cfg)
+        echo_calc = format_freeze_atoms_for_echo(calc_cfg)
         echo_gs   = dict(gs_cfg)
         echo_opt  = dict(opt_cfg)
         echo_opt["out_dir"] = str(out_dir_path)

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -131,6 +131,7 @@ from .utils import (
     apply_yaml_overrides,
     pretty_block,
     format_geom_for_echo,
+    format_freeze_atoms_for_echo,
     format_elapsed,
     merge_freeze_atom_indices,
     normalize_choice,
@@ -478,7 +479,7 @@ def cli(
         # Present final config
         out_dir_path = Path(opt_cfg["out_dir"]).resolve()
         echo_geom = format_geom_for_echo(geom_cfg)
-        echo_calc = dict(calc_cfg)
+        echo_calc = format_freeze_atoms_for_echo(calc_cfg)
         echo_opt  = dict(opt_cfg); echo_opt["out_dir"] = str(out_dir_path)
         echo_bias = dict(bias_cfg)
         echo_bond = dict(bond_cfg)

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -121,6 +121,7 @@ from .utils import (
     detect_freeze_links_safe,
     pretty_block,
     format_geom_for_echo,
+    format_freeze_atoms_for_echo,
     format_elapsed,
     merge_freeze_atom_indices,
     normalize_choice,
@@ -501,7 +502,7 @@ def cli(
         out_dir_path = Path(opt_cfg["out_dir"]).resolve()
         _ensure_dir(out_dir_path)
         echo_geom = format_geom_for_echo(geom_cfg)
-        echo_calc = dict(calc_cfg)
+        echo_calc = format_freeze_atoms_for_echo(calc_cfg)
         echo_opt = dict(opt_cfg)
         echo_opt["out_dir"] = str(out_dir_path)
         echo_bias = dict(bias_cfg)

--- a/pdb2reaction/scan3d.py
+++ b/pdb2reaction/scan3d.py
@@ -153,6 +153,7 @@ from .utils import (
     detect_freeze_links_safe,
     pretty_block,
     format_geom_for_echo,
+    format_freeze_atoms_for_echo,
     format_elapsed,
     merge_freeze_atom_indices,
     normalize_choice,
@@ -575,7 +576,7 @@ def cli(
         out_dir_path = Path(opt_cfg["out_dir"]).resolve()
         _ensure_dir(out_dir_path)
         echo_geom = format_geom_for_echo(geom_cfg)
-        echo_calc = dict(calc_cfg)
+        echo_calc = format_freeze_atoms_for_echo(calc_cfg)
         echo_opt = dict(opt_cfg)
         echo_opt["out_dir"] = str(out_dir_path)
         echo_bias = dict(bias_cfg)

--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -173,6 +173,7 @@ from .utils import (
     apply_yaml_overrides,
     pretty_block,
     format_geom_for_echo,
+    format_freeze_atoms_for_echo,
     format_elapsed,
     merge_freeze_atom_indices,
     normalize_choice,
@@ -1439,7 +1440,7 @@ def cli(
 
     # Pretty-print config summary
     click.echo(pretty_block("geom", format_geom_for_echo(geom_cfg)))
-    click.echo(pretty_block("calc", calc_cfg))
+    click.echo(pretty_block("calc", format_freeze_atoms_for_echo(calc_cfg)))
     click.echo(pretty_block("opt",  {**opt_cfg, "out_dir": str(out_dir_path)}))
     if kind == "light":
         # Split out pass-through dicts for readability

--- a/pdb2reaction/utils.py
+++ b/pdb2reaction/utils.py
@@ -161,7 +161,30 @@ def format_geom_for_echo(geom_cfg: Dict[str, Any]) -> Dict[str, Any]:
     except TypeError:
         return g
 
-    g["freeze_atoms"] = ",".join(map(str, items)) if items else ""
+    joined = ",".join(map(str, items))
+    g["freeze_atoms"] = f"[{joined}]" if items else "[]"
+    return g
+
+
+def format_freeze_atoms_for_echo(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of ``cfg`` with ``freeze_atoms`` flattened for logging."""
+
+    if "freeze_atoms" not in cfg:
+        return dict(cfg)
+
+    g = dict(cfg)
+    freeze_atoms = g.get("freeze_atoms")
+
+    if isinstance(freeze_atoms, str):
+        return g
+
+    try:
+        items = list(freeze_atoms)
+    except TypeError:
+        return g
+
+    joined = ",".join(map(str, items))
+    g["freeze_atoms"] = f"[{joined}]" if items else "[]"
     return g
 
 


### PR DESCRIPTION
## Summary
- apply freeze_atoms log formatting to all CLI calc echoes so lists stay on one line
- normalize geometry echo formatting for DFT runs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69332b9d091c832d81d27f882b5bd4cc)