### PR TITLE
Clarify sequential scan stages

### DIFF
--- a/docs/all.md
+++ b/docs/all.md
@@ -41,6 +41,7 @@ pdb2reaction all -i reactant.pdb -c "GPP,MMT" \
 
 2. **Optional staged scan (single-input only)**
    - Each `--scan-lists` argument is a Python-like list of `(i,j,target_Å)` tuples describing a UMA scan stage. Atom indices refer to the original input PDB (1-based) and are remapped to the pocket ordering.
+   - When `--scan-lists` is repeated, stages run **sequentially**: stage 1 relaxes the starting structure, stage 2 begins from stage 1's result, and so on.
    - Scan inherits charge/spin, `--freeze-links`, the UMA optimizer preset (`--opt-mode`), `--dump`, `--args-yaml`, and `--preopt`. Overrides such as `--scan-out-dir`, `--scan-one-based`, `--scan-max-step-size`, `--scan-bias-k`, `--scan-relax-max-cycles`, `--scan-preopt`, and `--scan-endopt` apply per run.
    - Stage endpoints (`stage_XX/result.pdb`) become the ordered intermediates that feed the subsequent GSM step.
 

--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -21,7 +21,7 @@ Usage (CLI)
         [--tsopt-max-cycles <int>] [--freq-* overrides] [--dft-* overrides] \
         [--dft-engine {gpu|cpu|auto}] [--scan-lists "[(...)]" ...]
 
-    # Single-structure scan builder (repeat --scan-lists to define stages; works with or without extraction)
+    # Single-structure scan builder (repeat --scan-lists to define sequential stages; works with or without extraction)
     pdb2reaction all -i INPUT.pdb [-c <substrate-spec>] --scan-lists "[(...)]" [...]
 
     # Single-structure TSOPT-only mode (no path_search) when --scan-lists is omitted and --tsopt True
@@ -67,6 +67,8 @@ Runs a one-shot pipeline centered on pocket models:
     - If **exactly one** full input PDB is provided and `--scan-lists` is given, the tool performs a
       **staged, bond-length–driven scan** on the extracted pocket PDB (or on the full input PDB when
       extraction is skipped) using the UMA calculator.
+    - When `--scan-lists` is repeated, **each stage starts from the relaxed structure of the previous
+      stage**, chaining the scans sequentially rather than running them independently.
     - For each stage, the final relaxed structure (`stage_XX/result.(pdb|xyz|gjf)`) is collected as an
       **intermediate/product candidate**.
     - The ordered input series for the MEP step becomes:
@@ -1962,7 +1964,9 @@ def _irc_and_match(
     multiple=True,
     required=False,
     help=(
-        "Python-like list of (i,j,target_Å) per stage for **single-structure** scan. Repeatable. "
+        "Python-like list of (i,j,target_Å) per stage for **single-structure** scan. Repeatable; "
+        "when repeated, stages run **sequentially**, each starting from the prior stage's relaxed "
+        "structure. "
         'Example: "[(12,45,1.35)]" "--scan-lists \'[(10,55,2.20),(23,34,1.80)]\'". '
         "Indices refer to the original full input PDB (1-based). When extraction is used, they are "
         "auto-mapped to the pocket after extraction. Stage results feed into the MEP step (path_search or path_opt)."


### PR DESCRIPTION
## Summary
- clarify that repeated --scan-lists stages are executed sequentially from the prior relaxed structure in the CLI help and docstring
- document the sequential scan chaining behavior in docs/all.md

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b7101cd10832db2b1e58e28bfdfc5)