### PR TITLE
Add ligand charge fallback for CLI commands

### DIFF
--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -364,6 +364,13 @@ def _compute_atomic_spin_densities(mol, mf) -> Dict[str, Optional[List[float]]]:
     help="Input structure file (.pdb, .xyz, .trj, etc.; loaded via pysisyphus.helpers.geom_loader).",
 )
 @click.option("-q", "--charge", type=int, required=False, help="Charge of the ML region.")
+@click.option(
+    "--ligand-charge",
+    type=str,
+    default=None,
+    show_default=False,
+    help="Total charge or per-resname mapping (e.g., GPP:-3,SAM:1) for unknown residues.",
+)
 @click.option("-m", "--multiplicity", "spin", type=int, default=None, show_default=False, help="Spin multiplicity (2S+1) for the ML region (inherits from .gjf when available; otherwise defaults to 1).")
 @click.option(
     "--convert-files/--no-convert-files",
@@ -400,6 +407,7 @@ def _compute_atomic_spin_densities(mol, mf) -> Dict[str, Optional[List[float]]]:
 def cli(
     input_path: Path,
     charge: Optional[int],
+    ligand_charge: Optional[str],
     spin: Optional[int],
     convert_files: bool,
     func_basis: str,
@@ -413,7 +421,13 @@ def cli(
     set_convert_file_enabled(convert_files)
     prepared_input = prepare_input_structure(input_path)
     geom_input_path = prepared_input.geom_path
-    charge, spin = resolve_charge_spin_or_raise(prepared_input, charge, spin)
+    charge, spin = resolve_charge_spin_or_raise(
+        prepared_input,
+        charge,
+        spin,
+        ligand_charge=ligand_charge,
+        prefix="[dft]",
+    )
     try:
         time_start = time.perf_counter()
         # --------------------------

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -513,6 +513,13 @@ THERMO_KW = {
     help="Input structure (.pdb, .xyz, .trj, ...)",
 )
 @click.option("-q", "--charge", type=int, required=False, help="Charge of the ML region.")
+@click.option(
+    "--ligand-charge",
+    type=str,
+    default=None,
+    show_default=False,
+    help="Total charge or per-resname mapping (e.g., GPP:-3,SAM:1) for unknown residues.",
+)
 @click.option("-m", "--multiplicity", "spin", type=int, default=1, show_default=True, help="Spin multiplicity (2S+1) for the ML region.")
 @click.option("--freeze-links", type=click.BOOL, default=True, show_default=True,
               help="Freeze parent atoms of link hydrogens (PDB only).")
@@ -554,6 +561,7 @@ THERMO_KW = {
 def cli(
     input_path: Path,
     charge: Optional[int],
+    ligand_charge: Optional[str],
     spin: Optional[int],
     freeze_links: bool,
     convert_files: bool,
@@ -574,7 +582,13 @@ def cli(
     set_convert_file_enabled(convert_files)
     prepared_input = prepare_input_structure(input_path)
     geom_input_path = prepared_input.geom_path
-    charge, spin = resolve_charge_spin_or_raise(prepared_input, charge, spin)
+    charge, spin = resolve_charge_spin_or_raise(
+        prepared_input,
+        charge,
+        spin,
+        ligand_charge=ligand_charge,
+        prefix="[freq]",
+    )
 
     # --------------------------
     # 1) Assemble configuration (defaults ← CLI ← YAML)

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -185,6 +185,13 @@ def _echo_convert_trj_if_exists(
     help="Input structure file (.pdb, .xyz, .trj, etc.).",
 )
 @click.option("-q", "--charge", type=int, required=False, help="Charge of the ML region.")
+@click.option(
+    "--ligand-charge",
+    type=str,
+    default=None,
+    show_default=False,
+    help="Total charge or per-resname mapping (e.g., GPP:-3,SAM:1) for unknown residues.",
+)
 @click.option("-m", "--multiplicity", "spin", type=int, default=1, show_default=True, help="Spin multiplicity (2S+1) for the ML region.")
 @click.option("--max-cycles", type=int, default=None, help="Maximum number of IRC steps; overrides irc.max_cycles from YAML.")
 @click.option("--step-size", type=float, default=None, help="Step length in mass-weighted coordinates; overrides irc.step_length from YAML.")
@@ -222,6 +229,7 @@ def _echo_convert_trj_if_exists(
 def cli(
     input_path: Path,
     charge: Optional[int],
+    ligand_charge: Optional[str],
     spin: Optional[int],
     max_cycles: Optional[int],
     step_size: Optional[float],
@@ -237,7 +245,13 @@ def cli(
     set_convert_file_enabled(convert_files)
     prepared_input = prepare_input_structure(input_path)
     geom_input_path = prepared_input.geom_path
-    charge, spin = resolve_charge_spin_or_raise(prepared_input, charge, spin)
+    charge, spin = resolve_charge_spin_or_raise(
+        prepared_input,
+        charge,
+        spin,
+        ligand_charge=ligand_charge,
+        prefix="[irc]",
+    )
     try:
         time_start = time.perf_counter()
 

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -468,6 +468,13 @@ def _maybe_convert_outputs(
 )
 @click.option("-q", "--charge", type=int, required=False, help="Charge of the ML region.")
 @click.option(
+    "--ligand-charge",
+    type=str,
+    default=None,
+    show_default=False,
+    help="Total charge or per-resname mapping (e.g., GPP:-3,SAM:1) for unknown residues.",
+)
+@click.option(
     "-m",
     "--multiplicity",
     "spin",
@@ -557,6 +564,7 @@ def _maybe_convert_outputs(
 def cli(
     input_path: Path,
     charge: Optional[int],
+    ligand_charge: Optional[str],
     spin: Optional[int],
     dist_freeze_raw: Sequence[str],
     one_based: bool,
@@ -574,7 +582,13 @@ def cli(
     set_convert_file_enabled(convert_files)
     prepared_input = prepare_input_structure(input_path)
     geom_input_path = prepared_input.geom_path
-    charge, spin = resolve_charge_spin_or_raise(prepared_input, charge, spin)
+    charge, spin = resolve_charge_spin_or_raise(
+        prepared_input,
+        charge,
+        spin,
+        ligand_charge=ligand_charge,
+        prefix="[opt]",
+    )
 
     try:
         dist_freeze = _parse_dist_freeze(dist_freeze_raw, one_based=bool(one_based))

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -196,6 +196,7 @@ from .utils import (
     build_energy_diagram,
     prepare_input_structure,
     fill_charge_spin_from_gjf,
+    _derive_charge_from_ligand_charge,
     maybe_convert_xyz_to_gjf,
     set_convert_file_enabled,
     convert_xyz_like_outputs,
@@ -1912,6 +1913,13 @@ def _merge_final_and_write(final_images: List[Any],
     help="Charge of the ML region.",
 )
 @click.option(
+    "--ligand-charge",
+    type=str,
+    default=None,
+    show_default=False,
+    help="Total charge or per-resname mapping (e.g., GPP:-3,SAM:1) for unknown residues.",
+)
+@click.option(
     "-m",
     "--multiplicity",
     "spin",
@@ -1992,6 +2000,7 @@ def cli(
     mep_mode: str,
     refine_mode: Optional[str],
     charge: Optional[int],
+    ligand_charge: Optional[str],
     spin: Optional[int],
     freeze_links_flag: bool,
     max_nodes: int,
@@ -2106,6 +2115,10 @@ def cli(
         for prepared in prepared_inputs:
             resolved_charge, resolved_spin = fill_charge_spin_from_gjf(
                 resolved_charge, resolved_spin, prepared.gjf_template
+            )
+        if resolved_charge is None and ligand_charge is not None:
+            resolved_charge = _derive_charge_from_ligand_charge(
+                prepared_inputs[0], ligand_charge, prefix="[path-search]"
             )
         if resolved_charge is None:
             if any_non_gjf:

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -351,6 +351,13 @@ def _snapshot_geometry(g) -> Any:
     help="Input structure file (.pdb, .xyz, .trj, ...).",
 )
 @click.option("-q", "--charge", type=int, required=False, help="Charge of the ML region.")
+@click.option(
+    "--ligand-charge",
+    type=str,
+    default=None,
+    show_default=False,
+    help="Total charge or per-resname mapping (e.g., GPP:-3,SAM:1) for unknown residues.",
+)
 @click.option("-m", "--multiplicity", "spin", type=int, default=1, show_default=True, help="Spin multiplicity (2S+1) for the ML region.")
 @click.option(
     "--scan-lists", "scan_lists_raw",
@@ -406,6 +413,7 @@ def _snapshot_geometry(g) -> Any:
 def cli(
     input_path: Path,
     charge: Optional[int],
+    ligand_charge: Optional[str],
     spin: Optional[int],
     scan_lists_raw: Sequence[str],
     one_based: bool,
@@ -425,7 +433,13 @@ def cli(
     set_convert_file_enabled(convert_files)
     prepared_input = prepare_input_structure(input_path)
     geom_input_path = prepared_input.geom_path
-    charge, spin = resolve_charge_spin_or_raise(prepared_input, charge, spin)
+    charge, spin = resolve_charge_spin_or_raise(
+        prepared_input,
+        charge,
+        spin,
+        ligand_charge=ligand_charge,
+        prefix="[scan]",
+    )
     needs_pdb = input_path.suffix.lower() == ".pdb"
     needs_gjf = prepared_input.is_gjf
     ref_pdb = input_path.resolve() if needs_pdb else None

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -311,6 +311,13 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
 )
 @click.option("-q", "--charge", type=int, required=False, help="Charge of the ML region.")
 @click.option(
+    "--ligand-charge",
+    type=str,
+    default=None,
+    show_default=False,
+    help="Total charge or per-resname mapping (e.g., GPP:-3,SAM:1) for unknown residues.",
+)
+@click.option(
     "-m",
     "--multiplicity",
     "spin",
@@ -433,6 +440,7 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
 def cli(
     input_path: Path,
     charge: Optional[int],
+    ligand_charge: Optional[str],
     spin: Optional[int],
     scan_list_raw: str,
     one_based: bool,
@@ -457,7 +465,13 @@ def cli(
     set_convert_file_enabled(convert_files)
     prepared_input = prepare_input_structure(input_path)
     geom_input_path = prepared_input.geom_path
-    charge, spin = resolve_charge_spin_or_raise(prepared_input, charge, spin)
+    charge, spin = resolve_charge_spin_or_raise(
+        prepared_input,
+        charge,
+        spin,
+        ligand_charge=ligand_charge,
+        prefix="[scan2d]",
+    )
 
     try:
         time_start = time.perf_counter()

--- a/pdb2reaction/scan3d.py
+++ b/pdb2reaction/scan3d.py
@@ -374,6 +374,13 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
 )
 @click.option("-q", "--charge", type=int, required=False, help="Charge of the ML region.")
 @click.option(
+    "--ligand-charge",
+    type=str,
+    default=None,
+    show_default=False,
+    help="Total charge or per-resname mapping (e.g., GPP:-3,SAM:1) for unknown residues.",
+)
+@click.option(
     "-m", "--multiplicity", "spin",
     type=int,
     default=1,
@@ -506,6 +513,7 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
 def cli(
     input_path: Path,
     charge: Optional[int],
+    ligand_charge: Optional[str],
     spin: Optional[int],
     scan_list_raw: str,
     one_based: bool,
@@ -531,7 +539,13 @@ def cli(
     prepared_input = prepare_input_structure(input_path)
     geom_input_path = prepared_input.geom_path
 
-    charge, spin = resolve_charge_spin_or_raise(prepared_input, charge, spin)
+    charge, spin = resolve_charge_spin_or_raise(
+        prepared_input,
+        charge,
+        spin,
+        ligand_charge=ligand_charge,
+        prefix="[scan3d]",
+    )
 
     try:
         time_start = time.perf_counter()

--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -1316,6 +1316,13 @@ RSIRFO_KW.update({
     help="Input structure (.pdb, .xyz, .trj, ...)",
 )
 @click.option("-q", "--charge", type=int, required=False, help="Charge of the ML region.")
+@click.option(
+    "--ligand-charge",
+    type=str,
+    default=None,
+    show_default=False,
+    help="Total charge or per-resname mapping (e.g., GPP:-3,SAM:1) for unknown residues.",
+)
 @click.option("-m", "--multiplicity", "spin", type=int, default=1, show_default=True, help="Spin multiplicity (2S+1) for the ML region.")
 @click.option("--freeze-links", type=click.BOOL, default=True, show_default=True,
               help="Freeze parent atoms of link hydrogens (PDB only).")
@@ -1359,6 +1366,7 @@ RSIRFO_KW.update({
 def cli(
     input_path: Path,
     charge: Optional[int],
+    ligand_charge: Optional[str],
     spin: Optional[int],
     freeze_links: bool,
     convert_files: bool,
@@ -1374,7 +1382,13 @@ def cli(
     prepared_input = prepare_input_structure(input_path)
     geom_input_path = prepared_input.geom_path
     source_path = prepared_input.source_path
-    charge, spin = resolve_charge_spin_or_raise(prepared_input, charge, spin)
+    charge, spin = resolve_charge_spin_or_raise(
+        prepared_input,
+        charge,
+        spin,
+        ligand_charge=ligand_charge,
+        prefix="[tsopt]",
+    )
     time_start = time.perf_counter()
 
     # --------------------------


### PR DESCRIPTION
## Summary
- add `--ligand-charge` to charge-requiring subcommands and derive total charge from the full complex when `-q` is omitted
- share extractor charge-summary logic for rounding/logging when inferring charges from complex inputs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fc12e73d0832db2392a03554287d0)