### PR TITLE
Fix README grammar and standardize US spelling across docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pdb2reaction: automated reaction-path modelling directly from PDB structures
+# pdb2reaction: automated reaction-path modeling directly from PDB structures
 
 ## Overview
 
@@ -14,13 +14,13 @@ for modeling enzymatic reaction pathways.
 
 Given one or more full protein–ligand PDBs `.pdb` (reactant, product, intermediates if you need), it automatically:
 
-- extracts a **active site** around user‑defined substrates to build **cluster model**,
-- explores **minimum‑energy paths (MEPs)** with path optimisation methods such as (growing string method and direct max flux method),
+- extracts an **active site** around user‑defined substrates to build **cluster model**,
+- explores **minimum‑energy paths (MEPs)** with path optimization methods such as the growing string method and direct max flux method,
 - _optionally_ refines **transition states**, runs **vibrational analysis**, **irc calculations** and **DFT single‑point calculations**
 
 with **machine learning interatomic potential** using Meta’s UMA model.
    
-All of this is exposed through a command‑line interface (CLI) designed so that a **multi‑step enzymatic reaction mechanism** can be generated with minimal manual intervention. Off course, this toolkit can handle small molecular systems. You can also use `.xyz` or `.gjf` format input structures.
+All of this is exposed through a command‑line interface (CLI) designed so that a **multi‑step enzymatic reaction mechanism** can be generated with minimal manual intervention. Of course, this toolkit can handle small molecular systems. You can also use `.xyz` or `.gjf` format input structures.
 
 On **HPC clusters or multi‑GPU workstations**, `pdb2reaction` can process **entire protein–ligand complexes** by scaling UMA inference across nodes. Set `workers` and `workers_per_nodes` to enable parallel calculation; see [`docs/uma_pysis.md`](docs/uma_pysis.md) for configuration details.
   
@@ -150,7 +150,7 @@ pdb2reaction [OPTIONS] ...
 pdb2reaction all [OPTIONS] ...
 ```
 
-The `all` workflow is an **orchestrator**: it chains pocket extraction, MEP search, TS optimisation, vibrational analysis, and optional DFT single points into a single command.
+The `all` workflow is an **orchestrator**: it chains pocket extraction, MEP search, TS optimization, vibrational analysis, and optional DFT single points into a single command.
 
 All high‑level workflows share two important options:
 
@@ -179,16 +179,16 @@ pdb2reaction -i R.pdb P.pdb -c "SAM,GPP" --ligand-charge "SAM:1,GPP:-3"
 pdb2reaction -i R.pdb I1.pdb I2.pdb P.pdb -c "SAM,GPP" --ligand-charge "SAM:1,GPP:-3" --out-dir ./result_all --tsopt True --thermo True --dft True
 ```
 
-Behaviour:
+Behavior:
 
 - takes two or more **full systems** in reaction order,
 - extracts catalytic pockets for each structure,
 - performs a **recursive MEP search** via `path_search` by default,
 - optionally switches to a **single‑pass** `path-opt` run with `--refine-path False`,
 - when PDB templates are available, merges the pocket‑level MEP back into the **full system**,
-- optionally runs TS optimisation, vibrational analysis, and DFT single points for each segment.
+- optionally runs TS optimization, vibrational analysis, and DFT single points for each segment.
 
-This is the recommended mode when you can generate reasonably spaced intermediates (e.g., from docking, MD, or manual modelling).
+This is the recommended mode when you can generate reasonably spaced intermediates (e.g., from docking, MD, or manual modeling).
 
 > **Important:** You need to input structures in **same atomic order**. And PDB structures must have **hydrogen atoms**.  
 ---
