### PR TITLE
Add legends and align PDB atom logs

### DIFF
--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -138,6 +138,9 @@ from .utils import (
     prepare_input_structure,
     resolve_charge_spin_or_raise,
     set_convert_file_enabled,
+    load_pdb_atom_metadata,
+    format_pdb_atom_metadata,
+    format_pdb_atom_metadata_header,
 )
 from .bond_changes import compare_structures, summarize_changes
 
@@ -495,6 +498,23 @@ def cli(
         stages = _parse_scan_lists(scan_lists_raw, one_based=one_based)
         K = len(stages)
         click.echo(f"[scan] Received {K} stage(s).")
+
+        pdb_atom_meta: List[Dict[str, Any]] = []
+        if input_path.suffix.lower() == ".pdb":
+            pdb_atom_meta = load_pdb_atom_metadata(input_path)
+            if pdb_atom_meta:
+                click.echo("[scan] PDB atom details for scanned pairs:")
+                legend = format_pdb_atom_metadata_header()
+                click.echo(f"        legend: {legend}")
+                for stage_idx, tuples in enumerate(stages, start=1):
+                    click.echo(f"  Stage {stage_idx}:")
+                    for pair_idx, (i, j, _) in enumerate(tuples, start=1):
+                        click.echo(
+                            f"    pair {pair_idx} i: {format_pdb_atom_metadata(pdb_atom_meta, i)}"
+                        )
+                        click.echo(
+                            f"              j: {format_pdb_atom_metadata(pdb_atom_meta, j)}"
+                        )
 
         # Prepare end-of-run summary collector
         stages_summary: List[Dict[str, Any]] = []

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -129,6 +129,9 @@ from .utils import (
     resolve_charge_spin_or_raise,
     set_convert_file_enabled,
     convert_xyz_like_outputs,
+    load_pdb_atom_metadata,
+    format_pdb_atom_metadata,
+    format_pdb_atom_metadata_header,
 )
 
 # Default keyword dictionaries for the 2D scan (override only the knobs we touch)
@@ -526,6 +529,18 @@ def cli(
                 {"d1": (i1, j1, low1, high1), "d2": (i2, j2, low2, high2)},
             )
         )
+
+        pdb_atom_meta: List[Dict[str, Any]] = []
+        if input_path.suffix.lower() == ".pdb":
+            pdb_atom_meta = load_pdb_atom_metadata(input_path)
+            if pdb_atom_meta:
+                click.echo("[scan2d] PDB atom details for scanned pairs:")
+                legend = format_pdb_atom_metadata_header()
+                click.echo(f"        legend: {legend}")
+                click.echo(f"  d1 i: {format_pdb_atom_metadata(pdb_atom_meta, i1)}")
+                click.echo(f"     j: {format_pdb_atom_metadata(pdb_atom_meta, j1)}")
+                click.echo(f"  d2 i: {format_pdb_atom_metadata(pdb_atom_meta, i2)}")
+                click.echo(f"     j: {format_pdb_atom_metadata(pdb_atom_meta, j2)}")
 
         # Temporary and grid directories
         tmp_root = Path(tempfile.mkdtemp(prefix="scan2d_tmp_"))

--- a/pdb2reaction/scan3d.py
+++ b/pdb2reaction/scan3d.py
@@ -161,6 +161,9 @@ from .utils import (
     resolve_charge_spin_or_raise,
     set_convert_file_enabled,
     convert_xyz_like_outputs,
+    load_pdb_atom_metadata,
+    format_pdb_atom_metadata,
+    format_pdb_atom_metadata_header,
 )
 
 # Default keyword dictionaries for the 3D scan (override only the knobs we touch)
@@ -601,6 +604,20 @@ def cli(
                 },
             )
         )
+
+        pdb_atom_meta: List[Dict[str, Any]] = []
+        if input_path.suffix.lower() == ".pdb":
+            pdb_atom_meta = load_pdb_atom_metadata(input_path)
+            if pdb_atom_meta:
+                click.echo("[scan3d] PDB atom details for scanned pairs:")
+                legend = format_pdb_atom_metadata_header()
+                click.echo(f"        legend: {legend}")
+                click.echo(f"  d1 i: {format_pdb_atom_metadata(pdb_atom_meta, i1)}")
+                click.echo(f"     j: {format_pdb_atom_metadata(pdb_atom_meta, j1)}")
+                click.echo(f"  d2 i: {format_pdb_atom_metadata(pdb_atom_meta, i2)}")
+                click.echo(f"     j: {format_pdb_atom_metadata(pdb_atom_meta, j2)}")
+                click.echo(f"  d3 i: {format_pdb_atom_metadata(pdb_atom_meta, i3)}")
+                click.echo(f"     j: {format_pdb_atom_metadata(pdb_atom_meta, j3)}")
 
         final_dir = out_dir_path
 


### PR DESCRIPTION
## Summary
- add an aligned PDB atom metadata legend for scan logging
- include the legend and padded columns in scan, scan2d, and scan3d PDB pair echoes

## Testing
- python -m compileall pdb2reaction

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d6d3f44e0832d87006c80ded32b15)