### PR TITLE
Support PDB atom selector strings for scan commands and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,20 +207,20 @@ Provide a single `-i` together with `--scan-lists`:
 **Minimal example**
 
 ```bash
-pdb2reaction -i R.pdb -c "SAM,GPP" --ligand-charge "SAM:1,GPP:-3" --scan-lists "[(10,55,2.20),(23,34,1.80)]"
+pdb2reaction -i R.pdb -c "SAM,GPP" --ligand-charge "SAM:1,GPP:-3" --scan-lists "[(\"TYR,285,CA\",\"MMT,309,C10\",2.20),(\"TYR,285,CB\",\"MMT,309,C11\",1.80)]"
 ```
 
 **Richer example**
 
 ```bash
-pdb2reaction -i SINGLE.pdb -c "SAM,GPP" --scan-lists "[(10,55,2.20),(23,34,1.80)]" --mult 1 --out-dir ./result_scan_all --tsopt True --thermo True --dft True
+pdb2reaction -i SINGLE.pdb -c "SAM,GPP" --scan-lists "[(\"TYR,285,CA\",\"MMT,309,C10\",2.20),(\"TYR,285,CB\",\"MMT,309,C11\",1.80)]" --mult 1 --out-dir ./result_scan_all --tsopt True --thermo True --dft True
 ```
 
 Key points:
 
 - `--scan-lists` describes **staged distance scans** on the extracted cluster model.
 - Each tuple `(i, j, target_Å)` is:
-  - 1‑based atom order indices in the input file after parsing (not the PDB ATOM serial number),
+  - a 1‑based atom index **or** a PDB atom selector string like `"TYR,285,CA"` (delimiters: space/comma/slash/backtick/backslash),
   - automatically remapped to the cluster-model indices.
 - Each stage writes a `stage_XX/result.pdb`, which is treated as a candidate intermediate or product.
 - The default `all` workflow refines the concatenated stages with recursive `path_search`.

--- a/docs/all.md
+++ b/docs/all.md
@@ -23,7 +23,7 @@ pdb2reaction all -i reactant.pdb product.pdb -c "GPP,MMT" \
 
 # Single-structure staged scan followed by GSM/DMF + TSOPT/freq/DFT
 pdb2reaction all -i single.pdb -c "308,309" \
-    --scan-lists "[(10,55,2.20),(23,34,1.80)]" \
+    --scan-lists "[(\"TYR,285,CA\",\"MMT,309,C10\",2.20),(\"TYR,285,CB\",\"MMT,309,C11\",1.80)]" \
     --opt-mode heavy --tsopt True --thermo True --dft True
 
 # TSOPT-only workflow (no path search)
@@ -39,7 +39,7 @@ pdb2reaction all -i reactant.pdb -c "GPP,MMT" \
    - The **first pocket’s total charge** is rounded to the nearest integer and propagated to scan/MEP/TSOPT (a console note appears when rounding occurs).
 
 2. **Optional staged scan (single-input only)**
-   - Each `--scan-lists` argument is a Python-like list of `(i,j,target_Å)` tuples describing a UMA scan stage. Atom indices refer to the original input PDB (1-based) and are remapped to the pocket ordering.
+   - Each `--scan-lists` argument is a Python-like list of `(i,j,target_Å)` tuples describing a UMA scan stage. Atom indices refer to the original input PDB (1-based) and are remapped to the pocket ordering. For PDB inputs, `i`/`j` can be integer indices or selector strings like `"TYR,285,CA"`; selectors accept spaces/commas/slashes/backticks/backslashes as delimiters and allow unordered tokens (fallback assumes resname, resseq, atom).
    - When `--scan-lists` is repeated, stages run **sequentially**: stage 1 relaxes the starting structure, stage 2 begins from stage 1's result, and so on.
    - Scan inherits charge/spin, `--freeze-links`, the UMA optimizer preset (`--opt-mode`), `--dump`, `--args-yaml`, and `--preopt`. Overrides such as `--scan-out-dir`, `--scan-one-based`, `--scan-max-step-size`, `--scan-bias-k`, `--scan-relax-max-cycles`, `--scan-preopt`, and `--scan-endopt` apply per run.
    - Stage endpoints (`stage_XX/result.pdb`) become the ordered intermediates that feed the subsequent MEP step.
@@ -115,7 +115,7 @@ pdb2reaction all -i reactant.pdb -c "GPP,MMT" \
 | `--dft-max-cycle INT` | Override `dft --max-cycle`. | _None_ |
 | `--dft-conv-tol FLOAT` | Override `dft --conv-tol`. | _None_ |
 | `--dft-grid-level INT` | Override `dft --grid-level`. | _None_ |