@@ -243,10 +243,10 @@ pdb2reaction -i TS_CANDIDATE.pdb -c "SAM,GPP" --ligand-charge "SAM:1,GPP:-3"
 pdb2reaction -i TS_CANDIDATE.pdb -c "SAM,GPP" --ligand-charge "SAM:1,GPP:-3" --tsopt True --thermo True --dft True --out-dir ./result_tsopt_only
 ```
 
-Behaviour:
+Behavior:
 
 - skips the MEP/path search entirely,
-- refines the **pocket TS** with TS optimisation,
+- refines the **pocket TS** with TS optimization,
 - runs a **IRC** in both directions and optimize both ends to relax down to R and P minima,
 - can then perform `freq` and `dft` on the R/TS/P,
 - produces UMA, Gibbs, and DFT//UMA energy diagrams.
@@ -257,7 +257,7 @@ Outputs such as `energy_diagram_*_all.png` and `irc_plot_all.png` are mirrored u
 
 ---
 
-## 4. Important CLI options and behaviours
+## 4. Important CLI options and behaviors
 
 Below are the most commonly used options across workflows.
 
@@ -271,7 +271,7 @@ Below are the most commonly used options across workflows.
   When pocket extraction is skipped, XYZ/GJF inputs are also accepted.
 
 - `-c, --center TEXT`  
-  Defines the substrate / pocket centre for extraction. Supports:
+  Defines the substrate / pocket center for extraction. Supports:
 
   - PDB paths,
   - residue IDs, e.g. `A:123,B:456`,
@@ -283,7 +283,7 @@ Below are the most commonly used options across workflows.
   - a single integer (total pocket charge), or
   - a mapping, e.g. `"SAM:1,GPP:-3"`.
 
-  The total charge of the first pocket is rounded to an integer and reused for scan, GSM, and TS optimisation runs.
+  The total charge of the first pocket is rounded to an integer and reused for scan, GSM, and TS optimization runs.
 
 - `-q, --charge INT`  
   Hard override of the total system charge. This bypasses:
@@ -310,13 +310,13 @@ Below are the most commonly used options across workflows.
   Top‑level output directory. All intermediate files, logs, and figures are placed here.
 
 - `--tsopt BOOLEAN`  
-  Enable TS optimisation and IRC propagation. Required for TSOPT‑only mode, but also useful in multi‑structure workflows to refine TS along the path.
+  Enable TS optimization and IRC propagation. Required for TSOPT‑only mode, but also useful in multi‑structure workflows to refine TS along the path.
 
 - `--thermo BOOLEAN`  
   Run vibrational analysis and compute thermochemistry on UMA geometries. Produces Gibbs free energies and corresponding energy diagrams.
 
 - `--dft BOOLEAN`  
-  Perform DFT single‑point calculations on UMA optimised structures via PySCF / gpu4pyscf. When combined with `--thermo True`, this adds DFT//UMA Gibbs diagrams.
+  Perform DFT single‑point calculations on UMA optimized structures via PySCF / gpu4pyscf. When combined with `--thermo True`, this adds DFT//UMA Gibbs diagrams.
 
 - `--refine-path BOOLEAN`
   Switch between:
@@ -326,10 +326,10 @@ Below are the most commonly used options across workflows.
   When `--refine-path True` (default) and full‑system PDB templates are available, merged MEP snapshots (`mep_w_ref*.pdb`) are written under `<out-dir>/path_search/`.
 
 - `--opt-mode light | heavy`
-  Switch Optimization / TS refinement method with Light (LBFGS and Dimer method) or Heavy (Hessian-using RFO and RS-I-RFO) algorithm. 
+  Switch optimization / TS refinement methods between Light (LBFGS and Dimer) and Heavy (Hessian-using RFO and RS-I-RFO) algorithms.
 
 - `--mep-mode gsm | dmf`
-  Switch MEP refinement method with Growing String Method (GSM) or Direct Max Flux (DMF) Method.
+  Switch MEP refinement between the Growing String Method (GSM) and Direct Max Flux (DMF).
 
 For a full matrix of options and YAML schemas, see `docs/all.md` in the repository.
 

--- a/docs/all.md
+++ b/docs/all.md
@@ -95,9 +95,9 @@ pdb2reaction all -i reactant.pdb -c "GPP,MMT" \
 | `--dump BOOLEAN` | Dump MEP (GSM/DMF) and single-structure trajectories (propagates to scan/tsopt/freq). | `False` |
 | `--convert-files/--no-convert-files` | Global toggle for XYZ/TRJ → PDB/GJF companions when templates are available. | `--convert-files` |
 | `--args-yaml FILE` | YAML forwarded unchanged to `path_search`, `scan`, `tsopt`, `freq`, and `dft`. | _None_ |
-| `--preopt BOOLEAN` | Pre-optimise pocket endpoints before MEP search (also the default for scan preopt). | `True` |
+| `--preopt BOOLEAN` | Pre-optimize pocket endpoints before MEP search (also the default for scan preopt). | `True` |
 | `--hessian-calc-mode [Analytical\|FiniteDifference]` | Shared UMA Hessian engine forwarded to tsopt and freq. | _None_ (uses YAML/default of `FiniteDifference`) |
-| `--tsopt BOOLEAN` | Run TS optimisation + IRC per reactive segment, or enable TSOPT-only mode (single input). | `False` |
+| `--tsopt BOOLEAN` | Run TS optimization + IRC per reactive segment, or enable TSOPT-only mode (single input). | `False` |
 | `--thermo BOOLEAN` | Run vibrational analysis (`freq`) on R/TS/P and build UMA Gibbs diagram. | `False` |
 | `--dft BOOLEAN` | Run single-point DFT on R/TS/P and build DFT energy + optional DFT//UMA diagrams. | `False` |
 | `--dft-engine [gpu\|cpu\|auto]` | Preferred backend for the DFT stage (`auto` tries GPU then CPU). | `gpu` |
@@ -107,7 +107,7 @@ pdb2reaction all -i reactant.pdb -c "GPP,MMT" \
 | `--freq-max-write INT` | Override `freq --max-write`. | _None_ |
 | `--freq-amplitude-ang FLOAT` | Override `freq --amplitude-ang` (Å). | _None_ |
 | `--freq-n-frames INT` | Override `freq --n-frames`. | _None_ |
-| `--freq-sort [value\|abs]` | Override freq mode sorting behaviour. | _None_ |
+| `--freq-sort [value\|abs]` | Override freq mode sorting behavior. | _None_ |
 | `--freq-temperature FLOAT` | Override freq thermochemistry temperature (K). | _None_ |
 | `--freq-pressure FLOAT` | Override freq thermochemistry pressure (atm). | _None_ |
 | `--dft-out-dir PATH` | Base directory override for DFT outputs. | _None_ |
@@ -121,8 +121,8 @@ pdb2reaction all -i reactant.pdb -c "GPP,MMT" \
 | `--scan-max-step-size FLOAT` | Override scan `--max-step-size` (Å). | _None_ |
 | `--scan-bias-k FLOAT` | Override the harmonic bias strength `k` (eV/Å²). | _None_ |
 | `--scan-relax-max-cycles INT` | Override scan relaxation max cycles per step. | _None_ |
-| `--scan-preopt BOOLEAN` | Override the scan preoptimisation toggle (otherwise `--preopt` propagates). | _None_ |
-| `--scan-endopt BOOLEAN` | Override the scan end-of-stage optimisation toggle. | _None_ |
+| `--scan-preopt BOOLEAN` | Override the scan preoptimization toggle (otherwise `--preopt` propagates). | _None_ |
+| `--scan-endopt BOOLEAN` | Override the scan end-of-stage optimization toggle. | _None_ |
 
 ## Outputs
 ```
