### PR TITLE
Rename workers_per_nodes → workers_per_node (CLI flag: --workers-per-node)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ with **machine learning interatomic potential** using Meta’s UMA model.
    
 All of this is exposed through a command‑line interface (CLI) designed so that a **multi‑step enzymatic reaction mechanism** can be generated with minimal manual intervention. Of course, this toolkit can handle small molecular systems. You can also use `.xyz` or `.gjf` format input structures.
 
-On **HPC clusters or multi‑GPU workstations**, `pdb2reaction` can process large pockets (and optionally **full protein–ligand complexes**) by scaling UMA inference across nodes. Set `workers` and `workers_per_nodes` to enable parallel calculation; see [`docs/uma_pysis.md`](docs/uma_pysis.md) for configuration details.
+On **HPC clusters or multi‑GPU workstations**, `pdb2reaction` can process large pockets (and optionally **full protein–ligand complexes**) by scaling UMA inference across nodes. Set `workers` and `workers_per_node` to enable parallel calculation; see [`docs/uma_pysis.md`](docs/uma_pysis.md) for configuration details.
 
 > **Important:** Input PDB files must already contain **hydrogen atoms**.
 

--- a/docs/all.md
+++ b/docs/all.md
@@ -84,7 +84,7 @@ pdb2reaction all -i reactant.pdb -c "GPP,MMT" \
 | `--selected_resn TEXT` | Residues to force include (comma/space separated; chain/insertion codes allowed). | `""` |
 | `--ligand-charge TEXT` | Total charge or residue-specific mapping for unknown residues (recommended). When `-q` is omitted, triggers extract-style charge derivation on the full complex. | `None` |
 | `-q, --charge INT` | Force the total system charge, overriding extractor rounding / `.gjf` metadata / `--ligand-charge` (logs a warning). | _None_ |
-| `--workers`, `--workers-per-nodes` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_nodes` forwarded to the parallel predictor). | `1`, `1` |
+| `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
 | `--verbose BOOLEAN` | Enable INFO-level extractor logging. | `True` |
 | `-m, --mult INT` | Spin multiplicity forwarded to all downstream steps. | `1` |
 | `--freeze-links BOOLEAN` | Freeze link parents in pocket PDBs (reused by scan/tsopt/freq). | `True` |

--- a/docs/freq.md
+++ b/docs/freq.md
@@ -59,7 +59,7 @@ pdb2reaction freq -i a.xyz -q -1 --args-yaml ./args.yaml --out-dir ./result_freq
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
 | `-q, --charge INT` | Total charge. When omitted, charge can be inferred from `--ligand-charge`; explicit `-q` overrides any derived value. | Required unless a `.gjf` template or `--ligand-charge` supplies it |
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
-| `--workers`, `--workers-per-nodes` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_nodes` forwarded to the parallel predictor). | `1`, `1` |
+| `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
 | `-m, --multiplicity INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--freeze-links BOOL` | PDB-only. Freeze parents of link hydrogens and merge with `geom.freeze_atoms`. | `True` |
 | `--max-write INT` | Number of modes to export. | `10` |

--- a/docs/irc.md
+++ b/docs/irc.md
@@ -37,7 +37,7 @@ pdb2reaction irc -i ts.pdb -q 0 -m 1 --max-cycles 50 --out-dir ./result_irc/
 | `-i, --input PATH` | Transition-state structure accepted by `geom_loader`. | Required |
 | `-q, --charge INT` | Total charge; overrides `calc.charge`. Required unless the input is a `.gjf` template with charge metadata. Overrides `--ligand-charge` when both are set. | Required when not in template |
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
-| `--workers`, `--workers-per-nodes` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_nodes` forwarded to the parallel predictor). | `1`, `1` |
+| `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
 | `-m, --multiplicity INT` | Spin multiplicity (2S+1); overrides `calc.spin`. | `.gjf` template value or `1` |
 | `--max-cycles INT` | Maximum IRC steps; overrides `irc.max_cycles`. | _None_ (use YAML/default `125`) |
 | `--step-size FLOAT` | Step length in mass-weighted coordinates; overrides `irc.step_length`. | _None_ (default `0.10`) |

