### PR TITLE
Remove exit code details from script docstrings

### DIFF
--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -66,7 +66,6 @@ Notes
   grid_level, verbose, out_dir) and "geom" (passed to pysisyphus.helpers.geom_loader).
 - Grids: sets grids.level when supported.
 - Units: input coordinates are in Å.
-- Exit codes: 0 if SCF converged; 3 if not converged; 2 if PySCF import fails; 1 on unhandled errors; 130 on user interrupt.
 - If any population analysis (Mulliken, meta‑Löwdin, IAO) fails, a WARNING is printed and the corresponding column is null.
 """
 

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -73,8 +73,7 @@ Notes
 - `--step-size` is in mass-weighted coordinates; `--root` selects the imaginary-frequency index used
   for the initial displacement.
 - Output conversion steps can be disabled via `--no-convert-files`.
-- Standard output includes progress and timing. Exit codes: `0` on success, `130` on `KeyboardInterrupt`,
-  `1` on unhandled exceptions.
+- Standard output includes progress and timing.
 """
 
 from __future__ import annotations

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -108,10 +108,8 @@ Notes
   coordinates.
 - **Devices:** `calc.device="auto"` selects CUDA when available; otherwise CPU.
 - **Hessian form:** Set `calc.out_hess_torch=True` to receive a torch/CUDA Hessian; otherwise numpy/CPU.
-- **Stopping safeguards:** A `ZeroStepLength` triggers exit code 2 (minimum step < 1e-8). `max_energy_incr` (RFO)
+- **Stopping safeguards:** A `ZeroStepLength` triggers termination when the minimum step is below 1e-8. `max_energy_incr` (RFO)
   aborts on large uphill steps.
-- **Exit codes:** 0 (success); 2 (`ZeroStepLength`); 3 (`OptimizationError`); 130 (keyboard interrupt);
-  1 (unhandled error).
 - **Precedence:** Settings are applied with the precedence **YAML > CLI > internal defaults**. If the same key is present in both `opt` and `lbfgs`/`rfo`, `opt` takes precedence.
 """
 

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -55,7 +55,6 @@ Notes
 - `--max-cycles` limits optimization; after full growth, the same bound applies to additional refinement.
 - `--preopt-max-cycles` limits only the optional endpoint single-structure preoptimization (LBFGS or RFO, selected via `--opt-mode`) and does not affect `--max-cycles`.
 - Format-aware XYZ/TRJ → PDB/GJF conversions respect the global `--convert-files/--no-convert-files` toggle (default: enabled).
-- Exit codes: 0 (success); 3 (optimization failed); 4 (final trajectory write error); 5 (HEI dump error); 130 (keyboard interrupt); 1 (unhandled error).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- remove exit-code descriptions from docstrings in CLI modules
- keep remaining docstring content intact while avoiding exit-code mentions

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dfff94388832dbdd35805176287a1)