@@ -132,10 +132,10 @@ out_dir/ (default: ./result_all/)
 ├─ pockets/                  # Per-input pocket PDBs when extraction runs
 ├─ scan/                     # Staged pocket scan results (present when --scan-lists is provided)
 ├─ path_search/              # MEP results (GSM/DMF): trajectories, merged PDBs, diagrams, summary.yaml, per-segment folders
-├─ path_search/tsopt_seg_XX/ # Post-processing outputs (TS optimisation, IRC, freq, DFT, diagrams)
+├─ path_search/tsopt_seg_XX/ # Post-processing outputs (TS optimization, IRC, freq, DFT, diagrams)
 └─ tsopt_single/             # TSOPT-only outputs with IRC endpoints and optional freq/DFT directories
 ```
-- Console logs summarising pocket charge resolution, YAML contents, scan stages, MEP progress (GSM/DMF), and per-stage timing.
+- Console logs summarizing pocket charge resolution, YAML contents, scan stages, MEP progress (GSM/DMF), and per-stage timing.
 
 ### Reading `summary.log`
 The log is organized into numbered sections:

--- a/docs/dft.md
+++ b/docs/dft.md
@@ -25,7 +25,7 @@ pdb2reaction dft -i input.pdb -q 1 -m 2 --func-basis "wb97m-v/def2-tzvpd" --max-
 1. **Input handling** – Any file loadable by `geom_loader` (.pdb/.xyz/.trj/…) is accepted. Coordinates are re-exported as `input_geometry.xyz`.
 2. **Configuration merge** – Defaults → CLI → YAML (`dft` block). YAML overrides take precedence over CLI flags. Charge/multiplicity inherit `.gjf` metadata when present. If `-q` is omitted but `--ligand-charge` is provided, the structure is treated as an enzyme–substrate complex and `extract.py`’s charge summary derives the total charge; explicit `-q` still overrides. Otherwise charge defaults to `0` and multiplicity to `1`.
 3. **SCF build** – `--func-basis` is parsed into functional and basis. Density fitting is enabled automatically with PySCF defaults. `--engine` controls GPU/CPU preference (`gpu` tries GPU4PySCF before falling back; `cpu` forces CPU; `auto` tries GPU then CPU). Nonlocal corrections (e.g., VV10) are not configured explicitly beyond the backend defaults.
-4. **Population analysis & outputs** – After convergence (or failure) the command writes `result.yaml` summarising energy (Hartree/kcal·mol⁻¹), convergence metadata, timing, backend info, and per-atom Mulliken/meta-Löwdin/IAO charges and spin densities (UKS only for spins). Any failed analysis column is set to `null` with a warning.
+4. **Population analysis & outputs** – After convergence (or failure) the command writes `result.yaml` summarizing energy (Hartree/kcal·mol⁻¹), convergence metadata, timing, backend info, and per-atom Mulliken/meta-Löwdin/IAO charges and spin densities (UKS only for spins). Any failed analysis column is set to `null` with a warning.
 
 ## CLI options
 | Option | Description | Default |
@@ -54,7 +54,7 @@ out_dir/ (default: ./result_dft/)
     (`gpu4pyscf` vs `pyscf(cpu)`, `used_gpu`).
   - `charges`: Mulliken, meta-Löwdin, and IAO atomic charges (`null` when a method fails).
   - `spin_densities`: Mulliken, meta-Löwdin, and IAO spin densities (UKS-only for spins).
-- It also summarises charge, multiplicity, spin (2S), functional, basis,
+- It also summarizes charge, multiplicity, spin (2S), functional, basis,
   convergence knobs, and resolved output directory.
 
 ## Notes

--- a/docs/extract.md
+++ b/docs/extract.md
@@ -109,4 +109,4 @@ pdb2reaction extract -i complex1.pdb complex2.pdb -c "GPP,SAM" -o pocket1.pdb po
 - Waters can be excluded with `--include-H2O false`.
 - Backbone trimming plus capping respect chain breaks and PRO/HYP safeguards as outlined above; non-amino residues never lose backbone-like atom names.
 - Link hydrogens are inserted only on carbon cuts and reuse identical bonding patterns across models in ensemble mode.
-- INFO logs summarise residue selection, truncation counts, and charge breakdowns.
+- INFO logs summarize residue selection, truncation counts, and charge breakdowns.

--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -21,7 +21,7 @@ pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} -q CHARGE -m MULT 
    - After the path is grown and refined, the tool searches for the highest-energy internal local maximum (preferred). If none exists, it falls back to the maximum among internal nodes; if no internal nodes are present, the global maximum is exported.
    - The highest-energy image (HEI) is written both as `.xyz` and `.pdb` when a PDB reference exists, and as `.gjf` when a Gaussian template is available; these conversions honor `--convert-files`.
 
-### Key behaviours
+### Key behaviors
 - **Endpoints**: Exactly two structures are required. Formats follow `geom_loader`. PDB inputs also enable trajectory/HEI PDB exports.
 - **Charge/spin**: CLI overrides `.gjf` template metadata. If `-q` is omitted but `--ligand-charge` is provided, the endpoints are treated as an enzyme–substrate complex and `extract.py`’s charge summary computes the total charge; explicit `-q` still overrides. When both are omitted, the charge defaults to `0` (spin defaults to `1`). Always set them explicitly for correct states.
 - **MEP segments**: `--max-nodes` controls the number of *internal* nodes/images for the GSM string or DMF path (total images = `max_nodes + 2` for GSM). GSM growth and the optional climbing-image refinement share a convergence threshold preset supplied via `--thresh` or YAML (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`).
