### PR TITLE
Update extract documentation to match behavior

### DIFF
--- a/docs/extract.md
+++ b/docs/extract.md
@@ -42,7 +42,7 @@ pdb2reaction extract -i complex1.pdb complex2.pdb -c "GPP,SAM" -o pocket1.pdb po
   - When `--exclude-backbone false`, any atom within the cutoff qualifies a residue.
   - When `--exclude-backbone true`, amino-acid residues must contact the substrate with a **non-backbone** atom (not N/H*/CA/HA*/C/O). Non-amino acids use any atom.
 - **Independent hetero–hetero cutoff (`--radius-het2het`):** adds residues when a substrate hetero atom (non C/H) lies within the specified Å of a protein hetero atom. With backbone exclusion enabled the protein atom must be non-backbone.
-- **Water handling:** HOH/WAT/TIP3/SOL/DOD/TIP/TIP3 are included by default (`--include-H2O true`).
+- **Water handling:** HOH/WAT/H2O/DOD/TIP/TIP3/SOL are included by default (`--include-H2O true`).
 - **Forced inclusion:** `--selected-resn` accepts IDs with chains/insertion codes (e.g., `A:123A`).
 - **Neighbor safeguards:**
   - When backbone exclusion is off and a residue contacts the substrate with a backbone atom, auto-include the peptide-adjacent N/C neighbors (C–N ≤ 1.9 Å). Termini keep caps (N/H* or C/O/OXT).
@@ -86,7 +86,7 @@ pdb2reaction extract -i complex1.pdb complex2.pdb -c "GPP,SAM" -o pocket1.pdb po
 | `-o, --output PATH...` | Pocket PDB output(s). One path ⇒ multi-MODEL, N paths ⇒ per input. | Auto (`pocket.pdb` or `pocket_<input>.pdb`) |
 | `-r, --radius FLOAT` | Atom–atom distance cutoff (Å) for inclusion. | `2.6` |
 | `--radius-het2het FLOAT` | Independent hetero–hetero cutoff (Å, non C/H). | `0.0` (internally 0.001 Å when zero) |
-| `--include-H2O BOOL` | Include HOH/WAT/TIP/SOL/DOD waters. | `true` |
+| `--include-H2O BOOL` | Include HOH/WAT/H2O/DOD/TIP/TIP3/SOL waters. | `true` |
 | `--exclude-backbone BOOL` | Remove backbone atoms on non-substrate amino acids (PRO/HYP safeguards). | `true` |
 | `--add-linkH BOOL` | Add carbon-only link hydrogens at 1.09 Å along severed bonds. | `true` |
 | `--selected-resn TEXT` | Force-include residues (IDs with optional chains/insertion codes). | `""` |
@@ -99,6 +99,7 @@ pdb2reaction extract -i complex1.pdb complex2.pdb -c "GPP,SAM" -o pocket1.pdb po
                # Single input → pocket.pdb by default
                # Multiple inputs without -o → pocket_<original_basename>.pdb per structure
                # One -o path with multiple inputs → single multi-MODEL PDB
+               # Output directories are not created automatically; ensure they exist
 ```
 - Charge summary (protein/ligand/ion/total) is logged for model #1 when verbose mode is enabled.
 - Programmatic use (`extract_api`) returns `{"outputs": [...], "counts": [...], "charge_summary": {...}}`.


### PR DESCRIPTION
## Summary
- clarify that include-H2O covers H2O along with other water residue names
- note that extract does not create output directories automatically

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dd94dc4a8832d820f49e47e104eb6)