### PR TITLE
Clarify comments and docstrings

### DIFF
--- a/pdb2reaction/cli.py
+++ b/pdb2reaction/cli.py
@@ -85,7 +85,7 @@ cli.add_command(scan3d_cmd, name="scan3d")
 import logging
 logging.disable(logging.CRITICAL)
 
-# Disable UMA warnings when using the analytical Hessian
+# Silence noisy UMA/torch_dmf warnings that do not impact functionality
 import warnings
 
 warnings.filterwarnings(

--- a/pdb2reaction/utils.py
+++ b/pdb2reaction/utils.py
@@ -971,7 +971,8 @@ def detect_freeze_links(pdb_path):
     Returns:
         List of 0-based indices into the sequence of non-LKH atoms ("others") corresponding
         to the nearest neighbors (link parents). Returns an empty list if no LKH/HL atoms
-        are present.
+        are present. When the input contains link hydrogens but no other atoms, the list
+        will contain ``-1`` entries to indicate missing parents.
     """
     others, lkhs = parse_pdb_coords(pdb_path)
 


### PR DESCRIPTION
## Summary
- clarify link-parent detection docstring to note -1 sentinel values when no non-LKH atoms exist
- adjust CLI warning filter comment to reflect general UMA/torch_dmf noise suppression

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b644d5c50832d96b0803d623c723e)