### PR TITLE
Align RFO print_every default with implementation

### DIFF
--- a/docs/opt.md
+++ b/docs/opt.md
@@ -147,7 +147,7 @@ lbfgs:
 rfo:
   thresh: gau                # RFOptimizer convergence preset
   max_cycles: 10000          # iteration cap
-  print_every: 10            # logging stride
+  print_every: 100           # logging stride (matches shared opt defaults)
   min_step_norm: 1.0e-08     # minimum accepted step norm
   assert_min_step: true      # assert when steps stagnate
   rms_force: null            # explicit RMS force target


### PR DESCRIPTION
## Summary
- Update `docs/opt.md` to reflect the RFO `print_every` default of 100 cycles, matching the implementation

## Testing
- Not run (documentation change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69421fb1ac8c832d895dba72011ff88a)