--- a/docs/opt.md
+++ b/docs/opt.md
@@ -33,7 +33,7 @@ pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} -q CHARGE -m MULT \
 | `-i, --input PATH` | Input structure accepted by `geom_loader`. | Required |
 | `-q, --charge INT` | Total charge. Required unless the input is a `.gjf` template that already encodes charge. Overrides `--ligand-charge` when both are set. | Required when not in template |
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
-| `--workers`, `--workers-per-nodes` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_nodes` forwarded to the parallel predictor). | `1`, `1` |
+| `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
 | `-m, --multiplicity INT` | Spin multiplicity (2S+1). Falls back to `.gjf` template or `1`. | Template/`1` |
 | `--dist-freeze TEXT` | Repeatable string parsed as Python literal describing `(i,j,target_A)` tuples for harmonic restraints. | _None_ |
 | `--one-based / --zero-based` | Interpret `--dist-freeze` indices as 1-based (default) or 0-based. | `--one-based` |

--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -35,7 +35,7 @@ pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} -q CHARGE -m MULT 
 | `-i, --input PATH PATH` | Reactant and product structures (`.pdb`/`.xyz`). | Required |
 | `-q, --charge INT` | Total charge (`calc.charge`). Required unless the input is a `.gjf` template that already encodes charge. Overrides `--ligand-charge` when both are set. | Required when not in template |
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex even without pocket extraction. | `None` |
-| `--workers`, `--workers-per-nodes` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_nodes` forwarded to the parallel predictor). | `1`, `1` |
+| `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
 | `-m, --multiplicity INT` | Spin multiplicity (`calc.spin`). | Template/`1` |
 | `--freeze-links BOOL` | PDB-only: freeze link-H parents (merged with YAML). | `True` |
 | `--max-nodes INT` | Number of internal nodes (string images = `max_nodes + 2`). | `10` |

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -34,7 +34,7 @@ pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--multiplicity 2S
 | `-i, --input PATH...` | Two or more structures in reaction order (reactant → product). Repeat `-i` or pass multiple paths after one flag. | Required |
 | `-q, --charge INT` | Total charge. Required unless the first input is a `.gjf` template that already stores charge. Overrides `--ligand-charge` when both are set. | Required when not in template |
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex even when pockets are skipped. | `None` |
-| `--workers`, `--workers-per-nodes` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_nodes` forwarded to the parallel predictor). | `1`, `1` |
+| `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
 | `-m, --multiplicity INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--freeze-links BOOL` | Explicit `True`/`False`. When loading PDB pockets, freeze the parent atoms of link hydrogens. | `True` |
 | `--max-nodes INT` | Internal nodes per MEP segment (GSM string images or DMF images). | `10` |

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -56,7 +56,7 @@ pdb2reaction scan -i input.pdb -q 0 \
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
 | `-q, --charge INT` | Total charge (CLI > template > 0). When omitted, charge can be inferred from `--ligand-charge`; explicit `-q` overrides any derived value. | Required unless a `.gjf` template or `--ligand-charge` supplies it |
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
-| `--workers`, `--workers-per-nodes` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_nodes` forwarded to the parallel predictor). | `1`, `1` |
+| `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
 | `-m, --multiplicity INT` | Spin multiplicity 2S+1 (CLI > template > 1). | `.gjf` template value or `1` |
 | `--scan-lists TEXT` | Repeatable Python literal with `(i,j,targetÅ)` tuples. Each literal is one stage. | Required |
 | `--one-based / --zero-based` | Interpret atom indices as 1- or 0-based. | `--one-based` |

--- a/docs/scan2d.md
+++ b/docs/scan2d.md
@@ -65,7 +65,7 @@ pdb2reaction scan2d -i input.pdb -q 0 \
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
 | `-q, --charge INT` | Total charge (CLI > template > 0). Overrides `--ligand-charge` when both are set. | Required when not in template |
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
-| `--workers`, `--workers-per-nodes` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_nodes` forwarded to the parallel predictor). | `1`, `1` |
+| `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
 | `-m, --multiplicity INT` | Spin multiplicity 2S+1 (CLI > template > 1). | `.gjf` template value or `1` |
 | `--scan-list TEXT` | **Single** Python literal with two quadruples `(i,j,lowÅ,highÅ)`. | Required |
 | `--one-based / --zero-based` | Interpret `(i, j)` indices as 1- or 0-based. | `--one-based` |

