### PR TITLE
Fix f-string quoting issues across CLI tools

### DIFF
--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -543,7 +543,7 @@ def _read_full_atom_keys_in_file_order(full_pdb: Path) -> List[AtomKey]:
 def _format_atom_key_for_msg(key: AtomKey) -> str:
     """Pretty string for diagnostics."""
     chain, resn, resseq, icode, atom, alt = key
-    res = f'{chain}:{resn}{resseq}{(icode if icode else '')}'
+    res = f"{chain}:{resn}{resseq}{(icode if icode else '')}"
     alt_sfx = f',alt={alt}' if alt else ''
     return f'{res}:{atom}{alt_sfx}'
 
@@ -2446,9 +2446,9 @@ def cli(
                     '[all] Charge summary from full complex (--ligand-charge without extraction):'
                 )
                 click.echo(
-                    f'  Protein: {charge_summary.get('protein_charge', 0.0):+g},  '
-                    f'Ligand: {charge_summary.get('ligand_total_charge', 0.0):+g},  '
-                    f'Ions: {charge_summary.get('ion_total_charge', 0.0):+g},  '
+                    f"  Protein: {charge_summary.get('protein_charge', 0.0):+g},  "
+                    f"Ligand: {charge_summary.get('ligand_total_charge', 0.0):+g},  "
+                    f"Ions: {charge_summary.get('ion_total_charge', 0.0):+g},  "
                     f'Total: {q_total_fallback:+g}'
                 )
             except Exception as e:
