### PR TITLE
Allow YAML overrides for DFT charge and engine settings

### DIFF
--- a/docs/dft.md
+++ b/docs/dft.md
@@ -24,9 +24,9 @@ pdb2reaction dft -i input.pdb -q 0 -m 2 --func-basis "wb97m-v/def2-tzvpd" \
 
 ## Workflow
 1. **Input handling** – Any file loadable by `geom_loader` (.pdb/.xyz/.trj/…) is accepted. Coordinates are re-exported as `input_geometry.xyz`.
-2. **Configuration merge** – Defaults → YAML (`dft` block) → CLI. Charge/multiplicity inherit `.gjf` metadata when present; otherwise `-q/--charge` is required and multiplicity defaults to `1`.  
-3. **SCF build** – `--func-basis` is parsed into functional and basis. Density fitting is enabled automatically with PySCF defaults. `--engine` controls GPU/CPU preference (`gpu` tries GPU4PySCF before falling back; `cpu` forces CPU; `auto` tries GPU then CPU). Nonlocal VV10 is activated for functionals whose names end in `-v` or contain `vv10`.
-4. **Population analysis & outputs** – After convergence (or failure) the command writes `result.yaml` summarising energy (Hartree/kcal·mol⁻¹), convergence metadata, timing, backend info, and per-atom Mulliken/meta-Löwdin/IAO charges and spin densities (UKS only for spins). Any failed analysis column is set to `null` with a warning.
+2. **Configuration merge** – Defaults → CLI → YAML (`dft` block). YAML values take final precedence and can override `charge`, `multiplicity`, `func_basis`, and `engine` in addition to SCF knobs. Charge/multiplicity inherit `.gjf` metadata when present; otherwise `-q/--charge` is required and multiplicity defaults to `1`.
+3. **SCF build** – `--func-basis` is parsed into functional and basis. Density fitting is enabled automatically with PySCF defaults. `--engine` controls GPU/CPU preference (`gpu` tries GPU4PySCF before falling back; `cpu` forces CPU; `auto` tries GPU then CPU). Nonlocal VV10 corrections are not configured explicitly.
+4. **Population analysis & outputs** – After convergence (or failure) the command writes `result.yaml` summarising energy (Hartree/kcal·mol⁻¹), convergence metadata, backend info, and per-atom Mulliken/meta-Löwdin/IAO charges and spin densities (UKS only for spins). Any failed analysis column is set to `null` with a warning.
 
 ## CLI options
 | Option | Description | Default |
@@ -50,7 +50,7 @@ out_dir/ (default: ./result_dft/)
 └─ result.yaml          # Energy/charge/spin summaries with convergence/engine metadata
 ```
 - `result.yaml` expands to:
-  - `energy`: Hartree/kcal·mol⁻¹ values, convergence flag, wall time, engine metadata
+  - `energy`: Hartree/kcal·mol⁻¹ values, convergence flag, and engine metadata
     (`gpu4pyscf` vs `pyscf(cpu)`, `used_gpu`).
   - `charges`: Mulliken, meta-Löwdin, and IAO atomic charges (`null` when a method fails).
   - `spin_densities`: Mulliken, meta-Löwdin, and IAO spin densities (UKS-only for spins).
@@ -61,24 +61,32 @@ out_dir/ (default: ./result_dft/)
 - GPU4PySCF is used whenever available; CPU PySCF is built otherwise (unless `--engine cpu` forces CPU). `--engine auto` mirrors the GPU-first fallback logic, automatically retrying on the CPU backend when GPU import/runtime errors occur. **Blackwell architecture** GPUs are detected and forced to CPU with a warning to avoid unsupported GPU4PySCF configurations.
 - GPU4PySCF is required to by compiled from source when you do not use **x86** archtecture. (See <https://github.com/pyscf/gpu4pyscf>)
 - Density fitting is always attempted with PySCF defaults (no auxiliary basis guessing is implemented).
-- The YAML file must contain a mapping root with top-level key `dft`; non-mapping roots raise an error via `load_yaml_dict`.
+- YAML overrides are read from a mapping root; `dft` entries override CLI/defaults (including `charge`, `multiplicity`, `func_basis`, and `engine`) and an optional `geom` block is passed to `geom_loader`.
 - Exit codes: `0` (converged), `3` (not converged), `2` (PySCF import failure), `1` (other errors), `130` (interrupt).
 - IAO spin/charge analysis may fail for challenging systems; corresponding columns in `result.yaml` become `null` and a warning is printed.
 
 ## YAML configuration (`--args-yaml`)
-Accepts a mapping with top-level key `dft`. YAML values override CLI values.
+Accepts a mapping with optional top-level key `dft` (and `geom`). YAML values override CLI values.
 
 `dft` keys (defaults in parentheses):
+- `charge` (`null` → template or `-q` required): Total charge.
+- `multiplicity` (`1`): Spin multiplicity (2S+1).
+- `func_basis` (`"wb97m-v/def2-tzvpd"`): Functional/basis pair in `FUNC/BASIS` form.
+- `engine` (`"gpu"`): Backend policy; accepts `gpu`, `cpu`, or `auto`.
 - `conv_tol` (`1e-9`): SCF convergence threshold (Hartree).
 - `max_cycle` (`100`): Maximum SCF iterations.
 - `grid_level` (`3`): PySCF `grids.level`.
 - `verbose` (`0`): PySCF verbosity (0–9). The CLI constructs the configuration with this quiet default unless overridden.
 - `out_dir` (`"./result_dft/"`): Output directory root.
 
-_Functional/basis selection defaults to `wb97m-v/def2-tzvpd` but can be overridden on the CLI. Charge/spin inherit `.gjf` template metadata when present; otherwise `-q/--charge` is required and spin defaults to `1`. Set them explicitly for non-default states._
+Charge/spin inherit `.gjf` template metadata when present; otherwise `-q/--charge` is required and spin defaults to `1`. YAML values override both CLI inputs and template metadata.
 
 ```yaml
 dft:
