### PR TITLE
docs: include DMF alongside GSM in MEP/path documentation and docstrings

### DIFF
--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -24,7 +24,7 @@ pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} -q CHARGE -m MULT 
 ### Key behaviours
 - **Endpoints**: Exactly two structures are required. Formats follow `geom_loader`. PDB inputs also enable trajectory/HEI PDB exports.
 - **Charge/spin**: CLI overrides `.gjf` template metadata. If `-q` is omitted but `--ligand-charge` is provided, the endpoints are treated as an enzyme–substrate complex and `extract.py`’s charge summary computes the total charge; explicit `-q` still overrides. When both are omitted, the charge defaults to `0` (spin defaults to `1`). Always set them explicitly for correct states.
-- **Growing string**: `--max-nodes` controls the number of *internal* nodes (total images = `max_nodes + 2`). GSM growth and the optional climbing-image refinement share a convergence threshold preset supplied via `--thresh` or YAML (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`).
+- **MEP segments**: `--max-nodes` controls the number of *internal* nodes/images for the GSM string or DMF path (total images = `max_nodes + 2` for GSM). GSM growth and the optional climbing-image refinement share a convergence threshold preset supplied via `--thresh` or YAML (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`).
 - **Climbing image**: `--climb` toggles both the standard climbing step and the Lanczos-based tangent refinement.
 - **Dumping**: `--dump True` mirrors `opt.dump=True` for the StringOptimizer, producing trajectory/restart dumps inside `out_dir`.
 - **Exit codes**: `0` success, `3` optimizer failure, `4` trajectory write error, `5` HEI export error, `130` interrupt, `1` unexpected error.
@@ -42,13 +42,13 @@ pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} -q CHARGE -m MULT 
 | `--mep-mode {gsm\|dmf}` | Select GSM (string-based) or DMF (direct flux) path generator. | `gsm` |
 | `--max-cycles INT` | Optimizer macro-iteration cap (`opt.max_cycles`). | `300` |
 | `--climb BOOL` | Enable climbing-image refinement (and Lanczos tangent). | `True` |
-| `--dump BOOL` | Dump GSM trajectories/restarts. | `False` |
+| `--dump BOOL` | Dump MEP trajectories/restarts (GSM/DMF). | `False` |
 | `--opt-mode TEXT` | Single-structure optimizer for endpoint preoptimization (`light` = LBFGS, `heavy` = RFO). | `light` |
 | `--convert-files/--no-convert-files` | Toggle XYZ/TRJ → PDB/GJF companions for PDB/Gaussian inputs. | `--convert-files` |
 | `--out-dir TEXT` | Output directory. | `./result_path_opt/` |
 | `--thresh TEXT` | Override convergence preset for GSM/string optimizer. | _None_ |
 | `--args-yaml FILE` | YAML overrides (sections `geom`, `calc`, `gs`, `opt`). | _None_ |
-| `--preopt BOOL` | Pre-optimise each endpoint with the selected single-structure optimizer before alignment/GSM. | `False` |
+| `--preopt BOOL` | Pre-optimise each endpoint with the selected single-structure optimizer before alignment/MEP search (GSM/DMF). | `False` |
 | `--preopt-max-cycles INT` | Cap for endpoint preoptimization cycles. | `10000` |
 | `--fix-ends BOOL` | Keep the endpoint geometries fixed during GSM growth/refinement. | `False` |
 
