### PR TITLE
Warn on Blackwell GPUs and refine GPU4PySCF docs

### DIFF
--- a/docs/dft.md
+++ b/docs/dft.md
@@ -58,8 +58,9 @@ out_dir/ (default: ./result_dft/)
   convergence knobs, and resolved output directory.
 
 ## Notes
-- GPU4PySCF is used whenever available; CPU PySCF is built otherwise (unless `--engine cpu` forces CPU). `--engine auto` mirrors the GPU-first fallback logic, automatically retrying on the CPU backend when GPU import/runtime errors occur. If **Blackwell architecture** GPUs are detected, it will be forced to fallback on CPU with a warning to avoid unsupported GPU4PySCF configurations.
-- GPU4PySCF is required to be compiled from source when you do **not** use **x86** archtecture. (See <https://github.com/pyscf/gpu4pyscf>)
+- GPU4PySCF is used whenever available; CPU PySCF is built otherwise (unless `--engine cpu` forces CPU). `--engine auto` mirrors the GPU-first fallback logic, automatically retrying on the CPU backend when GPU import/runtime errors occur.
+- If **Blackwell architecture** GPUs are detected, a warning is emitted because current GPU4PySCF may be unsupported.
+- Compiled GPU4PySCF wheels may not support Blackwell-architecture GPUs, and non-x86 systems require compiling from source; we recommend using the CPU backend or building GPU4PySCF yourself in these situations. (see https://github.com/pyscf/gpu4pyscf)
 - Density fitting is always attempted with PySCF defaults (no auxiliary basis guessing is implemented).
 - The YAML input file must contain a mapping root with top-level key `dft`; non-mapping roots raise an error via `load_yaml_dict`.
 - IAO spin/charge analysis may fail for challenging systems; corresponding columns in `result.yaml` become `null` and a warning is printed.

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -25,7 +25,7 @@ Description
 - Single-point DFT engine with optional GPU acceleration (GPU4PySCF) and a CPU PySCF backend.
   The backend policy is controlled by --engine:
   * gpu  (default): try GPU4PySCF first; on import/runtime errors, automatically fall back to CPU PySCF.
-                    Blackwell GPUs are forced to CPU with a warning.
+                    Blackwell GPUs emit a warning on detection.
   * cpu           : use CPU PySCF only.
   * auto          : try GPU4PySCF first and fall back to CPU PySCF if unavailable (same behavior as "gpu").
 - RKS/UKS is selected automatically from the spin multiplicity (2S+1).
@@ -540,7 +540,7 @@ def cli(
         make_ks = (lambda mod: mod.RKS(mol) if spin2s == 0 else mod.UKS(mol))
 
 
-        # --- Detect Blackwell GPU and force CPU backend ---
+        # --- Detect Blackwell GPU and emit warning ---
         is_blackwell_gpu = False
         try:
             import cupy as cp
@@ -555,8 +555,7 @@ def cli(
             is_blackwell_gpu = False
 
         if is_blackwell_gpu:
-            click.echo("[gpu] WARNING: GPU4PySCF does not support the Blackwell architecture; forcing CPU engine as requested.")
-            engine = "cpu"
+            click.echo("[gpu] WARNING: Detected a Blackwell GPU; GPU4PySCF may be unsupported.")
         # --------------------------------------------------
 
 


### PR DESCRIPTION
### Motivation
- Avoid forcing a CPU fallback when Blackwell-architecture GPUs are detected and instead inform the user non-fatally. 
- Clarify that compiled `gpu4pyscf` wheels may not support Blackwell GPUs and that non-`x86` systems must build from source. 
- Preserve the existing GPU-first behavior and allow the user to choose CPU vs GPU at runtime.

### Description
- In `pdb2reaction/dft.py` the Blackwell GPU detection no longer forces `engine = "cpu"` and now emits a warning on detection. 
- The in-file description was updated to reflect that Blackwell GPUs `emit a warning` rather than being forcibly disabled. 
- `docs/dft.md` was updated to split and clarify notes about backend selection and to recommend using the CPU backend or building `gpu4pyscf` from source when appropriate. 
- The GPU-first fallback logic for `--engine gpu` / `--engine auto` remains unchanged and still falls back to CPU on import/runtime errors.

### Testing
- No automated tests were run for these changes.
- Changes were applied to `pdb2reaction/dft.py` and `docs/dft.md` and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c0b5bf530832db163128c27a0d0fe)