-| `--scan-lists TEXT...` | One or more Python-like lists describing staged scans on the extracted pocket (single-input runs only). Each element is `(i,j,target_Å)`; indices come from the original input PDB (1-based) and are remapped internally. | _None_ |
+| `--scan-lists TEXT...` | One or more Python-like lists describing staged scans on the extracted pocket (single-input runs only). Each element is `(i,j,target_Å)`; `i`/`j` can be integer indices or PDB atom selectors like `"TYR,285,CA"` and are remapped internally. | _None_ |
 | `--scan-out-dir PATH` | Override the scan output directory (`<out-dir>/scan`). | _None_ |
 | `--scan-one-based BOOLEAN` | Force scan indexing to 1-based (`True`) or 0-based (`False`); `None` keeps the scan default (1-based). | _None_ |
 | `--scan-max-step-size FLOAT` | Override scan `--max-step-size` (Å). | _None_ |

--- a/docs/scan2d.md
+++ b/docs/scan2d.md
@@ -22,11 +22,11 @@ pdb2reaction scan2d -i INPUT.{pdb|xyz|trj|...} -q CHARGE [-m MULT] \
 ```bash
 # Minimal two-distance scan
 pdb2reaction scan2d -i input.pdb -q 0 \
-    --scan-list "[(12,45,1.30,3.10),(10,55,1.20,3.20)]"
+    --scan-list "[(\"TYR,285,CA\",1.30,3.10),(\"MMT,309,C10\",1.20,3.20)]"
 
 # LBFGS, dumped inner trajectories, and Plotly outputs
 pdb2reaction scan2d -i input.pdb -q 0 \
-    --scan-list "[(12,45,1.30,3.10),(10,55,1.20,3.20)]" \
+    --scan-list "[(\"TYR,285,CA\",1.30,3.10),(\"MMT,309,C10\",1.20,3.20)]" \
     --max-step-size 0.20 --dump True --out-dir ./result_scan2d/ --opt-mode light \
     --preopt True --baseline min
 ```
@@ -39,7 +39,10 @@ pdb2reaction scan2d -i input.pdb -q 0 \
    scan. The preoptimized structure is saved under `grid/preopt_i###_j###.*` and
    its unbiased energy is stored in `surface.csv` with indices `i = j = -1`.
 2. Parse the single `--scan-list` literal into two quadruples, normalize indices
-   (1-based by default), and construct linear grids: `N = ceil(|high − low| / h)`
+   (1-based by default). For PDB inputs, each atom entry can be an integer index
+   or a selector string like `"TYR,285,CA"`; delimiters may be spaces, commas,
+   slashes, backticks, or backslashes, and token order is flexible (fallback
+   assumes resname, resseq, atom). Construct linear grids: `N = ceil(|high − low| / h)`
    with `h = --max-step-size`. Zero-length spans collapse to a single point.
    Each axis is then reordered so that the distance closest to the preoptimized
    geometry is indexed as `i = 0` / `j = 0`.
@@ -67,7 +70,7 @@ pdb2reaction scan2d -i input.pdb -q 0 \
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
 | `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
 | `-m, --multiplicity INT` | Spin multiplicity 2S+1 (CLI > template > 1). | `.gjf` template value or `1` |
-| `--scan-list TEXT` | **Single** Python literal with two quadruples `(i,j,lowÅ,highÅ)`. | Required |
+| `--scan-list TEXT` | **Single** Python literal with two quadruples `(i,j,lowÅ,highÅ)`. `i`/`j` can be integer indices or PDB atom selectors like `"TYR,285,CA"`. | Required |
 | `--one-based {True|False}` | Interpret `(i, j)` indices as 1- or 0-based. | `True` |
 | `--max-step-size FLOAT` | Maximum change allowed for either distance per increment (Å). Determines the grid density. | `0.20` |
 | `--bias-k FLOAT` | Harmonic bias strength `k` in eV·Å⁻². Overrides `bias.k`. | `100` |

--- a/docs/scan3d.md
+++ b/docs/scan3d.md
@@ -22,17 +22,17 @@ pdb2reaction scan3d -i INPUT.{pdb|xyz|trj|...} -q CHARGE [-m MULT] \
 ```bash
 # Minimal three-distance scan
 pdb2reaction scan3d -i input.pdb -q 0 \
-    --scan-list "[(12,45,1.30,3.10),(10,55,1.20,3.20),(15,60,1.10,3.00)]"
+    --scan-list "[(\"TYR,285,CA\",1.30,3.10),(\"MMT,309,C10\",1.20,3.20),(\"TYR,285,CB\",1.10,3.00)]"
 
 # LBFGS relaxations, dumped inner trajectories, and HTML isosurface plot
 pdb2reaction scan3d -i input.pdb -q 0 \