@@ -48,7 +48,7 @@ pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} -q CHARGE -m MULT 
 | `--out-dir TEXT` | Output directory. | `./result_path_opt/` |
 | `--thresh TEXT` | Override convergence preset for GSM/string optimizer. | _None_ |
 | `--args-yaml FILE` | YAML overrides (sections `geom`, `calc`, `gs`, `opt`). | _None_ |
-| `--preopt BOOL` | Pre-optimise each endpoint with the selected single-structure optimizer before alignment/MEP search (GSM/DMF). | `False` |
+| `--preopt BOOL` | Pre-optimize each endpoint with the selected single-structure optimizer before alignment/MEP search (GSM/DMF). | `False` |
 | `--preopt-max-cycles INT` | Cap for endpoint preoptimization cycles. | `10000` |
 | `--fix-ends BOOL` | Keep the endpoint geometries fixed during GSM growth/refinement. | `False` |
 
@@ -72,13 +72,13 @@ YAML inputs override CLI, which override the defaults listed below.
 - Same keys as [`opt`](opt.md) (`coord_type`, `freeze_atoms`, etc.); `--freeze-links` augments `freeze_atoms` for PDBs.
 
 ### `calc`
-- UMA calculator setup identical to the single-structure optimization (`model`, `device`, neighbour radii, Hessian options, etc.).
+- UMA calculator setup identical to the single-structure optimization (`model`, `device`, neighbor radii, Hessian options, etc.).
 
 ### `dmf`
 - Direct Max Flux + (C)FB-ENM interpolation controls. Keys mirror the CLI-accessible `dmf` block:
 
 ### `gs`