@@ -2794,7 +2794,7 @@ def cli(
         try:
             with open(tsroot / 'summary.yaml', 'w') as f:
                 yaml.safe_dump(summary, f, sort_keys=False, allow_unicode=True)
-            click.echo(f'[write] Wrote "{tsroot / 'summary.yaml'}".')
+            click.echo(f"[write] Wrote \"{tsroot / 'summary.yaml'}\".")
             try:
                 dst_summary = out_dir / 'summary.yaml'
                 shutil.copy2(tsroot / 'summary.yaml', dst_summary)
@@ -3274,7 +3274,7 @@ def cli(
         try:
             run_trj2fig(final_trj, [path_dir / 'mep_plot.png'], unit='kcal', reference='init', reverse_x=False)
             _close_matplotlib_figures()
-            click.echo(f'[plot] Saved energy plot → "{path_dir / 'mep_plot.png'}"')
+            click.echo(f"[plot] Saved energy plot → \"{path_dir / 'mep_plot.png'}\"")
         except Exception as e:
             click.echo(f'[plot] WARNING: Failed to plot concatenated MEP: {e}', err=True)
 
@@ -3362,7 +3362,7 @@ def cli(
         try:
             with open(path_dir / 'summary.yaml', 'w') as f:
                 yaml.safe_dump(summary, f, sort_keys=False, allow_unicode=True)
-            click.echo(f'[write] Wrote "{path_dir / 'summary.yaml'}".')
+            click.echo(f"[write] Wrote \"{path_dir / 'summary.yaml'}\".")
         except Exception as e:
             click.echo(f'[write] WARNING: Failed to write summary.yaml for path-opt branch: {e}', err=True)
 
@@ -3446,7 +3446,7 @@ def cli(
             write_summary_log(path_dir / 'summary.log', summary_payload)
             try:
                 shutil.copy2(path_dir / 'summary.log', out_dir / 'summary.log')
-                click.echo(f'[all] Copied summary.log → {out_dir / 'summary.log'}')
+                click.echo(f"[all] Copied summary.log → {out_dir / 'summary.log'}")
             except Exception:
                 pass
         except Exception as e:
@@ -3627,7 +3627,7 @@ def cli(
             write_summary_log(path_dir / 'summary.log', summary_payload)
             try:
                 shutil.copy2(path_dir / 'summary.log', out_dir / 'summary.log')
-                click.echo(f'[all] Copied summary.log → {out_dir / 'summary.log'}')
+                click.echo(f"[all] Copied summary.log → {out_dir / 'summary.log'}")
             except Exception:
                 pass
         except Exception as e:
@@ -4225,7 +4225,7 @@ def cli(
         summary['energy_diagrams'] = list(energy_diagrams)
         with open(path_dir / 'summary.yaml', 'w') as f:
             yaml.safe_dump(summary, f, sort_keys=False, allow_unicode=True)
-        click.echo(f'[write] Updated "{path_dir / 'summary.yaml'}" with energy diagrams.')
+        click.echo(f"[write] Updated \"{path_dir / 'summary.yaml'}\" with energy diagrams.")
         try:
             dst_summary = out_dir / 'summary.yaml'
             shutil.copy2(path_dir / 'summary.yaml', dst_summary)

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -659,7 +659,7 @@ def cli(
         (out_dir_path / 'result.yaml').write_text(
             yaml.safe_dump(result_yaml, sort_keys=False, allow_unicode=True)
         )
-        click.echo(f'[write] Wrote "{out_dir_path / 'result.yaml'}".')
+        click.echo(f"[write] Wrote \"{out_dir_path / 'result.yaml'}\".")
 
         # --------------------------
         # 8) Final print: energies

--- a/pdb2reaction/extract.py
+++ b/pdb2reaction/extract.py
@@ -1183,13 +1183,13 @@ def _format_linkH_block(link_coords: List[Tuple[float, float, float]],
         serial += 1
         line = (
             f'HETATM{serial:5d} '
-            f'{'HL':>4s} '
-            f'{'LKH':>3s} '
+            f"{'HL':>4s} "
+            f"{'LKH':>3s} "
             f'{chain_id}'
             f'{resseq:4d}    '
             f'{x:8.3f}{y:8.3f}{z:8.3f}'
             f'{1.00:6.2f}{0.00:6.2f}'
-            f'          {'H':>2s}'
+            f"          {'H':>2s}"
         )
         lines.append(line)
         resseq += 1
@@ -1447,7 +1447,9 @@ def _keys_to_fids(structure, keys: Iterable[ResidueKey]) -> Set[Tuple]:
         else:
             fids.add(fid)
     if missing:
-        raise ValueError(f'Some residues not found in structure: {missing[:5]}{' ...' if len(missing)>5 else ''}')
+        raise ValueError(
+            f"Some residues not found in structure: {missing[:5]}{' ...' if len(missing)>5 else ''}"
+        )
     return fids
 
 def _fids_to_keys(structure, fids: Iterable[Tuple]) -> Set[ResidueKey]:

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -655,7 +655,9 @@ def cli(
             detected = []
         merged = merge_freeze_atom_indices(geom_cfg, detected)
         if merged:
-            click.echo(f'[freeze-links] Freeze atoms (0-based): {','.join(map(str, merged))}')
+            click.echo(
+                f"[freeze-links] Freeze atoms (0-based): {','.join(map(str, merged))}"
+            )
 
     out_dir_path = Path(out_dir).resolve()
     out_dir_path.mkdir(parents=True, exist_ok=True)
@@ -717,7 +719,9 @@ def cli(
             order = np.argsort(freqs_cm)
 
         n_write = int(min(freq_cfg['max_write'], len(order)))
-        click.echo(f'[INFO] Total modes: {len(freqs_cm)}  → write first {n_write} modes ({freq_cfg['sort']} ascending).')
+        click.echo(
+            f"[INFO] Total modes: {len(freqs_cm)}  → write first {n_write} modes ({freq_cfg['sort']} ascending)."
+        )
 
         # Reference PDB (only when input is PDB)
         ref_pdb = input_path if input_path.suffix.lower() == '.pdb' else None

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -329,7 +329,7 @@ def cli(
             merged_freeze = merge_freeze_atom_indices(geom_cfg, detected)
             if merged_freeze:
                 click.echo(
-                    f'[freeze-links] Freeze atoms (0-based): {','.join(map(str, merged_freeze))}'
+                    f"[freeze-links] Freeze atoms (0-based): {','.join(map(str, merged_freeze))}"
                 )
 
         # EulerPC currently only supports Cartesian coordinates
@@ -378,19 +378,31 @@ def cli(
         # --------------------------
         suffix_prefix = irc_cfg.get('prefix', '')
         _echo_convert_trj_if_exists(
-            out_dir_path / f'{suffix_prefix}{'finished_irc.trj'}',
+            out_dir_path / f'{suffix_prefix}finished_irc.trj',
             prepared_input,
-            out_pdb=out_dir_path / f'{suffix_prefix}{'finished_irc.pdb'}' if prepared_input.source_path.suffix.lower() == '.pdb' else None,
+            out_pdb=(
+                out_dir_path / f'{suffix_prefix}finished_irc.pdb'
+                if prepared_input.source_path.suffix.lower() == '.pdb'
+                else None
+            ),
         )
         _echo_convert_trj_if_exists(
-            out_dir_path / f'{suffix_prefix}{'forward_irc.trj'}',
+            out_dir_path / f'{suffix_prefix}forward_irc.trj',
             prepared_input,
-            out_pdb=out_dir_path / f'{suffix_prefix}{'forward_irc.pdb'}' if prepared_input.source_path.suffix.lower() == '.pdb' else None,
+            out_pdb=(
+                out_dir_path / f'{suffix_prefix}forward_irc.pdb'
+                if prepared_input.source_path.suffix.lower() == '.pdb'
+                else None
+            ),
         )
         _echo_convert_trj_if_exists(
-            out_dir_path / f'{suffix_prefix}{'backward_irc.trj'}',
+            out_dir_path / f'{suffix_prefix}backward_irc.trj',
             prepared_input,
-            out_pdb=out_dir_path / f'{suffix_prefix}{'backward_irc.pdb'}' if prepared_input.source_path.suffix.lower() == '.pdb' else None,
+            out_pdb=(
+                out_dir_path / f'{suffix_prefix}backward_irc.pdb'
+                if prepared_input.source_path.suffix.lower() == '.pdb'
+                else None
+            ),
         )
 
         click.echo(format_elapsed('[time] Elapsed Time for IRC', time_start))

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -663,7 +663,9 @@ def cli(
                 detected = []
             merged = merge_freeze_atom_indices(geom_cfg, detected)
             if merged:
-                click.echo(f'[freeze-links] Freeze atoms (0-based): {','.join(map(str, merged))}')
+                click.echo(
+                    f"[freeze-links] Freeze atoms (0-based): {','.join(map(str, merged))}"
+                )
 
         # Normalize and select optimizer kind
         kind = normalize_choice(

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -220,7 +220,7 @@ def _load_two_endpoints(
             if detected and freeze:
                 click.echo(
                     f'[freeze-links] {src_path.name}: Freeze atoms (0-based): '
-                    f'{','.join(map(str, freeze))}'
+                    f"{','.join(map(str, freeze))}"
                 )
         else:
             freeze = merge_freeze_atom_indices(cfg)

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -364,7 +364,9 @@ def _load_two_endpoints(
             detected = detect_freeze_links_safe(p)
             freeze = merge_freeze_atom_indices(cfg, detected)
             if detected and freeze:
-                click.echo(f'[freeze-links] {p.name}: Freeze atoms (0-based): {','.join(map(str, freeze))}')
+                click.echo(
+                    f"[freeze-links] {p.name}: Freeze atoms (0-based): {','.join(map(str, freeze))}"
+                )
         else:
             freeze = merge_freeze_atom_indices(cfg)
         g = geom_loader(p, coord_type=coord_type, freeze_atoms=freeze)
@@ -392,7 +394,9 @@ def _load_structures(
             detected = detect_freeze_links_safe(src_path)
             freeze = merge_freeze_atom_indices(cfg, detected)
             if detected and freeze:
-                click.echo(f'[freeze-links] {src_path.name}: Freeze atoms (0-based): {','.join(map(str, freeze))}')
+                click.echo(
+                    f"[freeze-links] {src_path.name}: Freeze atoms (0-based): {','.join(map(str, freeze))}"
+                )
         else:
             freeze = merge_freeze_atom_indices(cfg)
         g = geom_loader(geom_path, coord_type=coord_type, freeze_atoms=freeze)
@@ -707,7 +711,7 @@ def _run_mep_between(
         if wrote_with_energy:
             run_trj2fig(final_trj, [seg_dir / 'mep_plot.png'], unit='kcal', reference='init', reverse_x=False)
             _close_matplotlib_figures()
-            click.echo(f'[{tag}] Saved energy plot → "{seg_dir / 'mep_plot.png'}"')
+            click.echo(f"[{tag}] Saved energy plot → \"{seg_dir / 'mep_plot.png'}\"")
         else:
             click.echo(f'[{tag}] WARNING: Energies missing; skipping plot.', err=True)
     except Exception as e:
@@ -861,7 +865,7 @@ def _run_dmf_between(
     try:
         run_trj2fig(final_trj, [seg_dir / 'mep_plot.png'], unit='kcal', reference='init', reverse_x=False)
         _close_matplotlib_figures()
-        click.echo(f'[{tag}] Saved energy plot → "{seg_dir / 'mep_plot.png'}"')
+        click.echo(f"[{tag}] Saved energy plot → \"{seg_dir / 'mep_plot.png'}\"")
     except Exception as e:
         click.echo(f'[{tag}] WARNING: Failed to plot energy: {e}', err=True)
 
@@ -1362,10 +1366,10 @@ def _build_multistep_path(
     left_changed, left_summary = _has_bond_change(gA, left_end, bond_cfg)
     right_changed, right_summary = _has_bond_change(right_end, gB, bond_cfg)
 
-    click.echo(f'[{tag0}] Covalent changes (A vs left_end): {'Yes' if left_changed else 'No'}')
+    click.echo(f"[{tag0}] Covalent changes (A vs left_end): {'Yes' if left_changed else 'No'}")
     if left_changed:
         click.echo(textwrap.indent(left_summary, prefix='  '))
-    click.echo(f'[{tag0}] Covalent changes (right_end vs B): {'Yes' if right_changed else 'No'}')
+    click.echo(f"[{tag0}] Covalent changes (right_end vs B): {'Yes' if right_changed else 'No'}")
     if right_changed:
         click.echo(textwrap.indent(right_summary, prefix='  '))
 
@@ -2409,7 +2413,7 @@ def cli(
             try:
                 run_trj2fig(final_trj, [out_dir_path / 'mep_plot.png'], unit='kcal', reference='init', reverse_x=False)
                 _close_matplotlib_figures()
-                click.echo(f'[plot] Saved energy plot → "{out_dir_path / 'mep_plot.png'}"')
+                click.echo(f"[plot] Saved energy plot → \"{out_dir_path / 'mep_plot.png'}\"")
             except Exception as e:
                 click.echo(f'[plot] WARNING: Failed to plot final energy: {e}', err=True)
 
@@ -2422,7 +2426,7 @@ def cli(
                 try:
                     run_trj2fig(tmp_trj_path, [out_dir_path / 'mep_plot.png'], unit='kcal', reference='init', reverse_x=False)
                     _close_matplotlib_figures()
-                    click.echo(f'[plot] Saved energy plot → "{out_dir_path / 'mep_plot.png'}"')
+                    click.echo(f"[plot] Saved energy plot → \"{out_dir_path / 'mep_plot.png'}\"")
                 except Exception as e:
                     click.echo(f'[plot] WARNING: Failed to plot final energy: {e}', err=True)
                 try:
@@ -2640,7 +2644,7 @@ def cli(
                             peak_e = E_current_kcal + barrier_kcal
                             peaks = current.setdefault('bridge_peaks', [])
                             suffix = '' if len(peaks) == 0 else f'_{len(peaks) + 1}'
-                            peak_label = f'IM{current['index']}_TS{suffix}'
+                            peak_label = f"IM{current['index']}_TS{suffix}"
                             peaks.append({'label': peak_label, 'energy': peak_e})
                             # Log the corresponding peak in au for debugging
                             peak_e_au = E0_au + peak_e / AU2KCALPERMOL
@@ -2763,7 +2767,7 @@ def cli(
 
         with open(out_dir_path / 'summary.yaml', 'w') as f:
             yaml.safe_dump(summary, f, sort_keys=False, allow_unicode=True)
-        click.echo(f'[write] Wrote "{out_dir_path / 'summary.yaml'}".')
+        click.echo(f"[write] Wrote \"{out_dir_path / 'summary.yaml'}\".")
 
         try:
             try:
@@ -2814,7 +2818,7 @@ def cli(
                 },
             }
             write_summary_log(out_dir_path / 'summary.log', summary_payload)
-            click.echo(f'[write] Wrote "{out_dir_path / 'summary.log'}".')
+            click.echo(f"[write] Wrote \"{out_dir_path / 'summary.log'}\".")
         except Exception as e:
             click.echo(f'[write] WARNING: Failed to write summary.log: {e}', err=True)
 

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -596,7 +596,9 @@ def cli(
             if detected:
                 freeze = merge_freeze_atom_indices(geom_cfg, detected)
                 if freeze:
-                    click.echo(f'[freeze-links] Freeze atoms (0-based): {','.join(map(str, freeze))}')
+                    click.echo(
+                        f"[freeze-links] Freeze atoms (0-based): {','.join(map(str, freeze))}"
+                    )
 
         coord_type = geom_cfg.get('coord_type', GEOM_KW_DEFAULT['coord_type'])
         geom = geom_loader(geom_input_path, coord_type=coord_type, freeze_atoms=freeze)
@@ -664,7 +666,7 @@ def cli(
                         written.append('"result.pdb"')
                     if needs_gjf:
                         written.append('"result.gjf"')
-                    click.echo(f'[convert] Wrote {', '.join(written)}.')
+                    click.echo(f"[convert] Wrote {', '.join(written)}.")
             except Exception as e:
                 click.echo(f'[convert] WARNING: Failed to convert preopt result: {e}', err=True)
 
@@ -689,8 +691,12 @@ def cli(
             R_bohr = np.array(geom.coords3d, dtype=float)      # (N,3) Bohr
             R_ang  = R_bohr * BOHR2ANG                         # (N,3) Å
             Nsteps, r0, rT, step_widths = _schedule_for_stage(R_ang, tuples, float(max_step_size))
-            click.echo(f'[stage {k}] initial distances (Å) = {['{:.3f}'.format(x) for x in r0]}')
-            click.echo(f'[stage {k}] target distances  (Å) = {['{:.3f}'.format(x) for x in rT]}')
+            click.echo(
+                f"[stage {k}] initial distances (Å) = {['{:.3f}'.format(x) for x in r0]}"
+            )
+            click.echo(
+                f"[stage {k}] target distances  (Å) = {['{:.3f}'.format(x) for x in rT]}"
+            )
             click.echo(f'[stage {k}] steps N = {Nsteps}')
 
             # Record per-stage summary
@@ -725,7 +731,9 @@ def cli(
                 # Bond changes: start vs final (possibly endopt)
                 try:
                     changed, summary = _has_bond_change(start_geom_for_stage, geom, bond_cfg)
-                    click.echo(f'[stage {k}] Covalent-bond changes (start vs final): {'Yes' if changed else 'No'}')
+                    click.echo(
+                        f"[stage {k}] Covalent-bond changes (start vs final): {'Yes' if changed else 'No'}"
+                    )
                     if changed and summary and summary.strip():
                         click.echo(textwrap.indent(summary.strip(), prefix='  '))
                     if not changed:
@@ -754,7 +762,7 @@ def cli(
                             written.append('"result.pdb"')
                         if needs_gjf:
                             written.append('"result.gjf"')
-                        click.echo(f'[convert] Wrote {', '.join(written)}.')
+                        click.echo(f"[convert] Wrote {', '.join(written)}.")
                 except Exception as e:
                     click.echo(f'[convert] WARNING: Failed to convert stage result: {e}', err=True)
                 continue
@@ -799,7 +807,9 @@ def cli(
             # Bond changes: start vs final (possibly endopt)
             try:
                 changed, summary = _has_bond_change(start_geom_for_stage, geom, bond_cfg)
-                click.echo(f'[stage {k}] Covalent-bond changes (start vs final): {'Yes' if changed else 'No'}')
+                click.echo(
+                    f"[stage {k}] Covalent-bond changes (start vs final): {'Yes' if changed else 'No'}"
+                )
                 if changed and summary and summary.strip():
                     click.echo(textwrap.indent(summary.strip(), prefix='  '))
                 if not changed:
@@ -829,7 +839,7 @@ def cli(
                             written.append('"scan.pdb"')
                         if needs_gjf:
                             written.append('"scan.gjf"')
-                        click.echo(f'[convert] Wrote {', '.join(written)}.')
+                        click.echo(f"[convert] Wrote {', '.join(written)}.")
                 except Exception as e:
                     click.echo(f'[convert] WARNING: Failed to convert stage trajectory: {e}', err=True)
 
@@ -851,7 +861,7 @@ def cli(
                         written.append('"result.pdb"')
                     if needs_gjf:
                         written.append('"result.gjf"')
-                    click.echo(f'[convert] Wrote {', '.join(written)}.')
+                    click.echo(f"[convert] Wrote {', '.join(written)}.")
             except Exception as e:
                 click.echo(f'[convert] WARNING: Failed to convert stage result: {e}', err=True)
 
@@ -891,7 +901,9 @@ def cli(
                 click.echo(f'[stage {idx}] target distances  (Å) = { _list_of_str_3f(rT) }')
                 click.echo(f'[stage {idx}] per_pair_step     (Å) = { _list_of_str_3f(dA) }')
                 click.echo(f'[stage {idx}] steps N = {N}')
-                click.echo(f'[stage {idx}] Covalent-bond changes (start vs final): {'Yes' if changed else 'No'}')
+                click.echo(
+                    f"[stage {idx}] Covalent-bond changes (start vs final): {'Yes' if changed else 'No'}"
+                )
                 if changed and summary_txt:
                     click.echo(textwrap.indent(summary_txt, prefix='  '))
                 if not changed:

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -625,7 +625,7 @@ def cli(
                 freeze = merge_freeze_atom_indices(geom_cfg, detected)
                 if freeze:
                     click.echo(
-                        f'[freeze-links] Freeze atoms (0-based): {','.join(map(str, freeze))}'
+                        f"[freeze-links] Freeze atoms (0-based): {','.join(map(str, freeze))}"
                     )
         coord_type = geom_cfg.get('coord_type', GEOM_KW_DEFAULT['coord_type'])
         geom_outer = geom_loader(
@@ -741,10 +741,10 @@ def cli(
 
         N1, N2 = len(d1_values), len(d2_values)
         click.echo(
-            f'[grid] d1 steps = {N1}  values(A)={list(map(lambda x:f'{x:.3f}', d1_values))}'
+            f"[grid] d1 steps = {N1}  values(A)={list(map(lambda x:f'{x:.3f}', d1_values))}"
         )
         click.echo(
-            f'[grid] d2 steps = {N2}  values(A)={list(map(lambda x:f'{x:.3f}', d2_values))}'
+            f"[grid] d2 steps = {N2}  values(A)={list(map(lambda x:f'{x:.3f}', d2_values))}"
         )
         click.echo(f'[grid] total grid points = {N1*N2}')
 

--- a/pdb2reaction/scan3d.py
+++ b/pdb2reaction/scan3d.py
@@ -709,7 +709,9 @@ def cli(
                 if detected:
                     freeze = merge_freeze_atom_indices(geom_cfg, detected)
                     if freeze:
-                        click.echo(f'[freeze-links] Freeze atoms (0-based): {','.join(map(str, freeze))}')
+                        click.echo(
+                            f"[freeze-links] Freeze atoms (0-based): {','.join(map(str, freeze))}"
+                        )
             coord_type = geom_cfg.get('coord_type', GEOM_KW_DEFAULT['coord_type'])
             geom_outer = geom_loader(
                 geom_input_path, coord_type=coord_type, freeze_atoms=freeze
@@ -819,9 +821,15 @@ def cli(
             )
 
             N1, N2, N3 = len(d1_values), len(d2_values), len(d3_values)
-            click.echo(f'[grid] d1 steps = {N1}  values(A)={list(map(lambda x: f'{x:.3f}', d1_values))}')
-            click.echo(f'[grid] d2 steps = {N2}  values(A)={list(map(lambda x: f'{x:.3f}', d2_values))}')
-            click.echo(f'[grid] d3 steps = {N3}  values(A)={list(map(lambda x: f'{x:.3f}', d3_values))}')
+            click.echo(
+                f"[grid] d1 steps = {N1}  values(A)={list(map(lambda x: f'{x:.3f}', d1_values))}"
+            )
+            click.echo(
+                f"[grid] d2 steps = {N2}  values(A)={list(map(lambda x: f'{x:.3f}', d2_values))}"
+            )
+            click.echo(
+                f"[grid] d3 steps = {N3}  values(A)={list(map(lambda x: f'{x:.3f}', d3_values))}"
+            )
             click.echo(f'[grid] total grid points = {N1 * N2 * N3}')
 
             max_step_bohr = float(max_step_size) * ANG2BOHR

--- a/pdb2reaction/summary_log.py
+++ b/pdb2reaction/summary_log.py
@@ -59,8 +59,8 @@ def _format_energy_rows(
         if rel_e is None and abs_e is not None and base_e is not None:
             rel_e = (abs_e - base_e) * AU2KCALPERMOL
 
-        abs_txt = f'{abs_e:14.6f}' if abs_e is not None else f'{'n/a':>14}'
-        rel_txt = f'{rel_e:14.4f}' if rel_e is not None else f'{'n/a':>14}'
+        abs_txt = f'{abs_e:14.6f}' if abs_e is not None else f"{'n/a':>14}"
+        rel_txt = f'{rel_e:14.4f}' if rel_e is not None else f"{'n/a':>14}"
         rows.append(f'        {lab:<8}{abs_txt}    {rel_txt}')
     return rows
 
@@ -267,23 +267,23 @@ def write_summary_log(dest: Path, payload: Dict[str, Any]) -> None:
     )
     lines.append(f'Path module dir    : {path_module_disp}')
     lines.append(f'Pipeline mode      : {pipeline_mode}')
-    lines.append(f'refine-path        : {_fmt_bool(payload.get('refine_path'))}')
-    lines.append(f'TSOPT/IRC          : {_fmt_bool(payload.get('tsopt'))}')
-    lines.append(f'Thermochemistry    : {_fmt_bool(payload.get('thermo'))}')
-    lines.append(f'DFT single-point   : {_fmt_bool(payload.get('dft'))}')
+    lines.append(f"refine-path        : {_fmt_bool(payload.get('refine_path'))}")
+    lines.append(f"TSOPT/IRC          : {_fmt_bool(payload.get('tsopt'))}")
+    lines.append(f"Thermochemistry    : {_fmt_bool(payload.get('thermo'))}")
+    lines.append(f"DFT single-point   : {_fmt_bool(payload.get('dft'))}")
     opt_mode_disp = payload.get('opt_mode') or '-'
     lines.append(
         f'Opt mode           : {opt_mode_disp}  (light: LBFGS/Dimer; heavy: RFO/RSIRFO)'
     )
-    lines.append(f'MEP mode           : {payload.get('mep_mode') or '-'}')
+    lines.append(f"MEP mode           : {payload.get('mep_mode') or '-'}")
 
     version_base = payload.get('code_version') or __version__
     version_txt = f'pdb2reaction {version_base}'
     lines.append(f'Code version       : {version_txt}')
     uma_model = payload.get('uma_model') or CALC_KW.get('model') or '-'
     lines.append(f'UMA model          : {uma_model}')
-    lines.append(f'Total charge (ML)  : {charge if charge is not None else '-'}')
-    lines.append(f'Multiplicity (2S+1): {spin if spin is not None else '-'}')
+    lines.append(f"Total charge (ML)  : {charge if charge is not None else '-'}")
+    lines.append(f"Multiplicity (2S+1): {spin if spin is not None else '-'}")
 
     freeze_atoms_raw = payload.get('freeze_atoms') or []
     try:
@@ -299,22 +299,22 @@ def write_summary_log(dest: Path, payload: Dict[str, Any]) -> None:
     mep = payload.get('mep', {}) or {}
     diag = mep.get('diagram') or {}
     lines.append('[1] Global MEP overview')
-    lines.append(f'  Number of MEP images : {mep.get('n_images', '-')}')
-    lines.append(f'  Number of segments   : {mep.get('n_segments', '-')}')
+    lines.append(f"  Number of MEP images : {mep.get('n_images', '-')}")
+    lines.append(f"  Number of segments   : {mep.get('n_segments', '-')}")
     if mep.get('traj_pdb'):
         lines.append(
-            f'  MEP trajectory (PDB) : {_shorten_path(mep.get('traj_pdb'), root_out_path)}'
+            f"  MEP trajectory (PDB) : {_shorten_path(mep.get('traj_pdb'), root_out_path)}"
         )
     if mep.get('mep_plot'):
         lines.append(
-            f'  MEP energy plot      : {_shorten_path(mep.get('mep_plot'), root_out_path)}'
+            f"  MEP energy plot      : {_shorten_path(mep.get('mep_plot'), root_out_path)}"
         )
     lines.append('')
     lines.append('  MEP energy diagram (ΔE, kcal/mol)')
     if diag:
         if diag.get('image'):
             lines.append(
-                f'    Image : {_shorten_path(diag.get('image'), root_out_path)}'
+                f"    Image : {_shorten_path(diag.get('image'), root_out_path)}"
             )
         lines.append('    State    ΔE [kcal/mol]')
         labels = diag.get('labels', [])
@@ -370,17 +370,17 @@ def write_summary_log(dest: Path, payload: Dict[str, Any]) -> None:
             lines.append(f'  === Segment {idx:02d} ({kind}) tag={tag} ===')
             if seg.get('post_dir'):
                 lines.append(
-                    f'    Post-process dir : {_shorten_path(seg.get('post_dir'), root_out_path)}'
+                    f"    Post-process dir : {_shorten_path(seg.get('post_dir'), root_out_path)}"
                 )
             ts_imag = seg.get('ts_imag') or seg.get('ts_imag_freq_cm')
             lines.extend(_format_ts_imag_info(ts_imag))
             if seg.get('irc_plot'):
                 lines.append(
-                    f'    IRC plot         : {_shorten_path(seg.get('irc_plot'), root_out_path)}'
+                    f"    IRC plot         : {_shorten_path(seg.get('irc_plot'), root_out_path)}"
                 )
             if seg.get('irc_traj'):
                 lines.append(
-                    f'    IRC trajectory   : {_shorten_path(seg.get('irc_traj'), root_out_path)}'
+                    f"    IRC trajectory   : {_shorten_path(seg.get('irc_traj'), root_out_path)}"
                 )
             _emit_energy_block(
                 lines, 'UMA energies (TSOPT+IRC)', seg.get('uma'), root_out_path
@@ -441,7 +441,7 @@ def write_summary_log(dest: Path, payload: Dict[str, Any]) -> None:
             ('DFT//UMA ΔG  [kcal/mol]', 'gibbs_dft_uma_delta'),
         ]
         sorted_entries = [segment_entries[k] for k in sorted(segment_entries.keys())]
-        headers = [f'{int(e.get('index', 0)):d}({e.get('tag', '-')})' for e in sorted_entries]
+        headers = [f"{int(e.get('index', 0)):d}({e.get('tag', '-')})" for e in sorted_entries]
         label_width = max(len(label) for label, _ in table_rows) + 2
         col_width = max(max(len(h) for h in headers), 8)
 
@@ -457,7 +457,7 @@ def write_summary_log(dest: Path, payload: Dict[str, Any]) -> None:
         lines.append('  Segment overview table')
         lines.append(
             '    '
-            + f'{'Seg':<{label_width}} '
+            + f"{'Seg':<{label_width}} "
             + ' '.join(f'{h:>{col_width}}' for h in headers)
         )
         for label, key in table_rows:
@@ -501,7 +501,7 @@ def write_summary_log(dest: Path, payload: Dict[str, Any]) -> None:
             idx = labels_map.get(st)
             val = energies[idx] if idx is not None and idx < len(energies) else None
             row_vals.append(f'{val:>{col_width}.2f}' if val is not None else '---'.rjust(col_width))
-        return f'    {label:<{label_width}} {' '.join(row_vals)}'
+        return f"    {label:<{label_width}} {' '.join(row_vals)}"
 
     if diagrams:
         for diag_payload in diagrams:
@@ -522,7 +522,7 @@ def write_summary_log(dest: Path, payload: Dict[str, Any]) -> None:
                 lines.append(f'        {lab:<8}{rel_txt}')
             if diag_payload.get('image'):
                 lines.append(
-                    f'    Image : {_shorten_path(diag_payload.get('image'), root_out_path)}'
+                    f"    Image : {_shorten_path(diag_payload.get('image'), root_out_path)}"
                 )
 
             method_key = _classify_method(diag_payload)
@@ -549,7 +549,7 @@ def write_summary_log(dest: Path, payload: Dict[str, Any]) -> None:
 
         lines.append(
             '    '
-            + f'{'State':<{label_width}} '
+            + f"{'State':<{label_width}} "
             + ' '.join(f'{st:>{col_width}}' for st in state_order)
         )
 

--- a/pdb2reaction/trj2fig.py
+++ b/pdb2reaction/trj2fig.py
@@ -194,10 +194,10 @@ def transform_series(
     if is_delta:
         base = energies_hartree[ref_idx]  # type: ignore[index]
         values = [float((e - base) * scale) for e in energies_hartree]
-        ylabel = f'ΔE ({'kcal/mol' if unit == 'kcal' else 'hartree'})'
+        ylabel = f"ΔE ({'kcal/mol' if unit == 'kcal' else 'hartree'})"
     else:
         values = [float(e * scale) for e in energies_hartree]
-        ylabel = f'E ({'kcal/mol' if unit == 'kcal' else 'hartree'})'
+        ylabel = f"E ({'kcal/mol' if unit == 'kcal' else 'hartree'})"
 
     return values, ylabel, is_delta
 

--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -1459,7 +1459,9 @@ def cli(
             detected = []
         merged = merge_freeze_atom_indices(geom_cfg, detected)
         if merged:
-            click.echo(f'[freeze-links] Freeze atoms (0-based): {','.join(map(str, merged))}')
+            click.echo(
+                f"[freeze-links] Freeze atoms (0-based): {','.join(map(str, merged))}"
+            )
 
     # Pass freeze_atoms from geom → calc (so UMA knows active DOF for FD Hessian)
     if 'freeze_atoms' in geom_cfg:

--- a/pdb2reaction/utils.py
+++ b/pdb2reaction/utils.py
@@ -808,10 +808,10 @@ def _derive_charge_from_ligand_charge(
             f'{prefix} Charge summary from full complex (--ligand-charge without extraction):'
         )
         click.echo(
-            f'  Protein: {summary.get('protein_charge', 0.0):+g},  '
-            f'Ligand: {summary.get('ligand_total_charge', 0.0):+g},  '
-            f'Ions: {summary.get('ion_total_charge', 0.0):+g},  '
-            f'Total: {q_total:+g}'
+            f"  Protein: {summary.get('protein_charge', 0.0):+g},  "
+            f"Ligand: {summary.get('ligand_total_charge', 0.0):+g},  "
+            f"Ions: {summary.get('ion_total_charge', 0.0):+g},  "
+            f"Total: {q_total:+g}"
         )
         return _round_charge_with_note(q_total, prefix)
     except Exception as e:
@@ -1124,7 +1124,7 @@ def resolve_atom_spec_index(spec: str, atom_meta: Sequence[Dict[str, Any]]) -> i
 def format_pdb_atom_metadata_header() -> str:
     """Column legend for :func:`format_pdb_atom_metadata`, aligned to match values."""
 
-    return f'{'id':>5} {'atom':<4} {'res':<4} {'resid':>4} {'el':<2}'
+    return f"{'id':>5} {'atom':<4} {'res':<4} {'resid':>4} {'el':<2}"
 
 
 def format_pdb_atom_metadata(atom_meta: Sequence[Dict[str, Any]], index: int) -> str:
@@ -1132,7 +1132,7 @@ def format_pdb_atom_metadata(atom_meta: Sequence[Dict[str, Any]], index: int) ->
 
     fallback_serial = index + 1
     if index < 0 or index >= len(atom_meta):
-        return f'{fallback_serial:>5} {'?':<4} {'?':<4} {'?':>4} {'?':<2}'
+        return f"{fallback_serial:>5} {'?':<4} {'?':<4} {'?':>4} {'?':<2}"
 
     meta = atom_meta[index]
     serial = meta.get('serial') or fallback_serial


### PR DESCRIPTION
### Motivation

- Prevent syntax errors and unintended interpolation by normalizing quoting in `f-strings` used for CLI output and logging. 
- Ensure messages containing nested quotes (file paths, formatted lists, and diagram labels) render correctly across commands such as `scan`, `path_search`, `irc`, and others. 
- Improve readability and future maintainability of echo/log messages by applying a consistent quoting style and parenthesized multi-line `f-strings` where needed.

### Description

- Rewrote problematic `f-strings` to use double-quoted outer strings or parenthesized multi-line expressions in many modules including `pdb2reaction/scan.py`, `scan2d.py`, `scan3d.py`, `path_search.py`, `path_opt.py`, `opt.py`, `tsopt.py`, `irc.py`, `freq.py`, `dft.py`, `trj2fig.py`, `all.py`, `summary_log.py`, `utils.py`, and `extract.py` to avoid nested-quote collisions. 
- Replaced nested single-quote patterns like `f'...{... '...' ...}'` with safe alternatives such as `f"...{...}..."` and parenthesized `click.echo(...)` calls to break long `f-strings` across lines. 
- Adjusted a few path/message constructions (e.g. `out_pdb` and `summary` write messages) to use explicit formatting or escaped quotes so output remains unambiguous. 
- Commit message: `Fix quoting in f-strings` (changes staged and committed across the listed modules).

### Testing

- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e81f3846c832da945c1b860b842ac)