-    --scan-list "[(12,45,1.30,3.10),(10,55,1.20,3.20),(15,60,1.10,3.00)]" \
+    --scan-list "[(\"TYR,285,CA\",1.30,3.10),(\"MMT,309,C10\",1.20,3.20),(\"TYR,285,CB\",1.10,3.00)]" \
     --max-step-size 0.20 --dump True --out-dir ./result_scan3d/ --opt-mode light \
     --preopt True --baseline min
 
 # Plot only from an existing surface.csv (skip new energy evaluation)
 pdb2reaction scan3d -i input.pdb -q 0 \
-    --scan-list "[(12,45,1.30,3.10),(10,55,1.20,3.20),(15,60,1.10,3.00)]" \
+    --scan-list "[(\"TYR,285,CA\",1.30,3.10),(\"MMT,309,C10\",1.20,3.20),(\"TYR,285,CB\",1.10,3.00)]" \
     --csv ./result_scan3d/surface.csv --out-dir ./result_scan3d/
 ```
 
@@ -43,7 +43,10 @@ pdb2reaction scan3d -i input.pdb -q 0 \
    structure is treated as an enzyme–substrate complex and `extract.py`’s charge
    summary derives the total charge before scanning.
 2. Parse the single `--scan-list` literal (default 1-based indices unless
-   `--one-based False` is passed) into three quadruples. Build each linear grid using
+   `--one-based False` is passed) into three quadruples. For PDB inputs, each
+   atom entry can be an integer index or a selector string like `"TYR,285,CA"`;
+   delimiters may be spaces, commas, slashes, backticks, or backslashes, and
+   token order is flexible (fallback assumes resname, resseq, atom). Build each linear grid using
    `h = --max-step-size` and reorder the values so the ones closest to the
    starting distances are visited first.
 3. Outer loop over `d1[i]`: relax with only the d₁ restraint active, starting
@@ -67,7 +70,7 @@ pdb2reaction scan3d -i input.pdb -q 0 \
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
 | `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
 | `-m, --multiplicity INT` | Spin multiplicity 2S+1. | `1` |
-| `--scan-list TEXT` | **Single** Python literal with three quadruples `(i,j,lowÅ,highÅ)`. | Required |
+| `--scan-list TEXT` | **Single** Python literal with three quadruples `(i,j,lowÅ,highÅ)`. `i`/`j` can be integer indices or PDB atom selectors like `"TYR,285,CA"`. | Required |
 | `--one-based {True|False}` | Interpret `(i, j)` indices as 1- or 0-based. | `True` |
 | `--max-step-size FLOAT` | Maximum change allowed per distance increment (Å). Controls grid density. | `0.20` |
 | `--bias-k FLOAT` | Harmonic bias strength `k` in eV·Å⁻². Overrides `bias.k`. | `100` |


### PR DESCRIPTION
### Motivation
- Allow users to specify atoms in scan-related CLI args using human-friendly PDB selector strings (e.g. `"TYR,285,CA"`) in addition to numeric indices. 
- Accept flexible delimiters (space/comma/slash/backtick/backslash) and permit unordered selector tokens with a sensible fallback. 
- Ensure selector resolution works with pocket extraction by resolving against the full PDB before remapping to pocket indices. 
- Surface resolved PDB atom metadata in CLI diagnostics to help users inspect parsed pairs.

### Description
- Added selector parsing utilities: `resolve_atom_spec_index` and `_split_atom_spec_tokens` in `pdb2reaction/utils.py` and reused `load_pdb_atom_metadata` for resolution. 
- Extended parsing logic to accept string specs and convert them in `pdb2reaction/scan.py`, `scan2d.py`, `scan3d.py`, and `all.py` by updating `_parse_scan_lists`, `_parse_scan_list`/`_parse_scan_list` variants and `_parse_scan_lists_literals` to call the resolver when PDB metadata is present. 
- Wired resolution into the `all` workflow so full-PDB selectors are resolved before remapping to pocket indices, and updated CLI echoing to print PDB atom metadata via existing formatting helpers. 
- Updated documentation and examples in `README.md`, `docs/scan.md`, `docs/scan2d.md`, `docs/scan3d.md`, and `docs/all.md` to demonstrate selector strings and describe delimiter/token rules.

### Testing
- No automated tests were run for these changes. 
- This rollout focused on adding parsing/resolution logic and updating documentation, with no test suite execution performed. 
- Manual CLI behavior verification was not recorded as part of the automated rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e429b4704832daa96ceef8d4451be)