-- Controls the Growing String representation: `max_nodes`, `perp_thresh`, reparametrisation cadence (`reparam_check`, `reparam_every`, `reparam_every_full`, `param`), `max_micro_cycles`, DLC resets, climb toggles/thresholds, and optional scheduler hooks.
+- Controls the Growing String representation: `max_nodes`, `perp_thresh`, reparameterization cadence (`reparam_check`, `reparam_every`, `reparam_every_full`, `param`), `max_micro_cycles`, DLC resets, climb toggles/thresholds, and optional scheduler hooks.
 
 ### `opt`
 - StringOptimizer settings: type labels, `stop_in_when_full`, `align=False` (kept off), `scale_step`, `max_cycles`, dumping flags, `reparam_thresh`, `coord_diff_thresh`, `out_dir`, and `print_every`.

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -48,7 +48,7 @@ pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--multiplicity 2S
 | `--out-dir TEXT` | Output directory. | `./result_path_search/` |
 | `--thresh TEXT` | Override convergence preset for GSM and per-image optimizations (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | _None_ |
 | `--args-yaml FILE` | YAML overrides (see below). | _None_ |
-| `--preopt BOOL` | Explicit `True`/`False`. Pre-optimise each endpoint before MEP search (recommended). | `True` |
+| `--preopt BOOL` | Explicit `True`/`False`. Pre-optimize each endpoint before MEP search (recommended). | `True` |
 | `--align / --no-align` | Flag toggle. Align all inputs to the first structure before searching. | `--align` |
 | `--ref-pdb PATH...` | Full-size template PDBs (one per input, unless `--align` lets you reuse the first). | _None_ |
 

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -26,7 +26,7 @@ Description
   The backend policy is controlled by --engine:
   * gpu  (default): try GPU4PySCF first; on import/runtime errors, automatically fall back to CPU PySCF.
   * cpu           : use CPU PySCF only.
-  * auto          : try GPU4PySCF first and fall back to CPU PySCF if unavailable (same behaviour as "gpu").
+  * auto          : try GPU4PySCF first and fall back to CPU PySCF if unavailable (same behavior as "gpu").
 - RKS/UKS is selected automatically from the spin multiplicity (2S+1).
 - Inputs: any structure format supported by pysisyphus.helpers.geom_loader (.pdb, .xyz, .trj, …).
   The geometry is written back unchanged as input_geometry.xyz.


### PR DESCRIPTION
### Motivation

- Normalize writing style and fix obvious grammar issues in the top-level README and related documentation for improved clarity. 
- Standardize spelling to American English across docs and inline docstrings to avoid mixed variants and improve consistency. 
- Make several small phrase/terminology edits (e.g., remove redundant wording and unify option descriptions) so CLI docs read more clearly. 
- Ensure docstrings and standalone docs use the same terminology for user-facing options and behaviors.

### Description

- Updated `README.md` to correct grammar (e.g., "Off course" → "Of course", "a active site" → "an active site") and switch British spellings to US (e.g., "modelling" → "modeling", "optimisation" → "optimization").
- Standardized US spelling and wording in documentation files: `docs/all.md`, `docs/path_opt.md`, `docs/path_search.md`, `docs/dft.md`, and `docs/extract.md` (e.g., `centre` → `center`, `behaviour` → `behavior`, `neighbour` → `neighbor`, `reparametrisation` → `reparameterization`).
- Adjusted a small docstring in `pdb2reaction/dft.py` to use US spelling (`behaviour` → `behavior`).
- Minor clarifications to CLI option descriptions to remove redundancy and improve phrasing (e.g., streamline `--mep-mode` and `--opt-mode` descriptions).

### Testing

- No automated unit or integration tests were run because these are documentation-only changes. 
- Repository search/inspection was used to locate occurrences of target spellings and phrases prior to edits. 
- Changes were committed locally and staged as a documentation-only patch affecting 7 files. 
- No code behavior was modified and therefore no runtime tests were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694707446d70832d91671407019c048d)