### PR TITLE
Clarify charge requirement for non-Gaussian inputs

### DIFF
--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -59,8 +59,9 @@ out_dir/ (default: ./result_dft/)
 
 Notes
 -----
-- Charge/spin resolution: -q/--charge and -m/--multiplicity may inherit values from .gjf templates when present
-  and otherwise fall back to 0/1. Provide explicit values whenever possible to enforce the intended state
+- Charge/spin resolution: -q/--charge and -m/--multiplicity may inherit values from .gjf templates when present.
+  For .pdb/.xyz/.trj (and other non-.gjf inputs), omitting -q/--charge is an error; no fallback to 0 occurs.
+  Spin defaults to 1 when unspecified. Provide explicit values whenever possible to enforce the intended state
   (multiplicity > 1 selects UKS).
 - YAML overrides: --args-yaml points to a file with top-level keys "dft" (conv_tol, max_cycle,
   grid_level, verbose, out_dir) and "geom" (passed to pysisyphus.helpers.geom_loader).


### PR DESCRIPTION
## Summary
- update the DFT module documentation to state that non-Gaussian inputs require an explicit charge instead of falling back to zero
- note the spin default and avoid implying nonexistent charge fallback

## Testing
- not run (not needed for docs-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dff881b20832d935edff1948bfae5)