### PR TITLE
Stop generating input_geometry.gjf in dft outputs

### DIFF
--- a/docs/dft.md
+++ b/docs/dft.md
@@ -23,7 +23,7 @@ pdb2reaction dft -i input.pdb -q 0 -m 2 --func-basis "wb97m-v/def2-tzvpd" \
 ```
 
 ## Workflow
-1. **Input handling** – Any file loadable by `geom_loader` (.pdb/.xyz/.trj/…) is accepted. Coordinates are re-exported as `input_geometry.xyz`, and when the source was a Gaussian template and conversion is enabled a matching `.gjf` snapshot is written for reference.
+1. **Input handling** – Any file loadable by `geom_loader` (.pdb/.xyz/.trj/…) is accepted. Coordinates are re-exported as `input_geometry.xyz`.
 2. **Configuration merge** – Defaults → YAML (`dft` block) → CLI. Charge/multiplicity inherit `.gjf` metadata when present; otherwise `-q/--charge` is required and multiplicity defaults to `1`. Always set them explicitly so the correct RKS/UKS solver is selected.
 3. **SCF build** – `--func-basis` is parsed into XC functional and orbital basis. Density fitting is enabled automatically with PySCF defaults. `--engine` controls GPU/CPU preference (`gpu` tries GPU4PySCF before falling back; `cpu` forces CPU; `auto` tries GPU then CPU). Nonlocal VV10 is activated for functionals whose names end in `-v` or contain `vv10`.
 4. **Population analysis & outputs** – After convergence (or failure) the command writes `result.yaml` summarising energy (Hartree/kcal·mol⁻¹), convergence metadata, timing, backend info, and per-atom Mulliken/meta-Löwdin/IAO charges and spin densities (UKS only for spins). Any failed analysis column is set to `null` with a warning.
@@ -47,7 +47,6 @@ pdb2reaction dft -i input.pdb -q 0 -m 2 --func-basis "wb97m-v/def2-tzvpd" \
 ```
 out_dir/ (default: ./result_dft/)
 ├─ input_geometry.xyz   # Geometry snapshot sent to PySCF
-├─ input_geometry.gjf   # Only when a Gaussian template exists and conversion is enabled
 └─ result.yaml          # Energy/charge/spin summaries with convergence/engine metadata
 ```
 - `result.yaml` expands to:

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -30,8 +30,7 @@ Description
   * auto          : try GPU4PySCF first and fall back to CPU PySCF if unavailable (same behaviour as "gpu").
 - RKS/UKS is selected automatically from the spin multiplicity (2S+1).
 - Inputs: any structure format supported by pysisyphus.helpers.geom_loader (.pdb, .xyz, .trj, …).
-  The geometry is written back unchanged as input_geometry.xyz. If a Gaussian .gjf template
-  is present **and conversion is enabled**, a convenience input_geometry.gjf is also written.
+  The geometry is written back unchanged as input_geometry.xyz.
 - Functional/basis specified as "FUNC/BASIS" via --func-basis (e.g., "wb97m-v/6-31g**", "wb97m-v/def2-svp", "wb97m-v/def2-tzvpd").
   Names are case-insensitive in PySCF.
 - Density fitting (DF) is enabled via PySCF's density_fit(); the auxiliary basis is left to
@@ -55,7 +54,7 @@ Outputs (& Directory Layout)
 out_dir/ (default: ./result_dft/)
   ├─ result.yaml                # Input metadata, SCF energy (Eh/kcal), convergence status, timing, and per-atom charge/spin tables
   ├─ input_geometry.xyz         # Geometry snapshot passed to PySCF (as read; unchanged)
-  └─ input_geometry.gjf         # Convenience GJF when a Gaussian template is available and conversion is enabled
+  └─ (no .gjf snapshot is written)
 
 Notes
 -----
@@ -96,7 +95,6 @@ from .utils import (
     format_elapsed,
     prepare_input_structure,
     resolve_charge_spin_or_raise,
-    maybe_convert_xyz_to_gjf,
     set_convert_file_enabled,
 )
 from .uma_pysis import GEOM_KW_DEFAULT
@@ -475,9 +473,6 @@ def cli(
         input_xyz = out_dir_path / "input_geometry.xyz"
         input_xyz.write_text(xyz_s if xyz_s.endswith("\n") else (xyz_s + "\n"))
         click.echo(f"[write] Wrote '{input_xyz}'.")
-        gjf_written = maybe_convert_xyz_to_gjf(input_xyz, prepared_input.gjf_template, out_dir_path / "input_geometry.gjf")
-        if gjf_written:
-            click.echo(f"[convert] Wrote '{gjf_written}'.")
 
         # --------------------------
         # 3) Build PySCF molecule


### PR DESCRIPTION
## Summary
- remove input_geometry.gjf creation from the dft workflow
- update documentation to reflect only input_geometry.xyz and result.yaml outputs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d72a2a8f0832d8ffb325904c84d36)