### PR TITLE
Document missing YAML defaults across scan and path docs

### DIFF
--- a/docs/all.md
+++ b/docs/all.md
@@ -157,138 +157,138 @@ Example snippet combining shared and module-specific sections:
 
 ```yaml
 geom:
-  coord_type: cart
+  coord_type: cart                     # coordinate type: cartesian vs dlc internals
 calc:
-  model: uma-s-1p1
-  hessian_calc_mode: FiniteDifference
+  model: uma-s-1p1                     # UMA model tag
+  hessian_calc_mode: FiniteDifference  # Hessian mode selection
 gs:
-  max_nodes: 12
+  max_nodes: 12                        # maximum string nodes
 freq:
-  max_write: 8
+  max_write: 8                         # maximum modes written
 dft:
-  grid_level: 6
+  grid_level: 6                        # PySCF grid level
 ```
 
 ```yaml
 geom:
-  coord_type: cart
-  freeze_atoms: []
+  coord_type: cart           # coordinate type: cartesian vs dlc internals
+  freeze_atoms: []           # 0-based frozen atoms merged with CLI/link detection
 calc:
-  charge: 0
-  spin: 1
-  model: uma-s-1p1
-  task_name: omol
-  device: auto
-  max_neigh: null
-  radius: null
-  r_edges: false
-  out_hess_torch: true
-  freeze_atoms: null
-  hessian_calc_mode: FiniteDifference
-  return_partial_hessian: true
+  charge: 0                  # total charge (CLI/template override)
+  spin: 1                    # spin multiplicity 2S+1
+  model: uma-s-1p1           # UMA model tag
+  task_name: omol            # UMA task name
+  device: auto               # UMA device selection
+  max_neigh: null            # maximum neighbors for graph construction
+  radius: null               # cutoff radius for neighbor search
+  r_edges: false             # store radial edges
+  out_hess_torch: true       # request torch-form Hessian
+  freeze_atoms: null         # calculator-level frozen atoms
+  hessian_calc_mode: FiniteDifference   # Hessian mode selection
+  return_partial_hessian: true          # allow partial Hessians
 gs:
-  max_nodes: 10
-  perp_thresh: 0.005
-  reparam_check: rms
-  reparam_every: 1
-  reparam_every_full: 1
-  param: equi
-  max_micro_cycles: 10
-  reset_dlc: true
-  climb: true
-  climb_rms: 0.0005
-  climb_lanczos: true
-  climb_lanczos_rms: 0.0005
-  climb_fixed: false
-  scheduler: null
+  max_nodes: 10              # maximum string nodes
+  perp_thresh: 0.005         # perpendicular displacement threshold
+  reparam_check: rms         # reparametrization check metric
+  reparam_every: 1           # reparametrization stride
+  reparam_every_full: 1      # full reparametrization stride
+  param: equi                # parametrization scheme
+  max_micro_cycles: 10       # micro-iteration limit
+  reset_dlc: true            # rebuild delocalized coordinates each step
+  climb: true                # enable climbing image
+  climb_rms: 0.0005          # climbing RMS threshold
+  climb_lanczos: true        # Lanczos refinement for climbing
+  climb_lanczos_rms: 0.0005  # Lanczos RMS threshold
+  climb_fixed: false         # keep climbing image fixed
+  scheduler: null            # optional scheduler backend
 opt:
-  type: string
-  stop_in_when_full: 100
-  align: false
-  scale_step: global
-  max_cycles: 100
-  dump: false
-  dump_restart: false
-  reparam_thresh: 0.001
-  coord_diff_thresh: 0.0
-  out_dir: ./result_path_search/
-  print_every: 10
+  type: string               # optimizer type label
+  stop_in_when_full: 100     # early stop threshold when string is full
+  align: false               # alignment toggle (kept off)
+  scale_step: global         # step scaling mode
+  max_cycles: 100            # maximum optimization cycles
+  dump: false                # dump trajectory/restart data
+  dump_restart: false        # dump restart checkpoints
+  reparam_thresh: 0.001      # reparametrization threshold
+  coord_diff_thresh: 0.0     # coordinate difference threshold
+  out_dir: ./result_path_search/   # output directory
+  print_every: 10            # logging stride
 sopt:
   lbfgs:
-    thresh: gau
-    max_cycles: 10000
-    print_every: 100
-    min_step_norm: 1.0e-08
-    assert_min_step: true
-    rms_force: null
-    rms_force_only: false
-    max_force_only: false
-    force_only: false
-    converge_to_geom_rms_thresh: 0.05
-    overachieve_factor: 0.0
-    check_eigval_structure: false
-    line_search: true
-    dump: false
-    dump_restart: false
-    prefix: ""
-    out_dir: ./result_path_search/
-    keep_last: 7
-    beta: 1.0
-    gamma_mult: false
-    max_step: 0.3
-    control_step: true
-    double_damp: true
-    mu_reg: null
-    max_mu_reg_adaptions: 10
+    thresh: gau                # LBFGS convergence preset
+    max_cycles: 10000          # iteration limit
+    print_every: 100           # logging stride
+    min_step_norm: 1.0e-08     # minimum accepted step norm
+    assert_min_step: true      # assert when steps stagnate
+    rms_force: null            # explicit RMS force target
+    rms_force_only: false      # rely only on RMS force convergence
+    max_force_only: false      # rely only on max force convergence
+    force_only: false          # skip displacement checks
+    converge_to_geom_rms_thresh: 0.05   # RMS threshold when targeting geometry
+    overachieve_factor: 0.0    # tighten thresholds
+    check_eigval_structure: false   # validate Hessian eigenstructure
+    line_search: true          # enable line search
+    dump: false                # dump trajectory/restart data
+    dump_restart: false        # dump restart checkpoints
+    prefix: ""                 # filename prefix
+    out_dir: ./result_path_search/   # output directory
+    keep_last: 7               # history size for LBFGS buffers
+    beta: 1.0                  # initial damping beta
+    gamma_mult: false          # multiplicative gamma update toggle
+    max_step: 0.3              # maximum step length
+    control_step: true         # control step length adaptively
+    double_damp: true          # double damping safeguard
+    mu_reg: null               # regularization strength
+    max_mu_reg_adaptions: 10   # cap on mu adaptations
   rfo:
-    thresh: gau
-    max_cycles: 10000
-    print_every: 100
-    min_step_norm: 1.0e-08
-    assert_min_step: true
-    rms_force: null
-    rms_force_only: false
-    max_force_only: false
-    force_only: false
-    converge_to_geom_rms_thresh: 0.05
-    overachieve_factor: 0.0
-    check_eigval_structure: false
-    line_search: true
-    dump: false
-    dump_restart: false
-    prefix: ""
-    out_dir: ./result_path_search/
-    trust_radius: 0.3
-    trust_update: true
-    trust_min: 0.01
-    trust_max: 0.3
-    max_energy_incr: null
-    hessian_update: bfgs
-    hessian_init: calc
-    hessian_recalc: 100
-    hessian_recalc_adapt: 2.0
-    small_eigval_thresh: 1.0e-08
-    alpha0: 1.0
-    max_micro_cycles: 25
-    rfo_overlaps: false
-    gediis: false
-    gdiis: true
-    gdiis_thresh: 0.0025
-    gediis_thresh: 0.01
-    gdiis_test_direction: true
-    adapt_step_func: false
+    thresh: gau                # RFOptimizer convergence preset
+    max_cycles: 10000          # iteration cap
+    print_every: 100           # logging stride
+    min_step_norm: 1.0e-08     # minimum accepted step norm
+    assert_min_step: true      # assert when steps stagnate
+    rms_force: null            # explicit RMS force target
+    rms_force_only: false      # rely only on RMS force convergence
+    max_force_only: false      # rely only on max force convergence
+    force_only: false          # skip displacement checks
+    converge_to_geom_rms_thresh: 0.05   # RMS threshold when targeting geometry
+    overachieve_factor: 0.0    # tighten thresholds
+    check_eigval_structure: false   # validate Hessian eigenstructure
+    line_search: true          # enable line search
+    dump: false                # dump trajectory/restart data
+    dump_restart: false        # dump restart checkpoints
+    prefix: ""                 # filename prefix
+    out_dir: ./result_path_search/   # output directory
+    trust_radius: 0.3          # trust-region radius
+    trust_update: true         # enable trust-region updates
+    trust_min: 0.01            # minimum trust radius
+    trust_max: 0.3             # maximum trust radius
+    max_energy_incr: null      # allowed energy increase per step
+    hessian_update: bfgs       # Hessian update scheme
+    hessian_init: calc         # Hessian initialization source
+    hessian_recalc: 100        # rebuild Hessian every N steps
+    hessian_recalc_adapt: 2.0  # adaptive Hessian rebuild factor
+    small_eigval_thresh: 1.0e-08   # eigenvalue threshold for stability
+    alpha0: 1.0                # initial micro step
+    max_micro_cycles: 25       # micro-iteration limit
+    rfo_overlaps: false        # enable RFO overlaps
+    gediis: false              # enable GEDIIS
+    gdiis: true                # enable GDIIS
+    gdiis_thresh: 0.0025       # GDIIS acceptance threshold
+    gediis_thresh: 0.01        # GEDIIS acceptance threshold
+    gdiis_test_direction: true # test descent direction before DIIS
+    adapt_step_func: false     # adaptive step scaling toggle
 bond:
-  device: cuda
-  bond_factor: 1.2
-  margin_fraction: 0.05
-  delta_fraction: 0.05
+  device: cuda                # UMA device for bond analysis
+  bond_factor: 1.2            # covalent-radius scaling
+  margin_fraction: 0.05       # tolerance margin for comparisons
+  delta_fraction: 0.05        # minimum relative change to flag bonds
 search:
-  max_depth: 10
-  stitch_rmsd_thresh: 0.0001
-  bridge_rmsd_thresh: 0.0001
-  rmsd_align: true
-  max_nodes_segment: 10
-  max_nodes_bridge: 5
-  kink_max_nodes: 3
-  max_seq_kink: 2
+  max_depth: 10               # recursion depth limit
+  stitch_rmsd_thresh: 0.0001  # RMSD threshold for stitching segments
+  bridge_rmsd_thresh: 0.0001  # RMSD threshold for bridging nodes
+  rmsd_align: true            # legacy alignment flag (ignored)
+  max_nodes_segment: 10       # max nodes per segment
+  max_nodes_bridge: 5         # max nodes per bridge
+  kink_max_nodes: 3           # max nodes for kink optimizations
+  max_seq_kink: 2             # max sequential kinks
 ```