--- a/docs/scan3d.md
+++ b/docs/scan3d.md
@@ -65,7 +65,7 @@ pdb2reaction scan3d -i input.pdb -q 0 \
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
 | `-q, --charge INT` | Total charge (CLI > template > 0). Overrides `--ligand-charge` when both are set. | Required when not in template |
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
-| `--workers`, `--workers-per-nodes` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_nodes` forwarded to the parallel predictor). | `1`, `1` |
+| `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
 | `-m, --multiplicity INT` | Spin multiplicity 2S+1. | `1` |
 | `--scan-list TEXT` | **Single** Python literal with three quadruples `(i,j,lowÅ,highÅ)`. | Required |
 | `--one-based / --zero-based` | Interpret `(i, j)` indices as 1- or 0-based. | `--one-based` |

--- a/docs/tsopt.md
+++ b/docs/tsopt.md
@@ -76,7 +76,7 @@ pdb2reaction tsopt -i ts_cand.pdb -q 0 -m 1 --opt-mode heavy \
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
 | `-q, --charge INT` | Total charge. Required unless the input is a `.gjf` template with charge metadata. Overrides `--ligand-charge` when both are set. | Required when not in template |
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
-| `--workers`, `--workers-per-nodes` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_nodes` forwarded to the parallel predictor). | `1`, `1` |
+| `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
 | `-m, --multiplicity INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
 | `--freeze-links BOOL` | PDB-only. Freeze parents of link hydrogens (merged into `geom.freeze_atoms`). | `True` |
 | `--max-cycles INT` | Macro-cycle cap forwarded to `opt.max_cycles`. | `10000` |

--- a/docs/uma_pysis.md
+++ b/docs/uma_pysis.md
@@ -23,11 +23,11 @@ hessian = calc.get_hessian(["C", "O"], coords_bohr)
 - **Hessian modes** – `hessian_calc_mode="Analytical"` uses second-order autograd on the selected device; `"FiniteDifference"` (default) computes central differences of forces. Analytical mode is automatically disabled when multiple inference workers are requested.
 - **Freeze atoms** – provide 0-based indices via `freeze_atoms`; frozen atoms receive zeroed forces. Hessians either drop frozen degrees of freedom (`return_partial_hessian=True`) or zero corresponding columns in the full matrix.
 - **Precision control** – energies and forces are always returned as float64. Set `hessian_double=False` to obtain the Hessian in the model's native dtype (typically float32).
-- **Multi-worker inference** – `workers>1` spawns FAIR-Chem's `ParallelMLIPPredictUnit` with `workers_per_nodes` workers per node, useful for batch throughput. Analytical Hessians are skipped in this mode.
+- **Multi-worker inference** – `workers>1` spawns FAIR-Chem's `ParallelMLIPPredictUnit` with `workers_per_node` workers per node, useful for batch throughput. Analytical Hessians are skipped in this mode.
 
 ## HPC example: PBS + Open MPI + Ray
 
-`workers` / `workers_per_nodes` can be scaled across nodes by launching a Ray cluster under your scheduler. The following PBS script illustrates one way to build a multi-node Ray cluster on an Open MPI–equipped HPC system (adjust module names, ports, and resource requests to match your environment):
+`workers` / `workers_per_node` can be scaled across nodes by launching a Ray cluster under your scheduler. The following PBS script illustrates one way to build a multi-node Ray cluster on an Open MPI–equipped HPC system (adjust module names, ports, and resource requests to match your environment):
 
 ```bash
 #!/bin/bash
@@ -168,7 +168,7 @@ Common constructor keywords (defaults shown in the rightmost column):
 | `model` | UMA pretrained model name. | `"uma-s-1p1"` |
 | `task_name` | Task tag recorded in UMA batches. | `"omol"` |
 | `device` | "cuda", "cpu", or automatic selection. | `"auto"` |
-| `workers` / `workers_per_nodes` | Parallel UMA predictors; when `workers>1`, analytical Hessians are disabled. | `1` / `1` |
+| `workers` / `workers_per_node` | Parallel UMA predictors; when `workers>1`, analytical Hessians are disabled. | `1` / `1` |
 | `max_neigh`, `radius`, `r_edges` | Optional overrides for UMA neighborhood construction. | `None`, `None`, `False` |
 | `freeze_atoms` | List of 0-based atom indices to freeze. | `None` |
 | `hessian_calc_mode` | "Analytical" or "FiniteDifference" for Hessian evaluation. | `"FiniteDifference"` |

