### PR TITLE
Clarify path-opt charge default behaviour

### DIFF
--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -23,7 +23,7 @@ pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} -q CHARGE -m MULT 
 
 ### Key behaviours
 - **Endpoints**: Exactly two structures are required. Formats follow `geom_loader`. PDB inputs also enable trajectory/HEI PDB exports.
-- **Charge/spin**: CLI overrides `.gjf` template metadata. If `-q` is omitted but `--ligand-charge` is provided, the endpoints are treated as an enzyme–substrate complex and `extract.py`’s charge summary computes the total charge; explicit `-q` still overrides. Otherwise defaults are `0/1`. Always set them explicitly for correct states.
+- **Charge/spin**: CLI overrides `.gjf` template metadata. If `-q` is omitted but `--ligand-charge` is provided, the endpoints are treated as an enzyme–substrate complex and `extract.py`’s charge summary computes the total charge; explicit `-q` still overrides. When both are omitted, the charge defaults to `0` (spin defaults to `1`). Always set them explicitly for correct states.
 - **Growing string**: `--max-nodes` controls the number of *internal* nodes (total images = `max_nodes + 2`). GSM growth and the optional climbing-image refinement share a convergence threshold preset supplied via `--thresh` or YAML (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`).
 - **Climbing image**: `--climb` toggles both the standard climbing step and the Lanczos-based tangent refinement.
 - **Dumping**: `--dump True` mirrors `opt.dump=True` for the StringOptimizer, producing trajectory/restart dumps inside `out_dir`.

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -49,11 +49,11 @@ out_dir/ (default: ./result_path_opt/)
 
 Notes
 -----
-- Charge/spin: `-q/--charge` (required for non-`.gjf` inputs **unless** ``--ligand-charge`` is supplied) and `-m/--multiplicity`
+- Charge/spin: `-q/--charge` (recommended for non-`.gjf` inputs; otherwise defaults to 0) and `-m/--multiplicity`
   are reconciled with any `.gjf` template values: explicit CLI options win. When ``-q`` is omitted but ``--ligand-charge`` is set,
   the full complex is treated as an enzyme–substrate system and the total charge is inferred using ``extract.py``’s residue-aware
-  logic. Omitting both `-q` and `--ligand-charge` for non-`.gjf` inputs causes the CLI to abort. Override explicitly to avoid
-  unphysical conditions.
+  logic. If neither `-q` nor `--ligand-charge` is supplied, the charge falls back to 0; set it explicitly to avoid unphysical
+  conditions.
 - Coordinates are Cartesian; `freeze_atoms` use 0-based indices. With `--freeze-links=True` and PDB inputs, link-hydrogen parents are added automatically.
 - `--max-nodes` sets the number of internal nodes; the string has (max_nodes + 2) images including endpoints.
 - `--max-cycles` limits optimization; after full growth, the same bound applies to additional refinement.


### PR DESCRIPTION
## Summary
- Update the path-opt docstring and user documentation to reflect the actual charge default when none is provided.

## Testing
- Not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69421fb1ac8c832d895dba72011ff88a)