+  charge: 0             # total charge (overrides CLI/template)
+  multiplicity: 1       # spin multiplicity (2S+1)
+  func_basis: wb97m-v/def2-tzvpd  # functional/basis
+  engine: gpu           # backend policy: gpu, cpu, or auto
   conv_tol: 1.0e-09     # SCF convergence tolerance (Hartree)
   max_cycle: 100        # maximum SCF iterations
   grid_level: 3         # PySCF grid level

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -111,6 +111,10 @@ DFT_KW: Dict[str, Any] = {
     "grid_level": 3,           # Numerical integration grid level (PySCF grids.level)
     "verbose": 0,              # PySCF verbosity (0..9)
     "out_dir": "./result_dft/",# Output directory
+    "charge": None,            # Total charge (optional; may be filled by .gjf template)
+    "multiplicity": 1,         # Spin multiplicity (2S+1)
+    "func_basis": "wb97m-v/def2-tzvpd",  # Functional/basis pair
+    "engine": "gpu",          # Preferred backend policy
 }
 
 
@@ -395,7 +399,7 @@ def _compute_atomic_spin_densities(mol, mf) -> Dict[str, Optional[List[float]]]:
     "--args-yaml",
     type=click.Path(path_type=Path, exists=True, dir_okay=False),
     default=None,
-    help='Optional YAML overrides under key "dft" (conv_tol, max_cycle, grid_level, verbose, out_dir).',
+    help='Optional YAML overrides under key "dft" (charge, multiplicity, func_basis, engine, conv_tol, max_cycle, grid_level, verbose, out_dir).',
 )
 def cli(
     input_path: Path,
@@ -424,10 +428,18 @@ def cli(
         dft_cfg = dict(DFT_KW)
 
         # CLI overrides
-        dft_cfg["conv_tol"] = float(conv_tol)
-        dft_cfg["max_cycle"] = int(max_cycle)
-        dft_cfg["grid_level"] = int(grid_level)
-        dft_cfg["out_dir"] = out_dir
+        dft_cfg.update(
+            {
+                "conv_tol": float(conv_tol),
+                "max_cycle": int(max_cycle),
+                "grid_level": int(grid_level),
+                "out_dir": out_dir,
+                "engine": engine,
+                "func_basis": func_basis,
+                "charge": charge,
+                "multiplicity": spin,
+            }
+        )
 
         apply_yaml_overrides(
             yaml_cfg,
@@ -437,11 +449,20 @@ def cli(
             ],
         )
 
-        xc, basis = _parse_func_basis(func_basis)
-        multiplicity = int(spin)
+        charge, multiplicity = resolve_charge_spin_or_raise(
+            prepared_input,
+            dft_cfg.get("charge"),
+            dft_cfg.get("multiplicity"),
+        )
+        dft_cfg["charge"] = charge
+        dft_cfg["multiplicity"] = multiplicity
+
+        xc, basis = _parse_func_basis(str(dft_cfg["func_basis"]))
         if multiplicity < 1:
             raise click.BadParameter("Multiplicity (spin) must be >= 1.")
         spin2s = multiplicity - 1  # PySCF expects 2S
+        engine = str(dft_cfg.get("engine") or "gpu").strip().lower()
+        dft_cfg["engine"] = engine
 
         # Echo resolved config
         out_dir_path = Path(dft_cfg["out_dir"]).resolve()
@@ -455,7 +476,7 @@ def cli(
             "max_cycle": dft_cfg["max_cycle"],
             "grid_level": dft_cfg["grid_level"],
             "out_dir": str(out_dir_path),
-            "engine": engine,
+            "engine": dft_cfg.get("engine"),
         }
         click.echo(pretty_block("geom", format_geom_for_echo(geom_cfg)))
         click.echo(pretty_block("dft", echo_cfg))
@@ -497,7 +518,6 @@ def cli(
         # --------------------------
         # 4) Activate GPU & build SCF object
         # --------------------------
-        engine = (engine or "gpu").strip().lower()
         using_gpu = False
         engine_label = "pyscf(cpu)"
         make_ks = (lambda mod: mod.RKS(mol) if spin2s == 0 else mod.UKS(mol))


### PR DESCRIPTION
## Summary
- allow the DFT YAML block to override charge, multiplicity, functional/basis, and engine selection in addition to SCF controls
- merge YAML/CLI defaults into the runtime configuration before resolving charge/spin and normalizing engine values
- document the new YAML keys and precedence in `docs/dft.md`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dd92a5680832d85e0c71dc7cbdaf3)