@@ -63,7 +63,7 @@ out_dir/
 ├─ align_refine/               # Intermediate files from the rigid alignment/refinement stage (created only when scan output exists)
 └─ <optimizer dumps/restarts>  # Present when dumping is enabled
 ```
-Console output echoes the resolved YAML blocks and prints cycle-by-cycle GSM progress with timing information.
+Console output echoes the resolved YAML blocks and prints cycle-by-cycle MEP progress (GSM/DMF) with timing information.
 
 ## YAML configuration (`--args-yaml`)
 YAML inputs override CLI, which override the defaults listed below.

--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -104,9 +104,9 @@ Pipeline overview
           • multi-input: one template per pocket input in reaction order,
           • single+scan: the same original template is reused for all scan-derived structures.
 
-    **(2b) Pairwise GSM concatenation:** ``--refine-path False``
-      - Runs ``path-opt`` once for each adjacent pair in the ordered series and concatenates the resulting
-        trajectories into ``<out-dir>/path_opt/mep.trj`` (no recursive search).
+    **(2b) Pairwise MEP concatenation (GSM/DMF):** ``--refine-path False``
+      - Runs ``path-opt`` once for each adjacent pair in the ordered series (GSM or DMF, per ``--mep-mode``)
+        and concatenates the resulting trajectories into ``<out-dir>/path_opt/mep.trj`` (no recursive search).
       - Full-system merge is not performed in this mode.
 
     Shared knobs for the MEP step:
@@ -238,7 +238,7 @@ Outputs (& Directory Layout)
   │   ├─ hei_seg_XX.(xyz|pdb|gjf)        # HEI snapshots per reactive segment
   │   ├─ hei_w_ref_seg_XX.pdb            # merged HEI per segment (when --ref-pdb / PDB input)
   │   ├─ mep_w_ref_seg_XX.pdb            # merged per-segment trajectories (when --ref-pdb / PDB input; not mirrored)
-  │   ├─ seg_XXX_~~~/ ...                # GSM internals / recursion tree
+  │   ├─ seg_XXX_~~~/ ...                # GSM/DMF internals / recursion tree
   │   └─ post_seg_XX/                    # created when downstream post-processing runs
   │       ├─ ts/ ...
   │       ├─ irc/ ...

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -1,8 +1,8 @@
 # pdb2reaction/path_opt.py
 
 """
-path_opt — Minimum-energy path (MEP) optimization via the Growing String method (pysisyphus) with a UMA calculator
-===================================================================================================================
+path_opt — Minimum-energy path (MEP) optimization via GSM or DMF with a UMA calculator
+=====================================================================================
 
 Usage (CLI)
 -----------
@@ -25,10 +25,10 @@ Examples
 
 Description
 -----------
-- Optimizes a minimum-energy path between two endpoints using pysisyphus `GrowingString` and `StringOptimizer`, with UMA as the calculator (via `uma_pysis`).
+- Optimizes a minimum-energy path between two endpoints using GSM (pysisyphus `GrowingString` + `StringOptimizer`) or DMF, with UMA as the calculator (via `uma_pysis`).
 - Inputs: two structures (.pdb or .xyz). If a PDB is provided and `--freeze-links=True` (default), parent atoms of link hydrogens are added to `freeze_atoms` (0-based indices).
 - Configuration via YAML with sections `geom`, `calc`, `gs`, `opt`, and single-structure optimizer sections such as `sopt.lbfgs` / `sopt.rfo` (also accepting `opt.lbfgs` / `opt.rfo` and top-level `lbfgs` / `rfo`). Precedence: YAML > CLI > built-in defaults.
-- Optional endpoint pre-optimization: with `--preopt=True` (default False), each endpoint is relaxed individually via single-structure LBFGS ("light", default) or RFO ("heavy") before alignment and GSM. The iteration limit for this pre-optimization is controlled independently by `--preopt-max-cycles` (default: 10000) for whichever optimizer is selected.
+- Optional endpoint pre-optimization: with `--preopt=True` (default False), each endpoint is relaxed individually via single-structure LBFGS ("light", default) or RFO ("heavy") before alignment and MEP search. The iteration limit for this pre-optimization is controlled independently by `--preopt-max-cycles` (default: 10000) for whichever optimizer is selected.
 - Path generator: `--mep-mode` accepts GSM or DMF, with GSM enabled by default to match the CLI default.
 - Alignment: before optimization, all inputs after the first are rigidly Kabsch-aligned to the first structure using an external routine with a short relaxation. `StringOptimizer.align` is disabled. If either endpoint specifies `freeze_atoms`, the RMSD fit uses only those atoms and the resulting rigid transform is applied to all atoms.
 - With `--climb=True` (default), a climbing-image step refines the highest-energy image. Lanczos-based tangent estimation (`gs.climb_lanczos`) is enabled by default and follows the `--climb` flag; YAML can still override it.


### PR DESCRIPTION
### Motivation
- Clarify that the recursive MEP workflow supports both Growing String Method (GSM) and Direct Max Flux (DMF) as segment generators.
- Replace many GSM-specific phrasings with neutral "MEP segment / MEP" wording where the DMF mode is equally applicable.
- Ensure `--mep-mode`/CLI docs, examples, and output descriptions consistently reflect GSM/DMF support across the user-facing docs and in-module docstrings.

### Description
- Updated user docs to reference DMF alongside GSM and to generalize GSM-specific language to "MEP"/"MEP segment" where appropriate:
  - `docs/path_search.md`, `docs/all.md`, `docs/path_opt.md`
- Updated module-level docstrings and inline help text to mention DMF availability and to adjust parameter descriptions (`--max-nodes`, `--max-cycles`, `--dump`, `--preopt`, `--climb`, etc.):
  - `pdb2reaction/path_search.py`, `pdb2reaction/path_opt.py`, `pdb2reaction/all.py`
- Minor comments and output-layout text changed to show GSM/DMF-capable outputs (e.g., segment folders, dumps, stitching/bridging language). No algorithmic or runtime behavior was modified.

### Testing
- This is a documentation/docstring-only change; no automated tests were executed as part of this PR.
- No code paths were altered, so no runtime test impact is expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945b207f458832dbb9d7e41c586e615)