### PR TITLE
Honor output path over overwrite flag for add-elem-info

### DIFF
--- a/docs/add_elem_info.md
+++ b/docs/add_elem_info.md
@@ -10,8 +10,8 @@ is supplied.
 - If `-o/--out` is **omitted** and `--overwrite` is **not** set, the output is written to
   `<input>_add_elem.pdb` (i.e., it replaces a trailing `.pdb` with `_add_elem.pdb`;
   if the input does not end with `.pdb`, `_add_elem.pdb` is appended).
-- If `--overwrite` **is set**, the **input file is overwritten in-place**, and `-o/--out`
-  (if provided) is **ignored**.
+- If `--overwrite` **is set** **and** `-o/--out` is **omitted**, the **input file is overwritten
+  in-place**. When `-o/--out` is supplied, `--overwrite` is ignored.
 
 ## Usage
 ```bash
@@ -45,8 +45,8 @@ pdb2reaction add-elem-info -i 1abc.pdb --overwrite
    mode, all atoms are re-inferred even if the original fields were populated.
 4. Write the structure through `PDBIO`:
    - default output: `<input>_add_elem.pdb` (when `-o/--out` is omitted and `--overwrite` is not set)
-   - `-o/--out`: write to the specified path (when `--overwrite` is not set)
-   - `--overwrite`: overwrite the input path in-place (ignores `-o/--out`)
+   - `-o/--out`: write to the specified path; `--overwrite` is ignored when this is provided
+   - `--overwrite` (without `-o/--out`): overwrite the input path in-place
 5. Print a summary reporting how many atoms were newly assigned, kept, or
    overwritten plus per-element totals and a truncated list of unresolved atoms.
 
@@ -54,14 +54,14 @@ pdb2reaction add-elem-info -i 1abc.pdb --overwrite
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH` | Input PDB file. | Required |
-| `-o, --out PATH` | Output path (ignored when `--overwrite` is set). | _None_ → `<input>_add_elem.pdb` |
-| `--overwrite` | Re-infer elements even if the original fields are present **and** overwrite the input file in-place (ignores `-o/--out`). | `False` |
+| `-o, --out PATH` | Output path. When set, `--overwrite` is ignored. | _None_ → `<input>_add_elem.pdb` |
+| `--overwrite` | Re-infer elements even if the original fields are present **and** overwrite the input file in-place when `-o/--out` is omitted. | `False` |
 
 ## Outputs
 - A PDB file with element symbols populated/corrected:
   - `<input>_add_elem.pdb` by default (when `-o/--out` is omitted and `--overwrite` is not set)
-  - `OUTPUT.pdb` if `-o/--out` is provided (when `--overwrite` is not set)
-  - `INPUT.pdb` overwritten in-place if `--overwrite` is set
+  - `OUTPUT.pdb` if `-o/--out` is provided (regardless of `--overwrite`)
+  - `INPUT.pdb` overwritten in-place if `--overwrite` is set without `-o/--out`
 - Console report with totals for processed/assigned/kept/overwritten atoms,
   per-element counts, and up to 50 unresolved atoms.
 


### PR DESCRIPTION
## Summary
- ensure add-elem-info ignores --overwrite when an explicit output path is provided
- document the updated precedence for -o/--out versus --overwrite in CLI help and guide

## Testing
- python -m compileall pdb2reaction/add_elem_info.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d7d758b18832d87f26a1ea1df3a58)