--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -418,7 +418,7 @@ def _build_calc_cfg(
     charge: int,
     spin: int,
     workers: Optional[int] = None,
-    workers_per_nodes: Optional[int] = None,
+    workers_per_node: Optional[int] = None,
     yaml_cfg: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Return a UMA calculator configuration honoring YAML overrides when provided."""
@@ -427,8 +427,8 @@ def _build_calc_cfg(
     cfg["spin"] = int(spin)
     if workers is not None:
         cfg["workers"] = int(workers)
-    if workers_per_nodes is not None:
-        cfg["workers_per_nodes"] = int(workers_per_nodes)
+    if workers_per_node is not None:
+        cfg["workers_per_node"] = int(workers_per_node)
     if yaml_cfg:
         apply_yaml_overrides(
             yaml_cfg,
@@ -1797,10 +1797,10 @@ def _irc_and_match(
     help="UMA predictor workers; >1 spawns a parallel predictor (disables analytic Hessian).",
 )
 @click.option(
-    "--workers-per-nodes",
-    "workers_per_nodes",
+    "--workers-per-node",
+    "workers_per_node",
     type=int,
-    default=CALC_KW["workers_per_nodes"],
+    default=CALC_KW["workers_per_node"],
     show_default=True,
     help="Workers per node when using a parallel UMA predictor (workers>1).",
 )
@@ -2132,7 +2132,7 @@ def cli(
     ligand_charge: Optional[str],
     charge_override: Optional[int],
     workers: int,
-    workers_per_nodes: int,
+    workers_per_node: int,
     verbose: bool,
     spin: int,
     freeze_links_flag: bool,
@@ -2468,7 +2468,7 @@ def cli(
         q_int,
         spin,
         workers=workers,
-        workers_per_nodes=workers_per_nodes,
+        workers_per_node=workers_per_node,
         yaml_cfg=yaml_cfg,
     )
 

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -523,10 +523,10 @@ THERMO_KW = {
     help="UMA predictor workers; >1 spawns a parallel predictor (disables analytic Hessian).",
 )
 @click.option(
-    "--workers-per-nodes",
-    "workers_per_nodes",
+    "--workers-per-node",
+    "workers_per_node",
     type=int,
-    default=CALC_KW["workers_per_nodes"],
+    default=CALC_KW["workers_per_node"],
     show_default=True,
     help="Workers per node when using a parallel UMA predictor (workers>1).",
 )
@@ -580,7 +580,7 @@ def cli(
     charge: Optional[int],
     ligand_charge: Optional[str],
     workers: int,
-    workers_per_nodes: int,
+    workers_per_node: int,
     spin: Optional[int],
     freeze_links: bool,
     convert_files: bool,
@@ -622,7 +622,7 @@ def cli(
     calc_cfg["charge"] = int(charge)
     calc_cfg["spin"]   = int(spin)
     calc_cfg["workers"] = int(workers)
-    calc_cfg["workers_per_nodes"] = int(workers_per_nodes)
+    calc_cfg["workers_per_node"] = int(workers_per_node)
     if hessian_calc_mode is not None:
         calc_cfg["hessian_calc_mode"] = str(hessian_calc_mode)
 

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -195,10 +195,10 @@ def _echo_convert_trj_if_exists(
     help="UMA predictor workers; >1 spawns a parallel predictor (disables analytic Hessian).",
 )
 @click.option(
-    "--workers-per-nodes",
-    "workers_per_nodes",
+    "--workers-per-node",
+    "workers_per_node",
     type=int,
-    default=CALC_KW_DEFAULT["workers_per_nodes"],
+    default=CALC_KW_DEFAULT["workers_per_node"],
     show_default=True,
     help="Workers per node when using a parallel UMA predictor (workers>1).",
 )
@@ -248,7 +248,7 @@ def cli(
     charge: Optional[int],
     ligand_charge: Optional[str],
     workers: int,
-    workers_per_nodes: int,
+    workers_per_node: int,
     spin: Optional[int],
     max_cycles: Optional[int],
     step_size: Optional[float],
@@ -287,7 +287,7 @@ def cli(
         calc_cfg["charge"] = int(charge)
         calc_cfg["spin"]   = int(spin)
         calc_cfg["workers"] = int(workers)
-        calc_cfg["workers_per_nodes"] = int(workers_per_nodes)
+        calc_cfg["workers_per_node"] = int(workers_per_node)
 
         if hessian_calc_mode is not None:
             calc_cfg["hessian_calc_mode"] = str(hessian_calc_mode)

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -10,7 +10,7 @@ Usage (CLI)
         [--opt-mode {light|heavy}] [--freeze-links {True|False}] \
         [--dist-freeze "[(I,J,TARGET_A), ...]"] [--one-based|--zero-based] \
         [--bias-k <float>] [--dump {True|False}] [--out-dir <dir>] \
-        [--workers <int>] [--workers-per-nodes <int>] \
+        [--workers <int>] [--workers-per-node <int>] \
         [--max-cycles <int>] [--thresh <preset>] [--args-yaml <file>] \
         [--convert-files | --no-convert-files]
 
@@ -21,7 +21,7 @@ Examples
 
     # RFO with trajectory dumps, extra UMA workers, and YAML overrides
     pdb2reaction opt -i input.pdb -q 0 -m 1 --opt-mode heavy --dump True \
-        --workers 4 --workers-per-nodes 2 --out-dir ./result_opt/ --args-yaml ./args.yaml
+        --workers 4 --workers-per-node 2 --out-dir ./result_opt/ --args-yaml ./args.yaml
 
 Description
 -----------
@@ -102,7 +102,7 @@ Notes
   when ``-q`` is omitted but ``--ligand-charge`` is set, the full complex is treated as an enzyme–substrate system and the
   total charge is inferred using ``extract.py``’s residue-aware logic. `resolve_charge_spin_or_raise` reconciles CLI input with
   `.gjf` templates when available, and explicit `-q` always overrides derived values. UMA parallelism can be tuned via
-  ``--workers``/``--workers-per-nodes``; analytic Hessians are automatically disabled when `workers>1`. Always provide physically
+  ``--workers``/``--workers-per-node``; analytic Hessians are automatically disabled when `workers>1`. Always provide physically
   correct states.
 - **Input handling:** Supports .pdb/.xyz/.trj and other formats accepted by `geom_loader`. `geom.coord_type="dlc"` can
   improve stability for small molecules.
@@ -479,10 +479,10 @@ def _maybe_convert_outputs(
     help="UMA predictor workers; >1 spawns a parallel predictor (disables analytic Hessian).",
 )
 @click.option(
-    "--workers-per-nodes",
-    "workers_per_nodes",
+    "--workers-per-node",
+    "workers_per_node",
     type=int,
-    default=CALC_KW["workers_per_nodes"],
+    default=CALC_KW["workers_per_node"],
     show_default=True,
     help="Workers per node when using a parallel UMA predictor (workers>1).",
 )
@@ -585,7 +585,7 @@ def cli(
     charge: Optional[int],
     ligand_charge: Optional[str],
     workers: int,
-    workers_per_nodes: int,
+    workers_per_node: int,
     spin: Optional[int],
     dist_freeze_raw: Sequence[str],
     one_based: bool,
@@ -633,7 +633,7 @@ def cli(
         calc_cfg["charge"] = charge
         calc_cfg["spin"] = spin
         calc_cfg["workers"] = int(workers)
-        calc_cfg["workers_per_nodes"] = int(workers_per_nodes)
+        calc_cfg["workers_per_node"] = int(workers_per_node)
         opt_cfg["max_cycles"] = int(max_cycles)
         opt_cfg["dump"] = bool(dump)
         opt_cfg["out_dir"] = out_dir

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -550,10 +550,10 @@ def _optimize_single(
     help="UMA predictor workers; >1 spawns a parallel predictor (disables analytic Hessian).",
 )
 @click.option(
-    "--workers-per-nodes",
-    "workers_per_nodes",
+    "--workers-per-node",
+    "workers_per_node",
     type=int,
-    default=CALC_KW["workers_per_nodes"],
+    default=CALC_KW["workers_per_node"],
     show_default=True,
     help="Workers per node when using a parallel UMA predictor (workers>1).",
 )
@@ -671,7 +671,7 @@ def cli(
     charge: Optional[int],
     ligand_charge: Optional[str],
     workers: int,
-    workers_per_nodes: int,
+    workers_per_node: int,
     spin: Optional[int],
     freeze_links_flag: bool,
     max_nodes: int,
@@ -724,7 +724,7 @@ def cli(
         calc_cfg["charge"] = int(resolved_charge)
         calc_cfg["spin"] = int(resolved_spin)
         calc_cfg["workers"] = int(workers)
-        calc_cfg["workers_per_nodes"] = int(workers_per_nodes)
+        calc_cfg["workers_per_node"] = int(workers_per_node)
 
         gs_cfg["max_nodes"] = int(max_nodes)
         opt_cfg["max_cycles"] = int(max_cycles)

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -1924,10 +1924,10 @@ def _merge_final_and_write(final_images: List[Any],
     help="UMA predictor workers; >1 spawns a parallel predictor (disables analytic Hessian).",
 )
 @click.option(
-    "--workers-per-nodes",
-    "workers_per_nodes",
+    "--workers-per-node",
+    "workers_per_node",
     type=int,
-    default=CALC_KW["workers_per_nodes"],
+    default=CALC_KW["workers_per_node"],
     show_default=True,
     help="Workers per node when using a parallel UMA predictor (workers>1).",
 )
@@ -2021,7 +2021,7 @@ def cli(
     charge: Optional[int],
     ligand_charge: Optional[str],
     workers: int,
-    workers_per_nodes: int,
+    workers_per_node: int,
     spin: Optional[int],
     freeze_links_flag: bool,
     max_nodes: int,
@@ -2154,7 +2154,7 @@ def cli(
         calc_cfg["charge"] = int(resolved_charge)
         calc_cfg["spin"] = int(resolved_spin)
         calc_cfg["workers"] = int(workers)
-        calc_cfg["workers_per_nodes"] = int(workers_per_nodes)
+        calc_cfg["workers_per_node"] = int(workers_per_node)
 
         gs_cfg["max_nodes"] = int(max_nodes)
         opt_cfg["max_cycles"] = int(max_cycles)

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -361,10 +361,10 @@ def _snapshot_geometry(g) -> Any:
     help="UMA predictor workers; >1 spawns a parallel predictor (disables analytic Hessian).",
 )
 @click.option(
-    "--workers-per-nodes",
-    "workers_per_nodes",
+    "--workers-per-node",
+    "workers_per_node",
     type=int,
-    default=CALC_KW["workers_per_nodes"],
+    default=CALC_KW["workers_per_node"],
     show_default=True,
     help="Workers per node when using a parallel UMA predictor (workers>1).",
 )
@@ -432,7 +432,7 @@ def cli(
     charge: Optional[int],
     ligand_charge: Optional[str],
     workers: int,
-    workers_per_nodes: int,
+    workers_per_node: int,
     spin: Optional[int],
     scan_lists_raw: Sequence[str],
     one_based: bool,
@@ -482,7 +482,7 @@ def cli(
         calc_cfg["charge"] = int(charge)
         calc_cfg["spin"]   = int(spin)
         calc_cfg["workers"] = int(workers)
-        calc_cfg["workers_per_nodes"] = int(workers_per_nodes)
+        calc_cfg["workers_per_node"] = int(workers_per_node)
         opt_cfg["out_dir"] = out_dir
         # Do not use the optimizer's own dump per step; stage dumping is controlled separately.
         opt_cfg["dump"]    = False

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -321,10 +321,10 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
     help="UMA predictor workers; >1 spawns a parallel predictor (disables analytic Hessian).",
 )
 @click.option(
-    "--workers-per-nodes",
-    "workers_per_nodes",
+    "--workers-per-node",
+    "workers_per_node",
     type=int,
-    default=CALC_KW["workers_per_nodes"],
+    default=CALC_KW["workers_per_node"],
     show_default=True,
     help="Workers per node when using a parallel UMA predictor (workers>1).",
 )
@@ -460,7 +460,7 @@ def cli(
     charge: Optional[int],
     ligand_charge: Optional[str],
     workers: int,
-    workers_per_nodes: int,
+    workers_per_node: int,
     spin: Optional[int],
     scan_list_raw: str,
     one_based: bool,
@@ -509,7 +509,7 @@ def cli(
         calc_cfg["charge"] = int(charge)
         calc_cfg["spin"] = int(spin)
         calc_cfg["workers"] = int(workers)
-        calc_cfg["workers_per_nodes"] = int(workers_per_nodes)
+        calc_cfg["workers_per_node"] = int(workers_per_node)
         opt_cfg["out_dir"] = out_dir
         opt_cfg["dump"] = False
         if thresh is not None:

--- a/pdb2reaction/scan3d.py
+++ b/pdb2reaction/scan3d.py
@@ -384,10 +384,10 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
     help="UMA predictor workers; >1 spawns a parallel predictor (disables analytic Hessian).",
 )
 @click.option(
-    "--workers-per-nodes",
-    "workers_per_nodes",
+    "--workers-per-node",
+    "workers_per_node",
     type=int,
-    default=CALC_KW["workers_per_nodes"],
+    default=CALC_KW["workers_per_node"],
     show_default=True,
     help="Workers per node when using a parallel UMA predictor (workers>1).",
 )
@@ -533,7 +533,7 @@ def cli(
     charge: Optional[int],
     ligand_charge: Optional[str],
     workers: int,
-    workers_per_nodes: int,
+    workers_per_node: int,
     spin: Optional[int],
     scan_list_raw: str,
     one_based: bool,
@@ -583,7 +583,7 @@ def cli(
         calc_cfg["charge"] = int(charge)
         calc_cfg["spin"] = int(spin)
         calc_cfg["workers"] = int(workers)
-        calc_cfg["workers_per_nodes"] = int(workers_per_nodes)
+        calc_cfg["workers_per_node"] = int(workers_per_node)
         opt_cfg["out_dir"] = out_dir
         opt_cfg["dump"] = False
         if thresh is not None:

--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -1326,10 +1326,10 @@ RSIRFO_KW.update({
     help="UMA predictor workers; >1 spawns a parallel predictor (disables analytic Hessian).",
 )
 @click.option(
-    "--workers-per-nodes",
-    "workers_per_nodes",
+    "--workers-per-node",
+    "workers_per_node",
     type=int,
-    default=CALC_KW["workers_per_nodes"],
+    default=CALC_KW["workers_per_node"],
     show_default=True,
     help="Workers per node when using a parallel UMA predictor (workers>1).",
 )
@@ -1385,7 +1385,7 @@ def cli(
     charge: Optional[int],
     ligand_charge: Optional[str],
     workers: int,
-    workers_per_nodes: int,
+    workers_per_node: int,
     spin: Optional[int],
     freeze_links: bool,
     convert_files: bool,
@@ -1424,7 +1424,7 @@ def cli(
     calc_cfg["charge"] = int(charge)
     calc_cfg["spin"]   = int(spin)
     calc_cfg["workers"] = int(workers)
-    calc_cfg["workers_per_nodes"] = int(workers_per_nodes)
+    calc_cfg["workers_per_node"] = int(workers_per_node)
     opt_cfg["max_cycles"] = int(max_cycles)
     opt_cfg["dump"]       = bool(dump)
     opt_cfg["out_dir"]    = out_dir

--- a/pdb2reaction/uma_pysis.py
+++ b/pdb2reaction/uma_pysis.py
@@ -49,12 +49,12 @@ Description
 - Default Hessian mode at construction is `"FiniteDifference"`. If `hessian_calc_mode`
   is falsy *or unrecognized* in `get_hessian`, `"FiniteDifference"` is used.
 
-- **Parallel inference workers** (`workers`, `workers_per_nodes`):
+- **Parallel inference workers** (`workers`, `workers_per_node`):
     * If `workers > 1`, this wrapper directly instantiates FAIR‑Chem's
       `ParallelMLIPPredictUnit` (instead of calling `pretrained_mlip.get_predict_unit`)
       using:
         - `num_workers = workers`
-        - `num_workers_per_node = workers_per_nodes`
+        - `num_workers_per_node = workers_per_node`
     * When `workers>1`, FAIR‑Chem returns a parallel predictor that does **not**
       expose `predictor.model`. Therefore:
         - all `predictor.model`-related operations (eval/train toggles, dropout
@@ -147,7 +147,7 @@ CALC_KW: Dict[str, Any] = {
     # Device & graph construction
     "device": "auto",         # str, "cuda" | "cpu" | "auto"
     "workers": 1,             # int, predictor workers; if >1, ParallelMLIPPredictUnit is instantiated directly and Analytical Hessian is disabled
-    "workers_per_nodes": 1,   # int, num_workers_per_node passed to ParallelMLIPPredictUnit when workers>1
+    "workers_per_node": 1,   # int, num_workers_per_node passed to ParallelMLIPPredictUnit when workers>1
     "max_neigh": None,        # Optional[int], override model's neighbor cap
     "radius": None,           # Optional[float], cutoff radius (Å)
     "r_edges": False,         # bool, store edge vectors in graph (UMA option)
@@ -174,7 +174,7 @@ class UMAcore:
     Notes on `workers`
     ------------------
     If `workers > 1`, this wrapper directly instantiates `ParallelMLIPPredictUnit`
-    (with `num_workers=workers` and `num_workers_per_node=workers_per_nodes`) which
+    (with `num_workers=workers` and `num_workers_per_node=workers_per_node`) which
     typically does not expose `predictor.model`. In that situation, this wrapper will:
       - skip all `predictor.model` related operations (eval/dropout/etc.)
       - disallow Analytical Hessians (caller should use FD)
@@ -191,7 +191,7 @@ class UMAcore:
         task_name: str = "omol",
         device: str = "auto",
         workers: int = 1,
-        workers_per_nodes: int = 1,
+        workers_per_node: int = 1,
         max_neigh: Optional[int] = None,
         radius: Optional[float] = None,
         r_edges: bool = False,
@@ -206,9 +206,9 @@ class UMAcore:
         if self.workers < 1:
             self.workers = 1
 
-        self.workers_per_nodes = int(workers_per_nodes) if workers_per_nodes is not None else 1
-        if self.workers_per_nodes < 1:
-            self.workers_per_nodes = 1
+        self.workers_per_node = int(workers_per_node) if workers_per_node is not None else 1
+        if self.workers_per_node < 1:
+            self.workers_per_node = 1
 
         # If workers>1, we use ParallelMLIPPredictUnit directly.
         self.parallel_predict = self.workers > 1
@@ -238,7 +238,7 @@ class UMAcore:
                 atom_refs=atom_refs,
                 form_elem_refs=form_elem_refs,
                 num_workers=self.workers,
-                num_workers_per_node=self.workers_per_nodes,
+                num_workers_per_node=self.workers_per_node,
             )
         else:
             # Keep a defensive fallback if the installed fairchem build doesn't accept `workers`
@@ -438,7 +438,7 @@ class uma_pysis(Calculator):
         task_name: str = CALC_KW["task_name"],
         device: str = CALC_KW["device"],
         workers: int = CALC_KW["workers"],
-        workers_per_nodes: int = CALC_KW["workers_per_nodes"],
+        workers_per_node: int = CALC_KW["workers_per_node"],
         out_hess_torch: bool = CALC_KW["out_hess_torch"],
         max_neigh: Optional[int] = CALC_KW["max_neigh"],
         radius: Optional[float] = CALC_KW["radius"],
@@ -464,7 +464,7 @@ class uma_pysis(Calculator):
             If `workers > 1`, this wrapper instantiates `ParallelMLIPPredictUnit`
             directly (and `predictor.model` is not exposed); Hessian is forced
             to FiniteDifference.
-        workers_per_nodes : int, default 1
+        workers_per_node : int, default 1
             Passed as `num_workers_per_node` to `ParallelMLIPPredictUnit` when
             `workers > 1`.
         freeze_atoms : list[int], optional
@@ -487,7 +487,7 @@ class uma_pysis(Calculator):
             task_name=task_name,
             device=device,
             workers=workers,
-            workers_per_nodes=workers_per_nodes,
+            workers_per_node=workers_per_node,
             max_neigh=max_neigh,
             radius=radius,
             r_edges=r_edges,


### PR DESCRIPTION
### Motivation
- Standardize the UMA parallelism naming to a singular form (`workers_per_node` / `--workers-per-node`) across code and docs for consistency.
- Ensure CLI flags, YAML keys and internal calculator defaults all refer to the same configuration key for per-node worker counts.
- Prevent confusion between plural/singular variants and make `uma_pysis`/`UMAcore` parameter names consistent with the rest of the codebase.

### Description
- Replaced occurrences of `workers_per_nodes` / `workers-per-nodes` with `workers_per_node` / `workers-per-node` across Python modules, CLI option names, YAML defaults and documentation files (README + docs/*.md).
- Updated `CALC_KW`/defaults, `uma_pysis`/`UMAcore` constructor parameters, and all `click.option` handlers and places that build/propagate calculator configs to use `workers_per_node` and `--workers-per-node`.
- Adjusted all call sites that populated `calc_cfg[...]` and `_build_calc_cfg(...)` to read/write the new key `workers_per_node`.
- Refreshed command-line examples and explanatory text in `README.md` and `docs/*` to reflect the new flag name.

### Testing
- No automated tests or CI were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694763ee9ea4832db21c09360f710fa0)