### PR TITLE
Handle geometry proxies without cart_coords in mode writer

### DIFF
--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -414,7 +414,12 @@ def _write_mode_trj_and_pdb(geom,
     converting the .trj using the input PDB as the template; on failure, an ASE fallback is used.
     Set `write_pdb=False` to skip PDB generation.
     """
-    ref_ang = geom.cart_coords.reshape(-1, 3) * BOHR2ANG
+    cart_coords = getattr(geom, "cart_coords", None)
+    if cart_coords is None:
+        cart_coords = getattr(geom, "coords", None)
+    if cart_coords is None:
+        raise AttributeError("Geometry object must provide cart_coords or coords.")
+    ref_ang = np.asarray(cart_coords).reshape(-1, 3) * BOHR2ANG
     mode = mode_vec_3N.reshape(-1, 3).copy()
     mode /= np.linalg.norm(mode)
 


### PR DESCRIPTION
### Motivation
- Fix an uncaught `AttributeError` seen when writing vibrational mode animations: `_GProxy` used in the TS optimizer exposes `coords` but not `cart_coords`.
- Allow the mode writer to accept geometry-like objects that provide either `cart_coords` or `coords` so mode output generation does not fail.
- Provide a clearer error if neither coordinate attribute is available.

### Description
- Update `_write_mode_trj_and_pdb` in `pdb2reaction/freq.py` to read coordinates via `getattr(geom, "cart_coords", None)` and fall back to `getattr(geom, "coords", None)`.
- If neither attribute is present, raise an `AttributeError` with the message: "Geometry object must provide cart_coords or coords."
- Convert the selected coordinate array with `np.asarray(...).reshape(-1, 3) * BOHR2ANG` before using it to write `.trj`/`.pdb` output.
- Change is limited to `pdb2reaction/freq.py` around the top of `_write_mode_trj_and_pdb` (safe, small scope).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69459e712b50832d8050049a1399ab99)