--- a/docs/dft.md
+++ b/docs/dft.md
@@ -79,9 +79,9 @@ _Functional/basis selection defaults to `wb97m-v/def2-tzvpd` but can be overridd
 
 ```yaml
 dft:
-  conv_tol: 1.0e-09
-  max_cycle: 100
-  grid_level: 3
-  verbose: 0
-  out_dir: ./result_dft/
+  conv_tol: 1.0e-09     # SCF convergence tolerance (Hartree)
+  max_cycle: 100        # maximum SCF iterations
+  grid_level: 3         # PySCF grid level
+  verbose: 0            # PySCF verbosity (0-9)
+  out_dir: ./result_dft/  # output directory root
 ```

--- a/docs/freq.md
+++ b/docs/freq.md
@@ -95,24 +95,24 @@ Provide a mapping; YAML values override CLI. Shared sections reuse
 
 ```yaml
 geom:
-  coord_type: cart
-  freeze_atoms: []
+  coord_type: cart           # coordinate type: cartesian vs dlc internals
+  freeze_atoms: []           # 0-based frozen atoms merged with CLI/link detection
 calc:
-  charge: 0
-  spin: 1
-  model: uma-s-1p1
-  task_name: omol
-  device: auto
-  max_neigh: null
-  radius: null
-  r_edges: false
-  out_hess_torch: true
-  freeze_atoms: null
-  hessian_calc_mode: FiniteDifference
-  return_partial_hessian: true
+  charge: 0                  # total charge (CLI/template override)
+  spin: 1                    # spin multiplicity 2S+1
+  model: uma-s-1p1           # UMA model tag
+  task_name: omol            # UMA task name
+  device: auto               # UMA device selection
+  max_neigh: null            # maximum neighbors for graph construction
+  radius: null               # cutoff radius for neighbor search
+  r_edges: false             # store radial edges
+  out_hess_torch: true       # request torch-form Hessian
+  freeze_atoms: null         # calculator-level frozen atoms
+  hessian_calc_mode: FiniteDifference   # Hessian mode selection
+  return_partial_hessian: true          # allow partial Hessians
 freq:
-  amplitude_ang: 0.8
-  n_frames: 20
-  max_write: 10
-  sort: value
+  amplitude_ang: 0.8         # displacement amplitude for modes (Å)
+  n_frames: 20               # number of frames per mode
+  max_write: 10              # maximum number of modes to write
+  sort: value                # sort order: value vs abs
 ```

