### PR TITLE
Set UMA Hessian default to full for pysisyphus compatibility

### DIFF
--- a/docs/all.md
+++ b/docs/all.md
@@ -186,7 +186,7 @@ calc:
   out_hess_torch: true       # request torch-form Hessian
   freeze_atoms: null         # calculator-level frozen atoms
   hessian_calc_mode: FiniteDifference   # Hessian mode selection
-  return_partial_hessian: true          # allow partial Hessians
+  return_partial_hessian: false         # full Hessian (avoids shape mismatches)
 gs:
   max_nodes: 10              # maximum string nodes
   perp_thresh: 0.005         # perpendicular displacement threshold

--- a/docs/irc.md
+++ b/docs/irc.md
@@ -93,7 +93,7 @@ calc:
   out_hess_torch: true       # request torch-form Hessian
   freeze_atoms: null         # calculator-level frozen atoms
   hessian_calc_mode: FiniteDifference   # Hessian mode selection
-  return_partial_hessian: true          # allow partial Hessians
+  return_partial_hessian: false         # full Hessian (avoids shape mismatches)
 irc:
   step_length: 0.1           # integration step length
   max_cycles: 125            # maximum steps along IRC

--- a/docs/opt.md
+++ b/docs/opt.md
@@ -98,7 +98,7 @@ calc:
   out_hess_torch: true       # request torch-form Hessian
   freeze_atoms: null         # calculator-level frozen atoms
   hessian_calc_mode: FiniteDifference   # Hessian mode selection
-  return_partial_hessian: true          # allow partial Hessians
+  return_partial_hessian: false         # full Hessian (avoids shape mismatches)
 opt:
   thresh: gau                # convergence preset (Gaussian/Baker-style)
   max_cycles: 10000          # optimizer cycle cap

--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -98,7 +98,7 @@ calc:
   out_hess_torch: true       # request torch-form Hessian
   freeze_atoms: null         # calculator-level frozen atoms
   hessian_calc_mode: FiniteDifference   # Hessian mode selection
-  return_partial_hessian: true          # allow partial Hessians
+  return_partial_hessian: false         # full Hessian (avoids shape mismatches)
 gs:
   fix_first: true            # keep the first endpoint fixed during optimization
   fix_last: true             # keep the last endpoint fixed during optimization

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -115,7 +115,7 @@ calc:
   out_hess_torch: true       # request torch-form Hessian
   freeze_atoms: null         # calculator-level frozen atoms
   hessian_calc_mode: FiniteDifference   # Hessian mode selection
-  return_partial_hessian: true          # allow partial Hessians
+  return_partial_hessian: false         # full Hessian (avoids shape mismatches)
 gs:
   fix_first: true            # keep the first endpoint fixed during optimization
   fix_last: true             # keep the last endpoint fixed during optimization

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -133,7 +133,7 @@ calc:
   out_hess_torch: true       # request torch-form Hessian
   freeze_atoms: null         # calculator-level frozen atoms
   hessian_calc_mode: FiniteDifference   # Hessian mode selection
-  return_partial_hessian: true          # allow partial Hessians
+  return_partial_hessian: false         # full Hessian (avoids shape mismatches)
 opt:
   thresh: gau                # convergence preset (Gaussian/Baker-style)
   max_cycles: 10000          # optimizer cycle cap

--- a/docs/tsopt.md
+++ b/docs/tsopt.md
@@ -132,7 +132,7 @@ calc:
   out_hess_torch: true       # request torch-form Hessian
   freeze_atoms: null         # calculator-level frozen atoms
   hessian_calc_mode: FiniteDifference   # Hessian mode selection
-  return_partial_hessian: true          # allow partial Hessians
+  return_partial_hessian: false         # full Hessian (avoids shape mismatches)
 opt:
   thresh: gau                # convergence preset (Gaussian/Baker-style)
   max_cycles: 10000          # optimizer cycle cap

--- a/pdb2reaction/uma_pysis.py
+++ b/pdb2reaction/uma_pysis.py
@@ -128,7 +128,7 @@ CALC_KW: Dict[str, Any] = {
 
     # Hessian interfaces to UMA
     "hessian_calc_mode": "FiniteDifference",        # "FiniteDifference" (default) | "Analytical"
-    "return_partial_hessian": True,           # receive only the active-DOF Hessian block
+    "return_partial_hessian": False,          # receive the full Hessian (safer for pysisyphus)
 
     # Hessian precision (energy/forces are always returned as float64)
     "hessian_double": True,                   # if True, assemble/return Hessian in float64
@@ -329,9 +329,10 @@ class uma_pysis(Calculator):
         freeze_atoms : list[int], optional
             Atom indices (0-based). In both modes, DOFs of these atoms are
             treated as frozen.
-        return_partial_hessian : bool, default True
+        return_partial_hessian : bool, default False
             If True, return only the Active-DOF Hessian (submatrix for non-frozen atoms).
             If False, return a full (3N×3N) matrix where frozen-DOF columns are 0.
+            Full Hessians avoid shape mismatches with pysisyphus optimizers.
         hessian_double : bool, default True
             If True, assemble/return the Hessian in float64 (double precision).
             Energy and forces are always returned as float64 regardless of this flag.


### PR DESCRIPTION
## Summary
- default UMA calculator Hessian output to full matrices to match pysisyphus expectations
- update configuration docs to reflect the new Hessian default

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b74ffe504832d94a2814ee13aad62)