### PR TITLE
Align add-elem-info argparse with documented options

### DIFF
--- a/pdb2reaction/add_elem_info.py
+++ b/pdb2reaction/add_elem_info.py
@@ -297,7 +297,13 @@ def main():
     ap = argparse.ArgumentParser(
         description="Add/repair element columns (77–78) in a PDB using Biopython."
     )
-    ap.add_argument("pdb", help="input PDB filepath")
+    ap.add_argument(
+        "-i",
+        "--input",
+        dest="in_pdb",
+        required=True,
+        help="Input PDB filepath",
+    )
     ap.add_argument(
         "-o",
         "--out",
@@ -310,12 +316,12 @@ def main():
     )
     args = ap.parse_args()
 
-    if not os.path.isfile(args.pdb):
-        print(f"[ERR] Input not found: {args.pdb}", file=sys.stderr)
+    if not os.path.isfile(args.in_pdb):
+        print(f"[ERR] Input not found: {args.in_pdb}", file=sys.stderr)
         sys.exit(1)
 
     try:
-        assign_elements(args.pdb, args.out, overwrite=args.overwrite)
+        assign_elements(args.in_pdb, args.out, overwrite=args.overwrite)
     except Exception as e:
         print(f"[ERR] Failed: {e}", file=sys.stderr)
         sys.exit(2)


### PR DESCRIPTION
## Summary
- align the standalone add-elem-info argparse interface with the documented -i/--input option
- update file checks and invocation to use the named input argument

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69421fb1ac8c832d895dba72011ff88a)