--- a/docs/irc.md
+++ b/docs/irc.md
@@ -79,45 +79,45 @@ Provide a mapping; YAML overrides CLI. Shared sections reuse [`opt`](opt.md#yaml
 
 ```yaml
 geom:
-  coord_type: cart
-  freeze_atoms: []
+  coord_type: cart           # coordinate type: cartesian vs dlc internals
+  freeze_atoms: []           # 0-based frozen atoms merged with CLI/link detection
 calc:
-  charge: 0
-  spin: 1
-  model: uma-s-1p1
-  task_name: omol
-  device: auto
-  max_neigh: null
-  radius: null
-  r_edges: false
-  out_hess_torch: true
-  freeze_atoms: null
-  hessian_calc_mode: FiniteDifference
-  return_partial_hessian: true
+  charge: 0                  # total charge (CLI/template override)
+  spin: 1                    # spin multiplicity 2S+1
+  model: uma-s-1p1           # UMA model tag
+  task_name: omol            # UMA task name
+  device: auto               # UMA device selection
+  max_neigh: null            # maximum neighbors for graph construction
+  radius: null               # cutoff radius for neighbor search
+  r_edges: false             # store radial edges
+  out_hess_torch: true       # request torch-form Hessian
+  freeze_atoms: null         # calculator-level frozen atoms
+  hessian_calc_mode: FiniteDifference   # Hessian mode selection
+  return_partial_hessian: true          # allow partial Hessians
 irc:
-  step_length: 0.1
-  max_cycles: 125
-  downhill: false
-  forward: true
-  backward: true
-  root: 0
-  hessian_init: calc
-  displ: energy
-  displ_energy: 0.001
-  displ_length: 0.1
-  rms_grad_thresh: 0.001
-  hard_rms_grad_thresh: null
-  energy_thresh: 0.000001
-  imag_below: 0.0
-  force_inflection: true
-  check_bonds: false
-  out_dir: ./result_irc/
-  prefix: ""
-  dump_fn: irc_data.h5
-  dump_every: 5
-  hessian_update: bofill
-  hessian_recalc: null
-  max_pred_steps: 500
-  loose_cycles: 3
-  corr_func: mbs
+  step_length: 0.1           # integration step length
+  max_cycles: 125            # maximum steps along IRC
+  downhill: false            # follow downhill direction only
+  forward: true              # propagate in forward direction
+  backward: true             # propagate in backward direction
+  root: 0                    # normal-mode root index
+  hessian_init: calc         # Hessian initialization source
+  displ: energy              # displacement construction method
+  displ_energy: 0.001        # energy-based displacement scaling
+  displ_length: 0.1          # length-based displacement fallback
+  rms_grad_thresh: 0.001     # RMS gradient convergence threshold
+  hard_rms_grad_thresh: null # hard RMS gradient stop
+  energy_thresh: 0.000001    # energy change threshold
+  imag_below: 0.0            # imaginary frequency cutoff
+  force_inflection: true     # enforce inflection detection
+  check_bonds: false         # check bonds during propagation
+  out_dir: ./result_irc/     # output directory
+  prefix: ""                 # filename prefix
+  dump_fn: irc_data.h5       # IRC data filename
+  dump_every: 5              # dump stride
+  hessian_update: bofill     # Hessian update scheme
+  hessian_recalc: null       # Hessian rebuild cadence
+  max_pred_steps: 500        # predictor-corrector max steps
+  loose_cycles: 3            # loose cycles before tightening
+  corr_func: mbs             # correlation function choice
 ```

--- a/docs/opt.md
+++ b/docs/opt.md
@@ -84,100 +84,100 @@ Extends `opt` with RFOptimizer fields: trust-region sizing (`trust_radius`, `tru
 ### Example YAML
 ```yaml
 geom:
-  coord_type: cart
-  freeze_atoms: []
+  coord_type: cart           # coordinate type: cartesian vs dlc internals
+  freeze_atoms: []           # 0-based frozen atoms merged with CLI/link detection
 calc:
-  charge: 0
-  spin: 1
-  model: uma-s-1p1
-  task_name: omol
-  device: auto
-  max_neigh: null
-  radius: null
-  r_edges: false
-  out_hess_torch: true
-  freeze_atoms: null
-  hessian_calc_mode: FiniteDifference
-  return_partial_hessian: true
+  charge: 0                  # total charge (CLI/template override)
+  spin: 1                    # spin multiplicity 2S+1
+  model: uma-s-1p1           # UMA model tag
+  task_name: omol            # UMA task name
+  device: auto               # UMA device selection
+  max_neigh: null            # maximum neighbors for graph construction
+  radius: null               # cutoff radius for neighbor search
+  r_edges: false             # store radial edges
+  out_hess_torch: true       # request torch-form Hessian
+  freeze_atoms: null         # calculator-level frozen atoms
+  hessian_calc_mode: FiniteDifference   # Hessian mode selection
+  return_partial_hessian: true          # allow partial Hessians
 opt:
-  thresh: gau
-  max_cycles: 10000
-  print_every: 100
-  min_step_norm: 1.0e-08
-  assert_min_step: true
-  rms_force: null
-  rms_force_only: false
-  max_force_only: false
-  force_only: false
-  converge_to_geom_rms_thresh: 0.05
-  overachieve_factor: 0.0
-  check_eigval_structure: false
-  line_search: true
-  dump: false
-  dump_restart: false
-  prefix: ""
-  out_dir: ./result_opt/
+  thresh: gau                # convergence preset (Gaussian/Baker-style)
+  max_cycles: 10000          # optimizer cycle cap
+  print_every: 100           # logging stride
+  min_step_norm: 1.0e-08     # minimum norm for step acceptance
+  assert_min_step: true      # stop if steps fall below threshold
+  rms_force: null            # explicit RMS force target
+  rms_force_only: false      # rely only on RMS force convergence
+  max_force_only: false      # rely only on max force convergence
+  force_only: false          # skip displacement checks
+  converge_to_geom_rms_thresh: 0.05   # geom RMS threshold when converging to ref
+  overachieve_factor: 0.0    # factor to tighten thresholds
+  check_eigval_structure: false   # validate Hessian eigenstructure
+  line_search: true          # enable line search
+  dump: false                # dump trajectory/restart data
+  dump_restart: false        # dump restart checkpoints
+  prefix: ""                 # filename prefix
+  out_dir: ./result_opt/     # output directory
 lbfgs:
-  thresh: gau
-  max_cycles: 10000
-  print_every: 100
-  min_step_norm: 1.0e-08
-  assert_min_step: true
-  rms_force: null
-  rms_force_only: false
-  max_force_only: false
-  force_only: false
-  converge_to_geom_rms_thresh: 0.05
-  overachieve_factor: 0.0
-  check_eigval_structure: false
-  line_search: true
-  dump: false
-  dump_restart: false
-  prefix: ""
-  out_dir: ./result_opt/
-  keep_last: 7
-  beta: 1.0
-  gamma_mult: false
-  max_step: 0.3
-  control_step: true
-  double_damp: true
-  mu_reg: null
-  max_mu_reg_adaptions: 10
+  thresh: gau                # LBFGS convergence preset
+  max_cycles: 10000          # iteration limit
+  print_every: 100           # logging stride
+  min_step_norm: 1.0e-08     # minimum accepted step norm
+  assert_min_step: true      # assert when steps stagnate
+  rms_force: null            # explicit RMS force target
+  rms_force_only: false      # rely only on RMS force convergence
+  max_force_only: false      # rely only on max force convergence
+  force_only: false          # skip displacement checks
+  converge_to_geom_rms_thresh: 0.05   # RMS threshold when targeting geometry
+  overachieve_factor: 0.0    # tighten thresholds
+  check_eigval_structure: false   # validate Hessian eigenstructure
+  line_search: true          # enable line search
+  dump: false                # dump trajectory/restart data
+  dump_restart: false        # dump restart checkpoints
+  prefix: ""                 # filename prefix
+  out_dir: ./result_opt/     # output directory
+  keep_last: 7               # history size for LBFGS buffers
+  beta: 1.0                  # initial damping beta
+  gamma_mult: false          # multiplicative gamma update toggle
+  max_step: 0.3              # maximum step length
+  control_step: true         # control step length adaptively
+  double_damp: true          # double damping safeguard
+  mu_reg: null               # regularization strength
+  max_mu_reg_adaptions: 10   # cap on mu adaptations
 rfo:
-  thresh: gau
-  max_cycles: 10000
-  print_every: 10
-  min_step_norm: 1.0e-08
-  assert_min_step: true
-  rms_force: null
-  rms_force_only: false
-  max_force_only: false
-  force_only: false
-  converge_to_geom_rms_thresh: 0.05
-  overachieve_factor: 0.0
-  check_eigval_structure: false
-  line_search: true
-  dump: false
-  dump_restart: false
-  prefix: ""
-  out_dir: ./result_opt/
-  trust_radius: 0.1
-  trust_update: true
-  trust_min: 0.0
-  trust_max: 0.1
-  max_energy_incr: null
-  hessian_update: bfgs
-  hessian_init: calc
-  hessian_recalc: 200
-  hessian_recalc_adapt: null
-  small_eigval_thresh: 1.0e-08
-  alpha0: 1.0
-  max_micro_cycles: 50
-  rfo_overlaps: false
-  gediis: false
-  gdiis: true
-  gdiis_thresh: 0.0025
-  gediis_thresh: 0.01
-  gdiis_test_direction: true
-  adapt_step_func: true
+  thresh: gau                # RFOptimizer convergence preset
+  max_cycles: 10000          # iteration cap
+  print_every: 10            # logging stride
+  min_step_norm: 1.0e-08     # minimum accepted step norm
+  assert_min_step: true      # assert when steps stagnate
+  rms_force: null            # explicit RMS force target
+  rms_force_only: false      # rely only on RMS force convergence
+  max_force_only: false      # rely only on max force convergence
+  force_only: false          # skip displacement checks
+  converge_to_geom_rms_thresh: 0.05   # RMS threshold when targeting geometry
+  overachieve_factor: 0.0    # tighten thresholds
+  check_eigval_structure: false   # validate Hessian eigenstructure
+  line_search: true          # enable line search
+  dump: false                # dump trajectory/restart data
+  dump_restart: false        # dump restart checkpoints
+  prefix: ""                 # filename prefix
+  out_dir: ./result_opt/     # output directory
+  trust_radius: 0.1          # trust-region radius
+  trust_update: true         # enable trust-region updates
+  trust_min: 0.0             # minimum trust radius
+  trust_max: 0.1             # maximum trust radius
+  max_energy_incr: null      # allowed energy increase per step
+  hessian_update: bfgs       # Hessian update scheme
+  hessian_init: calc         # Hessian initialization source
+  hessian_recalc: 200        # rebuild Hessian every N steps
+  hessian_recalc_adapt: null # adaptive Hessian rebuild limit
+  small_eigval_thresh: 1.0e-08   # eigenvalue threshold for stability
+  alpha0: 1.0                # initial micro step
+  max_micro_cycles: 50       # micro-iteration limit
+  rfo_overlaps: false        # enable RFO overlaps
+  gediis: false              # enable GEDIIS
+  gdiis: true                # enable GDIIS
+  gdiis_thresh: 0.0025       # GDIIS acceptance threshold
+  gediis_thresh: 0.01        # GEDIIS acceptance threshold
+  gdiis_test_direction: true # test descent direction before DIIS
+  adapt_step_func: true      # adaptive step scaling
 ```

--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -84,74 +84,76 @@ YAML inputs override CLI, which override the defaults listed below.
 ### Example YAML (default value)
 ```yaml
 geom:
-  coord_type: cart
-  freeze_atoms: []
+  coord_type: cart           # coordinate type: cartesian vs dlc internals
+  freeze_atoms: []           # 0-based frozen atoms merged with CLI/link detection
 calc:
-  charge: 0
-  spin: 1
-  model: uma-s-1p1
-  task_name: omol
-  device: auto
-  max_neigh: null
-  radius: null
-  r_edges: false
-  out_hess_torch: true
-  freeze_atoms: null
-  hessian_calc_mode: FiniteDifference
-  return_partial_hessian: true
+  charge: 0                  # total charge (CLI/template override)
+  spin: 1                    # spin multiplicity 2S+1
+  model: uma-s-1p1           # UMA model tag
+  task_name: omol            # UMA task name
+  device: auto               # UMA device selection
+  max_neigh: null            # maximum neighbors for graph construction
+  radius: null               # cutoff radius for neighbor search
+  r_edges: false             # store radial edges
+  out_hess_torch: true       # request torch-form Hessian
+  freeze_atoms: null         # calculator-level frozen atoms
+  hessian_calc_mode: FiniteDifference   # Hessian mode selection
+  return_partial_hessian: true          # allow partial Hessians
 gs:
-  max_nodes: 10
-  perp_thresh: 0.005
-  reparam_check: rms
-  reparam_every: 1
-  reparam_every_full: 1
-  param: equi
-  max_micro_cycles: 10
-  reset_dlc: true
-  climb: true
-  climb_rms: 0.0005
-  climb_lanczos: true
-  climb_lanczos_rms: 0.0005
-  climb_fixed: false
-  scheduler: null
+  fix_first: true            # keep the first endpoint fixed during optimization
+  fix_last: true             # keep the last endpoint fixed during optimization
+  max_nodes: 10              # maximum string nodes
+  perp_thresh: 0.005         # perpendicular displacement threshold
+  reparam_check: rms         # reparametrization check metric
+  reparam_every: 1           # reparametrization stride
+  reparam_every_full: 1      # full reparametrization stride
+  param: equi                # parametrization scheme
+  max_micro_cycles: 10       # micro-iteration limit
+  reset_dlc: true            # rebuild delocalized coordinates each step
+  climb: true                # enable climbing image
+  climb_rms: 0.0005          # climbing RMS threshold
+  climb_lanczos: true        # Lanczos refinement for climbing
+  climb_lanczos_rms: 0.0005  # Lanczos RMS threshold
+  climb_fixed: false         # keep climbing image fixed
+  scheduler: null            # optional scheduler backend
 opt:
-  type: string
-  stop_in_when_full: 300
-  align: false
-  scale_step: global
-  max_cycles: 300
-  dump: false
-  dump_restart: false
-  reparam_thresh: 0.0
-  coord_diff_thresh: 0.0
-  out_dir: ./result_path_opt/
-  print_every: 10
+  type: string               # optimizer type label
+  stop_in_when_full: 300     # early stop threshold when string is full
+  align: false               # alignment toggle (kept off)
+  scale_step: global         # step scaling mode
+  max_cycles: 300            # maximum optimization cycles
+  dump: false                # dump trajectory/restart data
+  dump_restart: false        # dump restart checkpoints
+  reparam_thresh: 0.0        # reparametrization threshold
+  coord_diff_thresh: 0.0     # coordinate difference threshold
+  out_dir: ./result_path_opt/   # output directory
+  print_every: 10            # logging stride
 dmf:
-  correlated: true
-  sequential: true
-  fbenm_only_endpoints: false
+  correlated: true           # correlated DMF propagation
+  sequential: true           # sequential DMF execution
+  fbenm_only_endpoints: false   # run FB-ENM beyond endpoints
   fbenm_options:
-    delta_scale: 0.2
-    bond_scale: 1.25
-    fix_planes: true
-    two_hop_mode: sparse
+    delta_scale: 0.2         # FB-ENM displacement scaling
+    bond_scale: 1.25         # bond cutoff scaling
+    fix_planes: true         # enforce planar constraints
+    two_hop_mode: sparse     # neighbor traversal strategy
   cfbenm_options:
-    bond_scale: 1.25
-    corr0_scale: 1.1
-    corr1_scale: 1.5
-    corr2_scale: 1.6
-    eps: 0.05
-    pivotal: true
-    single: true
-    remove_fourmembered: true
-    two_hop_mode: sparse
+    bond_scale: 1.25         # CFB-ENM bond cutoff scaling
+    corr0_scale: 1.1         # correlation scale for corr0
+    corr1_scale: 1.5         # correlation scale for corr1
+    corr2_scale: 1.6         # correlation scale for corr2
+    eps: 0.05                # correlation epsilon
+    pivotal: true            # pivotal residue handling
+    single: true             # single-atom pivots
+    remove_fourmembered: true   # prune four-membered rings
+    two_hop_mode: sparse     # neighbor traversal strategy
   dmf_options:
-    remove_rotation_and_translation: false
-    mass_weighted: false
-    parallel: false
-    eps_vel: 0.01
-    eps_rot: 0.01
-    beta: 10.0
-    update_teval: false
-  k_fix: 100.0
+    remove_rotation_and_translation: false  # keep rigid-body motions
+    mass_weighted: false     # toggle mass weighting
+    parallel: false          # enable parallel DMF
+    eps_vel: 0.01            # velocity tolerance
+    eps_rot: 0.01            # rotational tolerance
+    beta: 10.0               # beta parameter for DMF
+    update_teval: false      # update transition evaluation
+  k_fix: 100.0               # harmonic constant for restraints
 ```

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -101,152 +101,155 @@ The YAML root must be a mapping. YAML parameters override the CLI values. Shared
 ### Example YAML (default value)
 ```yaml
 geom:
-  coord_type: cart
-  freeze_atoms: []
+  coord_type: cart           # coordinate type: cartesian vs dlc internals
+  freeze_atoms: []           # 0-based frozen atoms merged with CLI/link detection
 calc:
-  charge: 0
-  spin: 1
-  model: uma-s-1p1
-  task_name: omol
-  device: auto
-  max_neigh: null
-  radius: null
-  r_edges: false
-  out_hess_torch: true
-  freeze_atoms: null
-  hessian_calc_mode: FiniteDifference
-  return_partial_hessian: true
+  charge: 0                  # total charge (CLI/template override)
+  spin: 1                    # spin multiplicity 2S+1
+  model: uma-s-1p1           # UMA model tag
+  task_name: omol            # UMA task name
+  device: auto               # UMA device selection
+  max_neigh: null            # maximum neighbors for graph construction
+  radius: null               # cutoff radius for neighbor search
+  r_edges: false             # store radial edges
+  out_hess_torch: true       # request torch-form Hessian
+  freeze_atoms: null         # calculator-level frozen atoms
+  hessian_calc_mode: FiniteDifference   # Hessian mode selection
+  return_partial_hessian: true          # allow partial Hessians
 gs:
-  max_nodes: 10
-  perp_thresh: 0.005
-  reparam_check: rms
-  reparam_every: 1
-  reparam_every_full: 1
-  param: equi
-  max_micro_cycles: 10
-  reset_dlc: true
-  climb: true
-  climb_rms: 0.0005
-  climb_lanczos: true
-  climb_lanczos_rms: 0.0005
-  climb_fixed: false
-  scheduler: null
+  fix_first: true            # keep the first endpoint fixed during optimization
+  fix_last: true             # keep the last endpoint fixed during optimization
+  max_nodes: 10              # maximum string nodes
+  perp_thresh: 0.005         # perpendicular displacement threshold
+  reparam_check: rms         # reparametrization check metric
+  reparam_every: 1           # reparametrization stride
+  reparam_every_full: 1      # full reparametrization stride
+  param: equi                # parametrization scheme
+  max_micro_cycles: 10       # micro-iteration limit
+  reset_dlc: true            # rebuild delocalized coordinates each step
+  climb: true                # enable climbing image
+  climb_rms: 0.0005          # climbing RMS threshold
+  climb_lanczos: true        # Lanczos refinement for climbing
+  climb_lanczos_rms: 0.0005  # Lanczos RMS threshold
+  climb_fixed: false         # keep climbing image fixed
+  scheduler: null            # optional scheduler backend
 opt:
-  type: string
-  stop_in_when_full: 300
-  align: false
-  scale_step: global
-  max_cycles: 300
-  dump: false
-  dump_restart: false
-  reparam_thresh: 0.0
-  coord_diff_thresh: 0.0
-  out_dir: ./result_path_search/
-  print_every: 10
+  type: string               # optimizer type label
+  stop_in_when_full: 300     # early stop threshold when string is full
+  align: false               # alignment toggle (kept off)
+  scale_step: global         # step scaling mode
+  max_cycles: 300            # maximum optimization cycles
+  dump: false                # dump trajectory/restart data
+  dump_restart: false        # dump restart checkpoints
+  reparam_thresh: 0.0        # reparametrization threshold
+  coord_diff_thresh: 0.0     # coordinate difference threshold
+  out_dir: ./result_path_search/   # output directory
+  print_every: 10            # logging stride
 dmf:
-  correlated: true
-  sequential: true
-  fbenm_only_endpoints: false
+  correlated: true           # correlated DMF propagation
+  sequential: true           # sequential DMF execution
+  fbenm_only_endpoints: false   # run FB-ENM beyond endpoints
   fbenm_options:
-    delta_scale: 0.2
-    bond_scale: 1.25
-    fix_planes: true
-    two_hop_mode: sparse
+    delta_scale: 0.2         # FB-ENM displacement scaling
+    bond_scale: 1.25         # bond cutoff scaling
+    fix_planes: true         # enforce planar constraints
+    two_hop_mode: sparse     # neighbor traversal strategy
   cfbenm_options:
-    bond_scale: 1.25
-    corr0_scale: 1.1
-    corr1_scale: 1.5
-    corr2_scale: 1.6
-    eps: 0.05
-    pivotal: true
-    single: true
-    remove_fourmembered: true
-    two_hop_mode: sparse
+    bond_scale: 1.25         # CFB-ENM bond cutoff scaling
+    corr0_scale: 1.1         # correlation scale for corr0
+    corr1_scale: 1.5         # correlation scale for corr1
+    corr2_scale: 1.6         # correlation scale for corr2
+    eps: 0.05                # correlation epsilon
+    pivotal: true            # pivotal residue handling
+    single: true             # single-atom pivots
+    remove_fourmembered: true   # prune four-membered rings
+    two_hop_mode: sparse     # neighbor traversal strategy
   dmf_options:
-    remove_rotation_and_translation: false
-    mass_weighted: false
-    parallel: false
-    eps_vel: 0.01
-    eps_rot: 0.01
-    beta: 10.0
-    update_teval: false
-  k_fix: 100.0
+    remove_rotation_and_translation: false  # keep rigid-body motions
+    mass_weighted: false     # toggle mass weighting
+    parallel: false          # enable parallel DMF
+    eps_vel: 0.01            # velocity tolerance
+    eps_rot: 0.01            # rotational tolerance
+    beta: 10.0               # beta parameter for DMF
+    update_teval: false      # update transition evaluation
+  k_fix: 100.0               # harmonic constant for restraints
 sopt:
   lbfgs:
-    thresh: gau
-    max_cycles: 10000
-    print_every: 100
-    min_step_norm: 1.0e-08
-    assert_min_step: true
-    rms_force: null
-    rms_force_only: false
-    max_force_only: false
-    force_only: false
-    converge_to_geom_rms_thresh: 0.05
-    overachieve_factor: 0.0
-    check_eigval_structure: false
-    line_search: true
-    dump: false
-    dump_restart: false
-    prefix: ""
-    out_dir: ./result_path_search/
-    keep_last: 7
-    beta: 1.0
-    gamma_mult: false
-    max_step: 0.3
-    control_step: true
-    double_damp: true
-    mu_reg: null
-    max_mu_reg_adaptions: 10
+    thresh: gau                # LBFGS convergence preset
+    max_cycles: 10000          # iteration limit
+    print_every: 100           # logging stride
+    min_step_norm: 1.0e-08     # minimum accepted step norm
+    assert_min_step: true      # assert when steps stagnate
+    rms_force: null            # explicit RMS force target
+    rms_force_only: false      # rely only on RMS force convergence
+    max_force_only: false      # rely only on max force convergence
+    force_only: false          # skip displacement checks
+    converge_to_geom_rms_thresh: 0.05   # RMS threshold when targeting geometry
+    overachieve_factor: 0.0    # tighten thresholds
+    check_eigval_structure: false   # validate Hessian eigenstructure
+    line_search: true          # enable line search
+    dump: false                # dump trajectory/restart data
+    dump_restart: false        # dump restart checkpoints
+    prefix: ""                 # filename prefix
+    out_dir: ./result_path_search/   # output directory
+    keep_last: 7               # history size for LBFGS buffers
+    beta: 1.0                  # initial damping beta
+    gamma_mult: false          # multiplicative gamma update toggle
+    max_step: 0.3              # maximum step length
+    control_step: true         # control step length adaptively
+    double_damp: true          # double damping safeguard
+    mu_reg: null               # regularization strength
+    max_mu_reg_adaptions: 10   # cap on mu adaptations
   rfo:
-    thresh: gau
-    max_cycles: 10000
-    print_every: 100
-    min_step_norm: 1.0e-08
-    assert_min_step: true
-    rms_force: null
-    rms_force_only: false
-    max_force_only: false
-    force_only: false
-    converge_to_geom_rms_thresh: 0.05
-    overachieve_factor: 0.0
-    check_eigval_structure: false
-    line_search: true
-    dump: false
-    dump_restart: false
-    prefix: ""
-    out_dir: ./result_path_search/
-    trust_radius: 0.3
-    trust_update: true
-    trust_min: 0.01
-    trust_max: 0.3
-    max_energy_incr: null
-    hessian_update: bfgs
-    hessian_init: calc
-    hessian_recalc: 100
-    hessian_recalc_adapt: 2.0
-    small_eigval_thresh: 1.0e-08
-    alpha0: 1.0
-    max_micro_cycles: 25
-    rfo_overlaps: false
-    gediis: false
-    gdiis: true
-    gdiis_thresh: 0.0025
-    gediis_thresh: 0.01
-    gdiis_test_direction: true
-    adapt_step_func: false
+    thresh: gau                # RFOptimizer convergence preset
+    max_cycles: 10000          # iteration cap
+    print_every: 100           # logging stride
+    min_step_norm: 1.0e-08     # minimum accepted step norm
+    assert_min_step: true      # assert when steps stagnate
+    rms_force: null            # explicit RMS force target
+    rms_force_only: false      # rely only on RMS force convergence
+    max_force_only: false      # rely only on max force convergence
+    force_only: false          # skip displacement checks
+    converge_to_geom_rms_thresh: 0.05   # RMS threshold when targeting geometry
+    overachieve_factor: 0.0    # tighten thresholds
+    check_eigval_structure: false   # validate Hessian eigenstructure
+    line_search: true          # enable line search
+    dump: false                # dump trajectory/restart data
+    dump_restart: false        # dump restart checkpoints
+    prefix: ""                 # filename prefix
+    out_dir: ./result_path_search/   # output directory
+    trust_radius: 0.3          # trust-region radius
+    trust_update: true         # enable trust-region updates
+    trust_min: 0.01            # minimum trust radius
+    trust_max: 0.3             # maximum trust radius
+    max_energy_incr: null      # allowed energy increase per step
+    hessian_update: bfgs       # Hessian update scheme
+    hessian_init: calc         # Hessian initialization source
+    hessian_recalc: 100        # rebuild Hessian every N steps
+    hessian_recalc_adapt: 2.0  # adaptive Hessian rebuild factor
+    small_eigval_thresh: 1.0e-08   # eigenvalue threshold for stability
+    alpha0: 1.0                # initial micro step
+    max_micro_cycles: 25       # micro-iteration limit
+    rfo_overlaps: false        # enable RFO overlaps
+    gediis: false              # enable GEDIIS
+    gdiis: true                # enable GDIIS
+    gdiis_thresh: 0.0025       # GDIIS acceptance threshold
+    gediis_thresh: 0.01        # GEDIIS acceptance threshold
+    gdiis_test_direction: true # test descent direction before DIIS
+    adapt_step_func: false     # adaptive step scaling toggle
 bond:
-  device: cuda
-  bond_factor: 1.2
-  margin_fraction: 0.05
-  delta_fraction: 0.05
+  device: cuda                # UMA device for bond analysis
+  bond_factor: 1.2            # covalent-radius scaling
+  margin_fraction: 0.05       # tolerance margin for comparisons
+  delta_fraction: 0.05        # minimum relative change to flag bonds
 search:
-  max_depth: 10
-  stitch_rmsd_thresh: 0.0001
-  bridge_rmsd_thresh: 0.0001
-  rmsd_align: true
-  max_nodes_segment: 10
-  max_nodes_bridge: 5
-  kink_max_nodes: 3
-  max_seq_kink: 2
+  max_depth: 10               # recursion depth limit
+  stitch_rmsd_thresh: 0.0001  # RMSD threshold for stitching segments
+  bridge_rmsd_thresh: 0.0001  # RMSD threshold for bridging nodes
+  rmsd_align: true            # legacy alignment flag (ignored)
+  max_nodes_segment: 10       # max nodes per segment
+  max_nodes_bridge: 5         # max nodes per bridge
+  kink_max_nodes: 3           # max nodes for kink optimizations
+  max_seq_kink: 2             # max sequential kinks
+  refine_mode: null           # optional refinement strategy (auto-chooses when null)
 ```

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -117,107 +117,107 @@ reuse the definitions documented for [`opt`](opt.md#yaml-configuration-args-yaml
 
 ```yaml
 geom:
-  coord_type: cart
-  freeze_atoms: []
+  coord_type: cart           # coordinate type: cartesian vs dlc internals
+  freeze_atoms: []           # 0-based frozen atoms merged with CLI/link detection
 calc:
-  charge: 0
-  spin: 1
-  model: uma-s-1p1
-  task_name: omol
-  device: auto
-  max_neigh: null
-  radius: null
-  r_edges: false
-  out_hess_torch: true
-  freeze_atoms: null
-  hessian_calc_mode: FiniteDifference
-  return_partial_hessian: true
+  charge: 0                  # total charge (CLI/template override)
+  spin: 1                    # spin multiplicity 2S+1
+  model: uma-s-1p1           # UMA model tag
+  task_name: omol            # UMA task name
+  device: auto               # UMA device selection
+  max_neigh: null            # maximum neighbors for graph construction
+  radius: null               # cutoff radius for neighbor search
+  r_edges: false             # store radial edges
+  out_hess_torch: true       # request torch-form Hessian
+  freeze_atoms: null         # calculator-level frozen atoms
+  hessian_calc_mode: FiniteDifference   # Hessian mode selection
+  return_partial_hessian: true          # allow partial Hessians
 opt:
-  thresh: gau
-  max_cycles: 10000
-  print_every: 100
-  min_step_norm: 1.0e-08
-  assert_min_step: true
-  rms_force: null
-  rms_force_only: false
-  max_force_only: false
-  force_only: false
-  converge_to_geom_rms_thresh: 0.05
-  overachieve_factor: 0.0
-  check_eigval_structure: false
-  line_search: true
-  dump: false
-  dump_restart: false
-  prefix: ""
-  out_dir: ./result_scan/
+  thresh: gau                # convergence preset (Gaussian/Baker-style)
+  max_cycles: 10000          # optimizer cycle cap
+  print_every: 100           # logging stride
+  min_step_norm: 1.0e-08     # minimum norm for step acceptance
+  assert_min_step: true      # stop if steps fall below threshold
+  rms_force: null            # explicit RMS force target
+  rms_force_only: false      # rely only on RMS force convergence
+  max_force_only: false      # rely only on max force convergence
+  force_only: false          # skip displacement checks
+  converge_to_geom_rms_thresh: 0.05   # geom RMS threshold when converging to ref
+  overachieve_factor: 0.0    # factor to tighten thresholds
+  check_eigval_structure: false   # validate Hessian eigenstructure
+  line_search: true          # enable line search
+  dump: false                # dump trajectory/restart data
+  dump_restart: false        # dump restart checkpoints
+  prefix: ""                 # filename prefix
+  out_dir: ./result_scan/    # output directory
 lbfgs:
-  thresh: gau
-  max_cycles: 10000
-  print_every: 100
-  min_step_norm: 1.0e-08
-  assert_min_step: true
-  rms_force: null
-  rms_force_only: false
-  max_force_only: false
-  force_only: false
-  converge_to_geom_rms_thresh: 0.05
-  overachieve_factor: 0.0
-  check_eigval_structure: false
-  line_search: true
-  dump: false
-  dump_restart: false
-  prefix: ""
-  out_dir: ./result_scan/
-  keep_last: 7
-  beta: 1.0
-  gamma_mult: false
-  max_step: 0.3
-  control_step: true
-  double_damp: true
-  mu_reg: null
-  max_mu_reg_adaptions: 10
+  thresh: gau                # LBFGS convergence preset
+  max_cycles: 10000          # iteration limit
+  print_every: 100           # logging stride
+  min_step_norm: 1.0e-08     # minimum accepted step norm
+  assert_min_step: true      # assert when steps stagnate
+  rms_force: null            # explicit RMS force target
+  rms_force_only: false      # rely only on RMS force convergence
+  max_force_only: false      # rely only on max force convergence
+  force_only: false          # skip displacement checks
+  converge_to_geom_rms_thresh: 0.05   # RMS threshold when targeting geometry
+  overachieve_factor: 0.0    # tighten thresholds
+  check_eigval_structure: false   # validate Hessian eigenstructure
+  line_search: true          # enable line search
+  dump: false                # dump trajectory/restart data
+  dump_restart: false        # dump restart checkpoints
+  prefix: ""                 # filename prefix
+  out_dir: ./result_scan/    # output directory
+  keep_last: 7               # history size for LBFGS buffers
+  beta: 1.0                  # initial damping beta
+  gamma_mult: false          # multiplicative gamma update toggle
+  max_step: 0.3              # maximum step length
+  control_step: true         # control step length adaptively
+  double_damp: true          # double damping safeguard
+  mu_reg: null               # regularization strength
+  max_mu_reg_adaptions: 10   # cap on mu adaptations
 rfo:
-  thresh: gau
-  max_cycles: 10000
-  print_every: 100
-  min_step_norm: 1.0e-08
-  assert_min_step: true
-  rms_force: null
-  rms_force_only: false
-  max_force_only: false
-  force_only: false
-  converge_to_geom_rms_thresh: 0.05
-  overachieve_factor: 0.0
-  check_eigval_structure: false
-  line_search: true
-  dump: false
-  dump_restart: false
-  prefix: ""
-  out_dir: ./result_scan/
-  trust_radius: 0.3
-  trust_update: true
-  trust_min: 0.01
-  trust_max: 0.3
-  max_energy_incr: null
-  hessian_update: bfgs
-  hessian_init: calc
-  hessian_recalc: 100
-  hessian_recalc_adapt: 2.0
-  small_eigval_thresh: 1.0e-08
-  alpha0: 1.0
-  max_micro_cycles: 25
-  rfo_overlaps: false
-  gediis: false
-  gdiis: true
-  gdiis_thresh: 0.0025
-  gediis_thresh: 0.01
-  gdiis_test_direction: true
-  adapt_step_func: false
+  thresh: gau                # RFOptimizer convergence preset
+  max_cycles: 10000          # iteration cap
+  print_every: 100           # logging stride
+  min_step_norm: 1.0e-08     # minimum accepted step norm
+  assert_min_step: true      # assert when steps stagnate
+  rms_force: null            # explicit RMS force target
+  rms_force_only: false      # rely only on RMS force convergence
+  max_force_only: false      # rely only on max force convergence
+  force_only: false          # skip displacement checks
+  converge_to_geom_rms_thresh: 0.05   # RMS threshold when targeting geometry
+  overachieve_factor: 0.0    # tighten thresholds
+  check_eigval_structure: false   # validate Hessian eigenstructure
+  line_search: true          # enable line search
+  dump: false                # dump trajectory/restart data
+  dump_restart: false        # dump restart checkpoints
+  prefix: ""                 # filename prefix
+  out_dir: ./result_scan/    # output directory
+  trust_radius: 0.3          # trust-region radius
+  trust_update: true         # enable trust-region updates
+  trust_min: 0.01            # minimum trust radius
+  trust_max: 0.3             # maximum trust radius
+  max_energy_incr: null      # allowed energy increase per step
+  hessian_update: bfgs       # Hessian update scheme
+  hessian_init: calc         # Hessian initialization source
+  hessian_recalc: 100        # rebuild Hessian every N steps
+  hessian_recalc_adapt: 2.0  # adaptive Hessian rebuild factor
+  small_eigval_thresh: 1.0e-08   # eigenvalue threshold for stability
+  alpha0: 1.0                # initial micro step
+  max_micro_cycles: 25       # micro-iteration limit
+  rfo_overlaps: false        # enable RFO overlaps
+  gediis: false              # enable GEDIIS
+  gdiis: true                # enable GDIIS
+  gdiis_thresh: 0.0025       # GDIIS acceptance threshold
+  gediis_thresh: 0.01        # GEDIIS acceptance threshold
+  gdiis_test_direction: true # test descent direction before DIIS
+  adapt_step_func: false     # adaptive step scaling toggle
 bias:
-  k: 100
+  k: 100                    # harmonic bias strength (eV·Å⁻²)
 bond:
-  device: cuda
-  bond_factor: 1.2
-  margin_fraction: 0.05
-  delta_fraction: 0.05
+  device: cuda               # UMA device for bond analysis
+  bond_factor: 1.2           # covalent-radius scaling
+  margin_fraction: 0.05      # tolerance margin for comparisons
+  delta_fraction: 0.05       # minimum relative change to flag bonds
 ```

--- a/docs/scan2d.md
+++ b/docs/scan2d.md
@@ -108,21 +108,27 @@ configuration-args-yaml)):
 
 ```yaml
 geom:
-  coord_type: cart
-  freeze_atoms: []
+  coord_type: cart           # coordinate type: cartesian vs dlc internals
+  freeze_atoms: []           # 0-based frozen atoms merged with CLI/link detection
 calc:
-  charge: 0
-  spin: 1
-  model: uma-s-1p1
-  device: auto
+  charge: 0                  # total charge (CLI/template override)
+  spin: 1                    # spin multiplicity 2S+1
+  model: uma-s-1p1           # UMA model tag
+  device: auto               # UMA device selection
 opt:
-  thresh: gau
-  max_cycles: 10000
-  out_dir: ./result_scan2d/
+  thresh: gau                # convergence preset (Gaussian/Baker-style)
+  max_cycles: 10000          # optimizer cycle cap
+  dump: false                # trajectory dumping disabled (CLI controls dumping)
+  out_dir: ./result_scan2d/  # output directory
 lbfgs:
-  max_step: 0.3
+  max_step: 0.3              # maximum step length
+  out_dir: ./result_scan2d/  # LBFGS-specific output directory
 rfo:
-  trust_radius: 0.3
+  trust_radius: 0.3          # trust-region radius
+  out_dir: ./result_scan2d/  # RFO-specific output directory
 bias:
-  k: 100.0
+  k: 100.0                  # harmonic bias strength (eV·Å⁻²)
 ```
+
+More YAML options about `opt` are available in [docs/opt.md](opt.md#yaml-
+configuration-args-yaml).

--- a/docs/scan3d.md
+++ b/docs/scan3d.md
@@ -85,6 +85,37 @@ pdb2reaction scan3d -i input.pdb -q 0 \
   [`opt`](opt.md#yaml-configuration-args-yaml). `opt.dump` is forced to `False`
   so trajectory control stays on the CLI.
 
+More YAML options about `opt` are available in [docs/opt.md](opt.md#yaml-
+configuration-args-yaml).
+
+## YAML configuration (`--args-yaml`)
+A minimal example (extend using the keys documented for [`opt`](opt.md#yaml-
+configuration-args-yaml)):
+
+```yaml
+geom:
+  coord_type: cart           # coordinate type: cartesian vs dlc internals
+  freeze_atoms: []           # 0-based frozen atoms merged with CLI/link detection
+calc:
+  charge: 0                  # total charge (CLI/template override)
+  spin: 1                    # spin multiplicity 2S+1
+  model: uma-s-1p1           # UMA model tag
+  device: auto               # UMA device selection
+opt:
+  thresh: gau                # convergence preset (Gaussian/Baker-style)
+  max_cycles: 10000          # optimizer cycle cap
+  dump: false                # trajectory dumping disabled (CLI controls dumping)
+  out_dir: ./result_scan3d/  # output directory
+lbfgs:
+  max_step: 0.3              # maximum step length
+  out_dir: ./result_scan3d/  # LBFGS-specific output directory
+rfo:
+  trust_radius: 0.3          # trust-region radius
+  out_dir: ./result_scan3d/  # RFO-specific output directory
+bias:
+  k: 100.0                  # harmonic bias strength (eV·Å⁻²)
+```
+
 ### Section `bias`
 - `k` (`100`): Harmonic strength in eV·Å⁻². Overridden by `--bias-k`.
 

--- a/docs/tsopt.md
+++ b/docs/tsopt.md
@@ -118,124 +118,127 @@ matches your workflow—adjust only the values you need to change.
 
 ```yaml
 geom:
-  coord_type: cart
-  freeze_atoms: []
+  coord_type: cart           # coordinate type: cartesian vs dlc internals
+  freeze_atoms: []           # 0-based frozen atoms merged with CLI/link detection
 calc:
-  charge: 0
-  spin: 1
-  model: uma-s-1p1
-  task_name: omol
-  device: auto
-  max_neigh: null
-  radius: null
-  r_edges: false
-  out_hess_torch: true
-  freeze_atoms: null
-  hessian_calc_mode: FiniteDifference
-  return_partial_hessian: true
+  charge: 0                  # total charge (CLI/template override)
+  spin: 1                    # spin multiplicity 2S+1
+  model: uma-s-1p1           # UMA model tag
+  task_name: omol            # UMA task name
+  device: auto               # UMA device selection
+  max_neigh: null            # maximum neighbors for graph construction
+  radius: null               # cutoff radius for neighbor search
+  r_edges: false             # store radial edges
+  out_hess_torch: true       # request torch-form Hessian
+  freeze_atoms: null         # calculator-level frozen atoms
+  hessian_calc_mode: FiniteDifference   # Hessian mode selection
+  return_partial_hessian: true          # allow partial Hessians
 opt:
-  thresh: gau
-  max_cycles: 10000
-  print_every: 100
-  min_step_norm: 1.0e-08
-  assert_min_step: true
-  rms_force: null
-  rms_force_only: false
-  max_force_only: false
-  force_only: false
-  converge_to_geom_rms_thresh: 0.05
-  overachieve_factor: 0.0
-  check_eigval_structure: false
-  line_search: true
-  dump: false
-  dump_restart: false
-  prefix: ""
-  out_dir: ./result_tsopt/
+  thresh: gau                # convergence preset (Gaussian/Baker-style)
+  max_cycles: 10000          # optimizer cycle cap
+  print_every: 100           # logging stride
+  min_step_norm: 1.0e-08     # minimum norm for step acceptance
+  assert_min_step: true      # stop if steps fall below threshold
+  rms_force: null            # explicit RMS force target
+  rms_force_only: false      # rely only on RMS force convergence
+  max_force_only: false      # rely only on max force convergence
+  force_only: false          # skip displacement checks
+  converge_to_geom_rms_thresh: 0.05   # geom RMS threshold when converging to ref
+  overachieve_factor: 0.0    # factor to tighten thresholds
+  check_eigval_structure: false   # validate Hessian eigenstructure
+  line_search: true          # enable line search
+  dump: false                # dump trajectory/restart data
+  dump_restart: false        # dump restart checkpoints
+  prefix: ""                 # filename prefix
+  out_dir: ./result_tsopt/   # output directory
 hessian_dimer:
-  thresh_loose: gau_loose
-  thresh: gau
-  update_interval_hessian: 1000
-  neg_freq_thresh_cm: 5.0
-  flatten_amp_ang: 0.1
-  flatten_max_iter: 20
-  mem: 100000
-  use_lobpcg: true
-  device: auto
-  root: 0
+  thresh_loose: gau_loose    # loose convergence preset
+  thresh: gau                # main convergence preset
+  update_interval_hessian: 1000   # Hessian rebuild cadence
+  neg_freq_thresh_cm: 5.0    # negative frequency threshold (cm^-1)
+  flatten_amp_ang: 0.1       # flattening amplitude (Å)
+  flatten_max_iter: 20       # flattening iteration cap
+  flatten_sep_cutoff: 2.0    # minimum distance between representative atoms (Å)
+  flatten_k: 10              # representative atoms sampled per mode
+  mem: 100000                # memory limit for solver
+  use_lobpcg: true           # enable LOBPCG eigen solver
+  device: auto               # device selection for eigensolver
+  root: 0                    # targeted TS root index
   dimer:
-    length: 0.0189
-    rotation_max_cycles: 15
-    rotation_method: fourier
-    rotation_thresh: 0.0001
-    rotation_tol: 1
-    rotation_max_element: 0.001
-    rotation_interpolate: true
-    rotation_disable: false
-    rotation_disable_pos_curv: true
-    rotation_remove_trans: true
-    trans_force_f_perp: true
-    bonds: null
-    N_hessian: null
-    bias_rotation: false
-    bias_translation: false
-    bias_gaussian_dot: 0.1
-    seed: null
-    write_orientations: true
-    forward_hessian: true
+    length: 0.0189           # dimer separation (Bohr)
+    rotation_max_cycles: 15  # max rotation iterations
+    rotation_method: fourier # rotation optimizer method
+    rotation_thresh: 0.0001  # rotation convergence threshold
+    rotation_tol: 1          # rotation tolerance factor
+    rotation_max_element: 0.001   # max rotation matrix element
+    rotation_interpolate: true    # interpolate rotation steps
+    rotation_disable: false   # disable rotations entirely
+    rotation_disable_pos_curv: true   # disable when positive curvature detected
+    rotation_remove_trans: true   # remove translational components
+    trans_force_f_perp: true  # project forces perpendicular to translation
+    bonds: null               # bond list for constraints
+    N_hessian: null           # Hessian size override
+    bias_rotation: false      # bias rotational search
+    bias_translation: false   # bias translational search
+    bias_gaussian_dot: 0.1    # Gaussian bias dot product
+    seed: null                # RNG seed for rotations
+    write_orientations: true  # write rotation orientations
+    forward_hessian: true     # propagate Hessian forward
   lbfgs:
-    thresh: gau
-    max_cycles: 10000
-    print_every: 100
-    min_step_norm: 1.0e-08
-    assert_min_step: true
-    rms_force: null
-    rms_force_only: false
-    max_force_only: false
-    force_only: false
-    converge_to_geom_rms_thresh: 0.05
-    overachieve_factor: 0.0
-    check_eigval_structure: false
-    line_search: true
-    dump: false
-    dump_restart: false
-    prefix: ""
-    out_dir: ./result_opt/
-    keep_last: 7
-    beta: 1.0
-    gamma_mult: false
-    max_step: 0.3
-    control_step: true
-    double_damp: true
-    mu_reg: null
-    max_mu_reg_adaptions: 10
+    thresh: gau                # LBFGS convergence preset
+    max_cycles: 10000          # iteration limit
+    print_every: 100           # logging stride
+    min_step_norm: 1.0e-08     # minimum accepted step norm
+    assert_min_step: true      # assert when steps stagnate
+    rms_force: null            # explicit RMS force target
+    rms_force_only: false      # rely only on RMS force convergence
+    max_force_only: false      # rely only on max force convergence
+    force_only: false          # skip displacement checks
+    converge_to_geom_rms_thresh: 0.05   # RMS threshold when targeting geometry
+    overachieve_factor: 0.0    # tighten thresholds
+    check_eigval_structure: false   # validate Hessian eigenstructure
+    line_search: true          # enable line search
+    dump: false                # dump trajectory/restart data
+    dump_restart: false        # dump restart checkpoints
+    prefix: ""                 # filename prefix
+    out_dir: ./result_opt/     # output directory
+    keep_last: 7               # history size for LBFGS buffers
+    beta: 1.0                  # initial damping beta
+    gamma_mult: false          # multiplicative gamma update toggle
+    max_step: 0.3              # maximum step length
+    control_step: true         # control step length adaptively
+    double_damp: true          # double damping safeguard
+    mu_reg: null               # regularization strength
+    max_mu_reg_adaptions: 10   # cap on mu adaptations
 rsirfo:
-  thresh: gau
-  max_cycles: 10000
-  print_every: 100
-  min_step_norm: 1.0e-08
-  assert_min_step: true
-  rms_force: null
-  rms_force_only: false
-  max_force_only: false
-  force_only: false
-  converge_to_geom_rms_thresh: 0.05
-  overachieve_factor: 0.0
-  check_eigval_structure: false
-  line_search: true
-  dump: false
-  dump_restart: false
-  prefix: ""
-  out_dir: ./result_opt/
-  roots: [0]
-  hessian_ref: null
-  rx_modes: null
-  prim_coord: null
-  rx_coords: null
-  hessian_update: bofill
-  hessian_recalc_reset: true
-  max_micro_cycles: 50
-  augment_bonds: false
-  min_line_search: true
-  max_line_search: true
-  assert_neg_eigval: false
+  thresh: gau                # RS-IRFO convergence preset
+  max_cycles: 10000          # iteration cap
+  print_every: 100           # logging stride
+  min_step_norm: 1.0e-08     # minimum accepted step norm
+  assert_min_step: true      # assert when steps stagnate
+  rms_force: null            # explicit RMS force target
+  rms_force_only: false      # rely only on RMS force convergence
+  max_force_only: false      # rely only on max force convergence
+  force_only: false          # skip displacement checks
+  converge_to_geom_rms_thresh: 0.05   # RMS threshold when targeting geometry
+  overachieve_factor: 0.0    # tighten thresholds
+  check_eigval_structure: false   # validate Hessian eigenstructure
+  line_search: true          # enable line search
+  dump: false                # dump trajectory/restart data
+  dump_restart: false        # dump restart checkpoints
+  prefix: ""                 # filename prefix
+  out_dir: ./result_opt/     # output directory
+  roots: [0]                 # target root indices
+  hessian_ref: null          # reference Hessian
+  rx_modes: null             # reaction-mode definitions for projection
+  prim_coord: null           # primary coordinates to monitor
+  rx_coords: null            # reaction coordinates to monitor
+  hessian_update: bofill     # Hessian update scheme override
+  hessian_recalc_reset: true # reset recalc counter after exact Hessian
+  max_micro_cycles: 50       # micro-iterations per macro cycle
+  augment_bonds: false       # augment reaction path based on bond analysis
+  min_line_search: true      # enforce minimum line-search step
+  max_line_search: true      # enforce maximum line-search step
+  assert_neg_eigval: false   # require a negative eigenvalue at convergence
 ```
+

--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -338,7 +338,6 @@ def _resolve_override_dir(default: Path, override: Path | None) -> Path:
     return default.parent / override
 
 
-# Default UMA calculator configuration (overridable via YAML `calc` section)
 CALC_KW: Dict[str, Any] = dict(_UMA_CALC_KW)
 
 

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -478,7 +478,6 @@ def _write_mode_trj_and_pdb(geom,
 # Geometry defaults
 GEOM_KW = dict(GEOM_KW_DEFAULT)
 
-# UMA calculator defaults (freeze_atoms merged later from geom config)
 CALC_KW = dict(_UMA_CALC_KW)
 
 # Freq writer defaults

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -163,7 +163,6 @@ H_EVAA_2_AU = EV2AU / (ANG2BOHR * ANG2BOHR)  # (eV/Å^2) → (Hartree/Bohr^2)
 # Geometry options (YAML key: geom)
 GEOM_KW = dict(GEOM_KW_DEFAULT)
 
-# Calculator: UMA / uma_pysis  (YAML key: calc)
 CALC_KW = dict(_UMA_CALC_KW)
 
 # Optimizer base (common to LBFGS & RFO)  (YAML key: opt)

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -115,7 +115,6 @@ from .align_freeze_atoms import align_and_refine_sequence_inplace
 # Geometry (input handling)
 GEOM_KW: Dict[str, Any] = dict(GEOM_KW_DEFAULT)
 
-# UMA calculator settings
 CALC_KW: Dict[str, Any] = dict(_UMA_CALC_KW)
 
 # DMF (Direct Max Flux + (C)FB-ENM)
@@ -135,14 +134,14 @@ DMF_KW: Dict[str, Any] = {
 
     # CFB_ENM options (cfbenm_options)
     "cfbenm_options": {
-        "bond_scale": 1.25,
+        "bond_scale": 1.25,         # neighbor cutoff multiplier for CFB-ENM graph construction
         "corr0_scale": 1.10,        # d_corr0 ~ corr0_scale * d_bond
-        "corr1_scale": 1.50,
-        "corr2_scale": 1.60,
+        "corr1_scale": 1.50,        # scale for first correlation shell distance
+        "corr2_scale": 1.60,        # scale for second correlation shell distance
         "eps": 0.05,                # sqrt(pp^2 + eps^2) term's epsilon
-        "pivotal": True,
-        "single": True,
-        "remove_fourmembered": True,
+        "pivotal": True,            # enable pivotal constraints in the CFB-ENM
+        "single": True,             # enforce single-path constraint in correlation graph
+        "remove_fourmembered": True,# prune four-membered rings in the correlation network
         "two_hop_mode": "sparse",   # Two-hop construction on the CFB_ENM side
     },
 
@@ -150,9 +149,9 @@ DMF_KW: Dict[str, Any] = {
     "dmf_options": {
         "remove_rotation_and_translation": False,  # Do not explicitly constrain rigid-body motions
         "mass_weighted": False,                    # Whether to use mass-weighted velocity norms
-        "parallel": False,
-        "eps_vel": 0.01,
-        "eps_rot": 0.01,
+        "parallel": False,                         # allow parallel execution inside DMF core
+        "eps_vel": 0.01,                           # stabilization epsilon for velocity norms
+        "eps_rot": 0.01,                           # stabilization epsilon for rotational terms
         "beta": 10.0,                              # "Beta" for the geometric action
         "update_teval": False,                     # Control node relocation from interpolate_fbenm
     },
@@ -163,8 +162,8 @@ DMF_KW: Dict[str, Any] = {
 
 # GrowingString (path representation)
 GS_KW: Dict[str, Any] = {
-    "fix_first": True,
-    "fix_last": True,
+    "fix_first": True,           # keep the first image fixed during optimization
+    "fix_last": True,            # keep the last image fixed during optimization
     "max_nodes": 10,            # int, internal nodes; total images = max_nodes + 2 including endpoints
     "perp_thresh": 5e-3,        # float, frontier growth criterion (RMS/NORM of perpendicular force)
     "reparam_check": "rms",     # str, "rms" | "norm"; convergence check metric after reparam

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -295,7 +295,6 @@ def _bond_changes_block(text: Optional[str]):
 # Geometry (input handling)
 GEOM_KW: Dict[str, Any] = dict(GEOM_KW_DEFAULT)
 
-# UMA calculator settings
 CALC_KW: Dict[str, Any] = dict(_UMA_CALC_KW)
 
 # DMF (Direct Max Flux + (C)FB-ENM)
@@ -307,40 +306,40 @@ GS_KW: Dict[str, Any] = dict(_PATH_GS_KW)
 # StringOptimizer (GSM optimization control)
 STOPT_KW: Dict[str, Any] = dict(_PATH_STOPT_KW)
 STOPT_KW.update({
-    "out_dir": "./result_path_search/",
+    "out_dir": "./result_path_search/",  # output directory for string-optimizer artifacts
 })
 
 # LBFGS settings
 LBFGS_KW: Dict[str, Any] = dict(_LBFGS_KW)
 LBFGS_KW.update({
-    "out_dir": "./result_path_search/",
+    "out_dir": "./result_path_search/",  # LBFGS output directory (restart, logs)
 })
 
 # RFO settings
 RFO_KW: Dict[str, Any] = dict(_RFO_KW)
 RFO_KW.update({
-    "out_dir": "./result_path_search/",
+    "out_dir": "./result_path_search/",  # RFO output directory (restart, logs)
 })
 
 # Covalent‑bond change detection
 BOND_KW: Dict[str, Any] = {
-    "device": "cuda",
-    "bond_factor": 1.20,
-    "margin_fraction": 0.05,
-    "delta_fraction": 0.05,
+    "device": "cuda",               # compute UMA graph features on CUDA when available
+    "bond_factor": 1.20,            # covalent cutoff multiplier (r_cov * bond_factor)
+    "margin_fraction": 0.05,        # tolerance margin added to bond cutoff for stability
+    "delta_fraction": 0.05,         # threshold fraction to flag bond formation/breaking
 }
 
 # Global search control
 SEARCH_KW: Dict[str, Any] = {
-    "max_depth": 10,
-    "stitch_rmsd_thresh": 1.0e-4,
-    "bridge_rmsd_thresh": 1.0e-4,
-    "rmsd_align": True,  # retained for compatibility (ignored internally)
-    "max_nodes_segment": 10,
-    "max_nodes_bridge": 5,
-    "kink_max_nodes": 3,
-    "max_seq_kink": 2,
-    "refine_mode": None,
+    "max_depth": 10,                 # recursion depth for path-search branching
+    "stitch_rmsd_thresh": 1.0e-4,    # RMSD cutoff when stitching partial segments
+    "bridge_rmsd_thresh": 1.0e-4,    # RMSD cutoff when bridging paths
+    "rmsd_align": True,              # retained for compatibility (ignored internally)
+    "max_nodes_segment": 10,         # max nodes per segment during expansion
+    "max_nodes_bridge": 5,           # max nodes per bridge construction
+    "kink_max_nodes": 3,             # max nodes for kink resolution
+    "max_seq_kink": 2,               # max sequential kinks allowed before aborting
+    "refine_mode": None,             # optional refinement strategy tag
 }
 
 

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -149,26 +149,25 @@ from .bond_changes import compare_structures, summarize_changes
 # Geometry handling (Cartesian recommended for scans)
 GEOM_KW: Dict[str, Any] = dict(GEOM_KW_DEFAULT)
 
-# UMA calculator defaults
 CALC_KW: Dict[str, Any] = dict(_UMA_CALC_KW)
 
 # Optimizer base (convergence, dumping, etc.)
 OPT_BASE_KW: Dict[str, Any] = dict(_OPT_BASE_KW)
 OPT_BASE_KW.update({
-    "max_cycles": 100,
-    "out_dir": "./result_scan/",
+    "max_cycles": 100,          # hard cap on optimization cycles per biased segment
+    "out_dir": "./result_scan/",  # output directory for scan artifacts
 })
 
 # LBFGS specifics
 LBFGS_KW: Dict[str, Any] = dict(_LBFGS_KW)
 LBFGS_KW.update({
-    "out_dir": "./result_scan/",
+    "out_dir": "./result_scan/",  # location for LBFGS-specific outputs (restart, etc.)
 })
 
 # RFO specifics
 RFO_KW: Dict[str, Any] = dict(_RFO_KW)
 RFO_KW.update({
-    "out_dir": "./result_scan/",
+    "out_dir": "./result_scan/",  # location for RFO-specific outputs (restart, etc.)
 })
 
 # Bias (harmonic well) defaults; can be overridden via YAML: section "bias"

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -137,18 +137,18 @@ CALC_KW: Dict[str, Any] = dict(_UMA_CALC_KW)
 
 OPT_BASE_KW: Dict[str, Any] = dict(_OPT_BASE_KW)
 OPT_BASE_KW.update({
-    "out_dir": "./result_scan2d/",
-    "dump": False,
-    "max_cycles": 10000,
+    "out_dir": "./result_scan2d/",  # base output directory for 2D scan artifacts
+    "dump": False,                   # disable trajectory dumping by default
+    "max_cycles": 10000,             # safety cap on optimization cycles
 })
 
 LBFGS_KW: Dict[str, Any] = dict(_LBFGS_KW)
-LBFGS_KW.update({"out_dir": "./result_scan2d/"})
+LBFGS_KW.update({"out_dir": "./result_scan2d/"})  # directory for LBFGS-specific files
 
 RFO_KW: Dict[str, Any] = dict(_RFO_KW)
-RFO_KW.update({"out_dir": "./result_scan2d/"})
+RFO_KW.update({"out_dir": "./result_scan2d/"})    # directory for RFO-specific files
 
-BIAS_KW: Dict[str, Any] = {"k": 100.0}  # eV/Å^2
+BIAS_KW: Dict[str, Any] = {"k": 100.0}  # harmonic restraint strength (eV/Å^2)
 
 _OPT_MODE_ALIASES = (
     (("light",), "lbfgs"),

--- a/pdb2reaction/scan3d.py
+++ b/pdb2reaction/scan3d.py
@@ -169,18 +169,18 @@ CALC_KW: Dict[str, Any] = dict(_UMA_CALC_KW)
 
 OPT_BASE_KW: Dict[str, Any] = dict(_OPT_BASE_KW)
 OPT_BASE_KW.update({
-    "out_dir": "./result_scan3d/",
-    "dump": False,
-    "max_cycles": 10000,
+    "out_dir": "./result_scan3d/",  # base output directory for 3D scan artifacts
+    "dump": False,                   # disable trajectory dumping by default
+    "max_cycles": 10000,             # safety cap on optimization cycles
 })
 
 LBFGS_KW: Dict[str, Any] = dict(_LBFGS_KW)
-LBFGS_KW.update({"out_dir": "./result_scan3d/"})
+LBFGS_KW.update({"out_dir": "./result_scan3d/"})  # directory for LBFGS-specific files
 
 RFO_KW: Dict[str, Any] = dict(_RFO_KW)
-RFO_KW.update({"out_dir": "./result_scan3d/"})
+RFO_KW.update({"out_dir": "./result_scan3d/"})    # directory for RFO-specific files
 
-BIAS_KW: Dict[str, Any] = {"k": 100.0}  # eV/Å^2
+BIAS_KW: Dict[str, Any] = {"k": 100.0}  # harmonic restraint strength (eV/Å^2)
 
 _OPT_MODE_ALIASES = (
     (("light",), "lbfgs"),

--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -1218,13 +1218,12 @@ class HessianDimer:
 # Geometry defaults
 GEOM_KW = dict(GEOM_KW_DEFAULT)
 
-# UMA calculator defaults
 CALC_KW = dict(_UMA_CALC_KW)
 
 # Optimizer base (common) — used by both RSIRFO and the inner LBFGS of HessianDimer
 OPT_BASE_KW = dict(_OPT_BASE_KW)
 OPT_BASE_KW.update({
-    "out_dir": "./result_tsopt/",
+    "out_dir": "./result_tsopt/",  # base output directory for TS optimization artifacts
 })
 
 DIMER_KW = {


### PR DESCRIPTION
## Summary
- add missing optimizer and output keys to scan2d/scan3d YAML examples, including new scan3d sample block
- align path_opt and path_search YAML examples with GrowingString/search defaults
- document additional Hessian Dimer and RS-IRFO parameters in tsopt YAML guidance

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69335539278c832d91c135d91ad425cd)