### PR TITLE
Normalize CLI example quoting across docs and CLI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   
 Basically, you just need a **single command** such as  
 ```bash
-pdb2reaction -i R.pdb P.pdb -c "SAM,GPP" --ligand-charge "SAM:1,GPP:-3"
+pdb2reaction -i R.pdb P.pdb -c 'SAM,GPP' --ligand-charge 'SAM:1,GPP:-3'
 ```  
 for modeling enzymatic reaction pathways.  
 
@@ -60,7 +60,7 @@ Finally, log in to **Hugging Face Hub** so that UMA models can be downloaded. Ei
 
 ```bash
 # Hugging Face CLI
-hf auth login --token "<YOUR_ACCESS_TOKEN>" --add-to-git-credential
+hf auth login --token '<YOUR_ACCESS_TOKEN>' --add-to-git-credential
 ```
 
 or
@@ -175,13 +175,13 @@ Use this when you already have several full PDB structures along a putative reac
 **Minimal example**
 
 ```bash
-pdb2reaction -i R.pdb P.pdb -c "SAM,GPP" --ligand-charge "SAM:1,GPP:-3"
+pdb2reaction -i R.pdb P.pdb -c 'SAM,GPP' --ligand-charge 'SAM:1,GPP:-3'
 ```
 
 **Richer example**
 
 ```bash
-pdb2reaction -i R.pdb I1.pdb I2.pdb P.pdb -c "SAM,GPP" --ligand-charge "SAM:1,GPP:-3" --out-dir ./result_all --tsopt True --thermo True --dft True
+pdb2reaction -i R.pdb I1.pdb I2.pdb P.pdb -c 'SAM,GPP' --ligand-charge 'SAM:1,GPP:-3' --out-dir ./result_all --tsopt True --thermo True --dft True
 ```
 
 Behavior:
@@ -207,20 +207,20 @@ Provide a single `-i` together with `--scan-lists`:
 **Minimal example**
 
 ```bash
-pdb2reaction -i R.pdb -c "SAM,GPP" --ligand-charge "SAM:1,GPP:-3" --scan-lists "[('TYR,285,CA','MMT,309,C10',2.20),('TYR,285,CB','MMT,309,C11',1.80)]"
+pdb2reaction -i R.pdb -c 'SAM,GPP' --ligand-charge 'SAM:1,GPP:-3' --scan-lists '[("TYR,285,CA","MMT,309,C10",2.20),("TYR,285,CB","MMT,309,C11",1.80)]'
 ```
 
 **Richer example**
 
 ```bash
-pdb2reaction -i SINGLE.pdb -c "SAM,GPP" --scan-lists "[('TYR,285,CA','MMT,309,C10',2.20),('TYR,285,CB','MMT,309,C11',1.80)]" --mult 1 --out-dir ./result_scan_all --tsopt True --thermo True --dft True
+pdb2reaction -i SINGLE.pdb -c 'SAM,GPP' --scan-lists '[("TYR,285,CA","MMT,309,C10",2.20),("TYR,285,CB","MMT,309,C11",1.80)]' --mult 1 --out-dir ./result_scan_all --tsopt True --thermo True --dft True
 ```
 
 Key points:
 
 - `--scan-lists` describes **staged distance scans** on the extracted cluster model.
 - Each tuple `(i, j, target_Å)` is:
-  - a 1‑based atom index **or** a PDB atom selector string like `"TYR,285,CA"` (delimiters: space/comma/slash/backtick/backslash),
+  - a 1‑based atom index **or** a PDB atom selector string like `'TYR,285,CA'` (delimiters: space/comma/slash/backtick/backslash),
   - automatically remapped to the cluster-model indices.
 - Each stage writes a `stage_XX/result.pdb`, which is treated as a candidate intermediate or product.
 - The default `all` workflow refines the concatenated stages with recursive `path_search`.
@@ -239,13 +239,13 @@ Provide exactly one PDB and enable `--tsopt`:
 **Minimal example**
 
 ```bash
-pdb2reaction -i TS_CANDIDATE.pdb -c "SAM,GPP" --ligand-charge "SAM:1,GPP:-3" --tsopt True
+pdb2reaction -i TS_CANDIDATE.pdb -c 'SAM,GPP' --ligand-charge 'SAM:1,GPP:-3' --tsopt True
 ```
 
 **Richer example**
 
 ```bash
-pdb2reaction -i TS_CANDIDATE.pdb -c "SAM,GPP" --ligand-charge "SAM:1,GPP:-3" --tsopt True --thermo True --dft True --out-dir ./result_tsopt_only
+pdb2reaction -i TS_CANDIDATE.pdb -c 'SAM,GPP' --ligand-charge 'SAM:1,GPP:-3' --tsopt True --thermo True --dft True --out-dir ./result_tsopt_only
 ```
 
 Behavior:
@@ -280,13 +280,13 @@ Below are the most commonly used options across workflows.
 
   - PDB paths (the atoms in the given PDB define the center structure used during cluster extraction),
   - residue IDs, e.g. `A:123,B:456`,
-  - residue names, e.g. `"SAM,GPP"`.
+  - residue names, e.g. `'SAM,GPP'`.
 
 - `--ligand-charge TEXT`  
   Total charge information, either:
 
   - a single integer (total cluster-model charge), or
-  - a mapping, e.g. `"SAM:1,GPP:-3"`.
+  - a mapping, e.g. `'SAM:1,GPP:-3'`.
 
   The total charge of the first cluster model is summed and used for scan, GSM, and TS optimization runs.
 
@@ -306,7 +306,7 @@ Below are the most commonly used options across workflows.
   One or more Python‑style lists describing **staged scans** for single‑input runs. Example:
 
   ```bash
-  --scan-lists "[(10,55,2.20),(23,34,1.80)]"
+  --scan-lists '[(10,55,2.20),(23,34,1.80)]'
   ```
 
   Each tuple describes a harmonic distance restraint between atoms `i` and `j` driven to a target in Å. Indices are 1‑based in the original full PDB and are automatically remapped onto the cluster model.

--- a/docs/all.md
+++ b/docs/all.md
@@ -16,19 +16,19 @@ pdb2reaction all -i INPUT1 [INPUT2 ...] -c SUBSTRATE [options]
 ### Examples
 ```bash
 # Multi-structure ensemble with explicit ligand charges and post-processing
-pdb2reaction all -i reactant.pdb product.pdb -c "GPP,MMT" \
-    --ligand-charge "GPP:-3,MMT:-1" --mult 1 --freeze-links True \
+pdb2reaction all -i reactant.pdb product.pdb -c 'GPP,MMT' \
+    --ligand-charge 'GPP:-3,MMT:-1' --mult 1 --freeze-links True \
     --max-nodes 10 --max-cycles 100 --climb True --opt-mode light \
     --out-dir result_all_${date} --tsopt True --thermo True --dft True
 
 # Single-structure staged scan followed by GSM/DMF + TSOPT/freq/DFT
-pdb2reaction all -i single.pdb -c "308,309" \
-    --scan-lists "[('TYR,285,CA','MMT,309,C10',2.20),('TYR,285,CB','MMT,309,C11',1.80)]" \
+pdb2reaction all -i single.pdb -c '308,309' \
+    --scan-lists '[("TYR,285,CA","MMT,309,C10",2.20),("TYR,285,CB","MMT,309,C11",1.80)]' \
     --opt-mode heavy --tsopt True --thermo True --dft True
 
 # TSOPT-only workflow (no path search)
-pdb2reaction all -i reactant.pdb -c "GPP,MMT" \
-    --ligand-charge "GPP:-3,MMT:-1" --tsopt True --thermo True --dft True
+pdb2reaction all -i reactant.pdb -c 'GPP,MMT' \
+    --ligand-charge 'GPP:-3,MMT:-1' --tsopt True --thermo True --dft True
 ```
 
 ## Workflow
@@ -39,7 +39,7 @@ pdb2reaction all -i reactant.pdb -c "GPP,MMT" \
    - The **first pocket’s total charge** is rounded to the nearest integer and propagated to scan/MEP/TSOPT (a console note appears when rounding occurs).
 
 2. **Optional staged scan (single-input only)**
-   - Each `--scan-lists` argument is a Python-like list of `(i,j,target_Å)` tuples describing a UMA scan stage. Atom indices refer to the original input PDB (1-based) and are remapped to the pocket ordering. For PDB inputs, `i`/`j` can be integer indices or selector strings like `"TYR,285,CA"`; selectors accept spaces/commas/slashes/backticks/backslashes as delimiters and allow unordered tokens (fallback assumes resname, resseq, atom).
+   - Each `--scan-lists` argument is a Python-like list of `(i,j,target_Å)` tuples describing a UMA scan stage. Atom indices refer to the original input PDB (1-based) and are remapped to the pocket ordering. For PDB inputs, `i`/`j` can be integer indices or selector strings like `'TYR,285,CA'`; selectors accept spaces/commas/slashes/backticks/backslashes as delimiters and allow unordered tokens (fallback assumes resname, resseq, atom).
    - When `--scan-lists` is repeated, stages run **sequentially**: stage 1 relaxes the starting structure, stage 2 begins from stage 1's result, and so on.
    - Scan inherits charge/spin, `--freeze-links`, the UMA optimizer preset (`--opt-mode`), `--dump`, `--args-yaml`, and `--preopt`. Overrides such as `--scan-out-dir`, `--scan-one-based`, `--scan-max-step-size`, `--scan-bias-k`, `--scan-relax-max-cycles`, `--scan-preopt`, and `--scan-endopt` apply per run.
    - Stage endpoints (`stage_XX/result.pdb`) become the ordered intermediates that feed the subsequent MEP step.
@@ -115,7 +115,7 @@ pdb2reaction all -i reactant.pdb -c "GPP,MMT" \
 | `--dft-max-cycle INT` | Override `dft --max-cycle`. | _None_ |
 | `--dft-conv-tol FLOAT` | Override `dft --conv-tol`. | _None_ |
 | `--dft-grid-level INT` | Override `dft --grid-level`. | _None_ |
-| `--scan-lists TEXT...` | One or more Python-like lists describing staged scans on the extracted pocket (single-input runs only). Each element is `(i,j,target_Å)`; `i`/`j` can be integer indices or PDB atom selectors like `"TYR,285,CA"` and are remapped internally. | _None_ |
+| `--scan-lists TEXT...` | One or more Python-like lists describing staged scans on the extracted pocket (single-input runs only). Each element is `(i,j,target_Å)`; `i`/`j` can be integer indices or PDB atom selectors like `'TYR,285,CA'` and are remapped internally. | _None_ |
 | `--scan-out-dir PATH` | Override the scan output directory (`<out-dir>/scan`). | _None_ |
 | `--scan-one-based BOOLEAN` | Force scan indexing to 1-based (`True`) or 0-based (`False`); `None` keeps the scan default (1-based). | _None_ |
 | `--scan-max-step-size FLOAT` | Override scan `--max-step-size` (Å). | _None_ |

--- a/docs/dft.md
+++ b/docs/dft.md
@@ -6,7 +6,7 @@ Run single-point DFT calculations with a GPU (GPU4PySCF when available, CPU PySC
 ## Usage
 ```bash
 pdb2reaction dft -i INPUT.{pdb|xyz|gjf|...} -q CHARGE [-m MULTIPLICITY] \
-                 --func-basis "FUNC/BASIS" \
+                 --func-basis 'FUNC/BASIS' \
                  [--max-cycle N] [--conv-tol Eh] [--grid-level L] \
                  [--out-dir DIR] [--engine gpu|cpu|auto] [--convert-files {True|False}] \
                  [--args-yaml FILE]
@@ -15,10 +15,10 @@ pdb2reaction dft -i INPUT.{pdb|xyz|gjf|...} -q CHARGE [-m MULTIPLICITY] \
 ### Examples
 ```bash
 # Default GPU-first policy with explicit functional/basis
-pdb2reaction dft -i input.pdb -q 0 -m 1 --func-basis "wb97m-v/6-31g**"
+pdb2reaction dft -i input.pdb -q 0 -m 1 --func-basis 'wb97m-v/6-31g**'
 
 # Tighter controls, larger basis, CPU-only backend
-pdb2reaction dft -i input.pdb -q 1 -m 2 --func-basis "wb97m-v/def2-tzvpd" --max-cycle 150 --conv-tol 1e-9 --engine cpu
+pdb2reaction dft -i input.pdb -q 1 -m 2 --func-basis 'wb97m-v/def2-tzvpd' --max-cycle 150 --conv-tol 1e-9 --engine cpu
 ```
 
 ## Workflow

--- a/docs/extract.md
+++ b/docs/extract.md
@@ -23,16 +23,16 @@ pdb2reaction extract -i COMPLEX.pdb [COMPLEX2.pdb ...]
 pdb2reaction extract -i complex.pdb -c '123' -o pocket.pdb --ligand-charge -3
 
 # Substrate provided as a PDB; per-resname charge mapping (others remain 0)
-pdb2reaction extract -i complex.pdb -c substrate.pdb -o pocket.pdb --ligand-charge "GPP:-3,SAM:1"
+pdb2reaction extract -i complex.pdb -c substrate.pdb -o pocket.pdb --ligand-charge 'GPP:-3,SAM:1'
 
 # Name-based substrate selection including all matches (WARNING is logged)
-pdb2reaction extract -i complex.pdb -c "GPP,SAM" -o pocket.pdb --ligand-charge "GPP:-3,SAM:1"
+pdb2reaction extract -i complex.pdb -c 'GPP,SAM' -o pocket.pdb --ligand-charge 'GPP:-3,SAM:1'
 
 # Multi-structure to single multi-MODEL output with hetero-hetero proximity enabled
-pdb2reaction extract -i complex1.pdb complex2.pdb -c "GPP,SAM" -o pocket_multi.pdb --radius-het2het 2.6 --ligand-charge "GPP:-3,SAM:1"
+pdb2reaction extract -i complex1.pdb complex2.pdb -c 'GPP,SAM' -o pocket_multi.pdb --radius-het2het 2.6 --ligand-charge 'GPP:-3,SAM:1'
 
 # Multi-structure to multi outputs with hetero-hetero proximity enabled
-pdb2reaction extract -i complex1.pdb complex2.pdb -c "GPP,SAM" -o pocket1.pdb pocket2.pdb --ligand-charge "GPP:-3,SAM:1"
+pdb2reaction extract -i complex1.pdb complex2.pdb -c 'GPP,SAM' -o pocket1.pdb pocket2.pdb --ligand-charge 'GPP:-3,SAM:1'
 ```
 
 ## Workflow
@@ -75,7 +75,7 @@ pdb2reaction extract -i complex1.pdb complex2.pdb -c "GPP,SAM" -o pocket1.pdb po
 
 ### Substrate specification (`-c/--center`)
 - PDB path: the coordinates must match the first input exactly (tolerance 1e-3 Å); residue IDs propagate to other structures.
-- Residue IDs: `"123,124"`, `"A:123,B:456"`, `"123A"`, `"A:123A"` (insertion codes supported).
+- Residue IDs: `'123,124'`, `'A:123,B:456'`, `'123A'`, `'A:123A'` (insertion codes supported).
 - Residue names: comma-separated list (case insensitive). If multiple residues share a name, **all** matches are included and a warning is logged.
 
 ## CLI options

--- a/docs/opt.md
+++ b/docs/opt.md
@@ -13,7 +13,7 @@ A Gaussian `.gjf` template seeds the charge/spin defaults and enables automatic 
 ```bash
 pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} -q CHARGE -m MULT \
                  [--opt-mode light|heavy] [--freeze-links BOOL] \
-                 [--dist-freeze "[(i,j,target_A), ...]"] [--one-based {True|False}] \
+                 [--dist-freeze '[(i,j,target_A), ...]'] [--one-based {True|False}] \
                  [--bias-k K_eV_per_A2] [--dump BOOL] [--out-dir DIR] \
                  [--max-cycles N] [--thresh PRESET] [--args-yaml FILE] \
                  [--convert-files {True|False}]

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -12,19 +12,19 @@ to disk.
 ## Usage
 ```bash
 pdb2reaction scan -i INPUT.{pdb|xyz|trj|...} -q CHARGE [-m MULT] \
-                  --scan-lists "[(i,j,targetÅ), ...]" [options]
+                  --scan-lists '[(i,j,targetÅ), ...]' [options]
                   [--convert-files {True|False}]
 ```
 
 ### Examples
 ```bash
 # Single-stage, minimal inputs (PDB)
-pdb2reaction scan -i input.pdb -q 0 --scan-lists "[('TYR,285,CA','MMT,309,C10',1.35)]"
+pdb2reaction scan -i input.pdb -q 0 --scan-lists '[("TYR,285,CA","MMT,309,C10",1.35)]'
 
 # Two stages, LBFGS relaxations, and trajectory dumping
 pdb2reaction scan -i input.pdb -q 0 \
-    --scan-lists "[('TYR,285,CA','MMT,309,C10',1.35)]" \
-    --scan-lists "[('TYR,285,CA','MMT,309,C10',2.20),('TYR,285,CB','MMT,309,C11',1.80)]" \
+    --scan-lists '[("TYR,285,CA","MMT,309,C10",1.35)]' \
+    --scan-lists '[("TYR,285,CA","MMT,309,C10",2.20),("TYR,285,CB","MMT,309,C11",1.80)]' \
     --max-step-size 0.20 --dump True --out-dir ./result_scan/ --opt-mode light \
     --preopt True --endopt True
 ```
@@ -39,7 +39,7 @@ pdb2reaction scan -i input.pdb -q 0 \
    biasing so the starting point is relaxed.
 3. For each stage literal supplied via `--scan-lists`, parse and normalize the
    `(i, j)` indices (1-based by default). When the input is a PDB, each entry
-   may be either an integer index or an atom selector string like `"TYR,285,CA"`;
+   may be either an integer index or an atom selector string like `'TYR,285,CA'`;
    selector fields can be separated by spaces, commas, slashes, backticks, or
    backslashes and may be in any order (fallback assumes resname, resseq, atom).
    Compute the per-bond displacement
@@ -62,7 +62,7 @@ pdb2reaction scan -i input.pdb -q 0 \
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
 | `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
 | `-m, --multiplicity INT` | Spin multiplicity 2S+1 (CLI > template > 1). | `.gjf` template value or `1` |
-| `--scan-lists TEXT` | Repeatable Python literal with `(i,j,targetÅ)` tuples. Each literal is one stage. `i`/`j` can be integer indices or PDB atom selectors like `"TYR,285,CA"`. | Required |
+| `--scan-lists TEXT` | Repeatable Python literal with `(i,j,targetÅ)` tuples. Each literal is one stage. `i`/`j` can be integer indices or PDB atom selectors like `'TYR,285,CA'`. | Required |
 | `--one-based {True|False}` | Interpret atom indices as 1- or 0-based. | `True` |
 | `--max-step-size FLOAT` | Maximum change in any scanned bond per step (Å). Controls the number of integration steps. | `0.20` |
 | `--bias-k FLOAT` | Harmonic bias strength `k` in eV·Å⁻². Overrides `bias.k`. | `100` |

--- a/docs/scan2d.md
+++ b/docs/scan2d.md
@@ -14,7 +14,7 @@ or RFOptimizer when `--opt-mode heavy`.
 ## Usage
 ```bash
 pdb2reaction scan2d -i INPUT.{pdb|xyz|trj|...} -q CHARGE [-m MULT] \
-                    --scan-list "[(i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ)]" [options]
+                    --scan-list '[(i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ)]' [options]
                     [--convert-files {True|False}]
 ```
 
@@ -22,11 +22,11 @@ pdb2reaction scan2d -i INPUT.{pdb|xyz|trj|...} -q CHARGE [-m MULT] \
 ```bash
 # Minimal two-distance scan
 pdb2reaction scan2d -i input.pdb -q 0 \
-    --scan-list "[('TYR,285,CA',1.30,3.10),('MMT,309,C10',1.20,3.20)]"
+    --scan-list '[("TYR,285,CA",1.30,3.10),("MMT,309,C10",1.20,3.20)]'
 
 # LBFGS, dumped inner trajectories, and Plotly outputs
 pdb2reaction scan2d -i input.pdb -q 0 \
-    --scan-list "[('TYR,285,CA',1.30,3.10),('MMT,309,C10',1.20,3.20)]" \
+    --scan-list '[("TYR,285,CA",1.30,3.10),("MMT,309,C10",1.20,3.20)]' \
     --max-step-size 0.20 --dump True --out-dir ./result_scan2d/ --opt-mode light \
     --preopt True --baseline min
 ```
@@ -40,7 +40,7 @@ pdb2reaction scan2d -i input.pdb -q 0 \
    its unbiased energy is stored in `surface.csv` with indices `i = j = -1`.
 2. Parse the single `--scan-list` literal into two quadruples, normalize indices
    (1-based by default). For PDB inputs, each atom entry can be an integer index
-   or a selector string like `"TYR,285,CA"`; delimiters may be spaces, commas,
+   or a selector string like `'TYR,285,CA'`; delimiters may be spaces, commas,
    slashes, backticks, or backslashes, and token order is flexible (fallback
    assumes resname, resseq, atom). Construct linear grids: `N = ceil(|high − low| / h)`
    with `h = --max-step-size`. Zero-length spans collapse to a single point.
@@ -70,7 +70,7 @@ pdb2reaction scan2d -i input.pdb -q 0 \
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
 | `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
 | `-m, --multiplicity INT` | Spin multiplicity 2S+1 (CLI > template > 1). | `.gjf` template value or `1` |
-| `--scan-list TEXT` | **Single** Python literal with two quadruples `(i,j,lowÅ,highÅ)`. `i`/`j` can be integer indices or PDB atom selectors like `"TYR,285,CA"`. | Required |
+| `--scan-list TEXT` | **Single** Python literal with two quadruples `(i,j,lowÅ,highÅ)`. `i`/`j` can be integer indices or PDB atom selectors like `'TYR,285,CA'`. | Required |
 | `--one-based {True|False}` | Interpret `(i, j)` indices as 1- or 0-based. | `True` |
 | `--max-step-size FLOAT` | Maximum change allowed for either distance per increment (Å). Determines the grid density. | `0.20` |
 | `--bias-k FLOAT` | Harmonic bias strength `k` in eV·Å⁻². Overrides `bias.k`. | `100` |

--- a/docs/scan3d.md
+++ b/docs/scan3d.md
@@ -14,7 +14,7 @@ rerunning the scan.
 ## Usage
 ```bash
 pdb2reaction scan3d -i INPUT.{pdb|xyz|trj|...} -q CHARGE [-m MULT] \
-                    --scan-list "[(i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ)]" [options] \
+                    --scan-list '[(i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ)]' [options] \
                     [--convert-files {True|False}]
 ```
 
@@ -22,17 +22,17 @@ pdb2reaction scan3d -i INPUT.{pdb|xyz|trj|...} -q CHARGE [-m MULT] \
 ```bash
 # Minimal three-distance scan
 pdb2reaction scan3d -i input.pdb -q 0 \
-    --scan-list "[('TYR,285,CA',1.30,3.10),('MMT,309,C10',1.20,3.20),('TYR,285,CB',1.10,3.00)]"
+    --scan-list '[("TYR,285,CA",1.30,3.10),("MMT,309,C10",1.20,3.20),("TYR,285,CB",1.10,3.00)]'
 
 # LBFGS relaxations, dumped inner trajectories, and HTML isosurface plot
 pdb2reaction scan3d -i input.pdb -q 0 \
-    --scan-list "[('TYR,285,CA',1.30,3.10),('MMT,309,C10',1.20,3.20),('TYR,285,CB',1.10,3.00)]" \
+    --scan-list '[("TYR,285,CA",1.30,3.10),("MMT,309,C10",1.20,3.20),("TYR,285,CB",1.10,3.00)]' \
     --max-step-size 0.20 --dump True --out-dir ./result_scan3d/ --opt-mode light \
     --preopt True --baseline min
 
 # Plot only from an existing surface.csv (skip new energy evaluation)
 pdb2reaction scan3d -i input.pdb -q 0 \
-    --scan-list "[('TYR,285,CA',1.30,3.10),('MMT,309,C10',1.20,3.20),('TYR,285,CB',1.10,3.00)]" \
+    --scan-list '[("TYR,285,CA",1.30,3.10),("MMT,309,C10",1.20,3.20),("TYR,285,CB",1.10,3.00)]' \
     --csv ./result_scan3d/surface.csv --out-dir ./result_scan3d/
 ```
 
@@ -44,7 +44,7 @@ pdb2reaction scan3d -i input.pdb -q 0 \
    summary derives the total charge before scanning.
 2. Parse the single `--scan-list` literal (default 1-based indices unless
    `--one-based False` is passed) into three quadruples. For PDB inputs, each
-   atom entry can be an integer index or a selector string like `"TYR,285,CA"`;
+   atom entry can be an integer index or a selector string like `'TYR,285,CA'`;
    delimiters may be spaces, commas, slashes, backticks, or backslashes, and
    token order is flexible (fallback assumes resname, resseq, atom). Build each linear grid using
    `h = --max-step-size` and reorder the values so the ones closest to the
@@ -70,7 +70,7 @@ pdb2reaction scan3d -i input.pdb -q 0 \
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
 | `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
 | `-m, --multiplicity INT` | Spin multiplicity 2S+1. | `1` |
-| `--scan-list TEXT` | **Single** Python literal with three quadruples `(i,j,lowÅ,highÅ)`. `i`/`j` can be integer indices or PDB atom selectors like `"TYR,285,CA"`. | Required |
+| `--scan-list TEXT` | **Single** Python literal with three quadruples `(i,j,lowÅ,highÅ)`. `i`/`j` can be integer indices or PDB atom selectors like `'TYR,285,CA'`. | Required |
 | `--one-based {True|False}` | Interpret `(i, j)` indices as 1- or 0-based. | `True` |
 | `--max-step-size FLOAT` | Maximum change allowed per distance increment (Å). Controls grid density. | `0.20` |
 | `--bias-k FLOAT` | Harmonic bias strength `k` in eV·Å⁻². Overrides `bias.k`. | `100` |

--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -11,7 +11,7 @@ thermochemistry (freq), DFT single-points, and DFT//UMA diagrams.
 Usage (CLI)
 -----------
     pdb2reaction all -i INPUT1 [INPUT2 ...] [-c <substrate-spec>] \
-        [--ligand-charge <number|"RES:Q,...">] [-q/--charge <forced_net_charge>] [-m/--mult <2S+1>] \
+        [--ligand-charge <number|'RES:Q,...'>] [-q/--charge <forced_net_charge>] [-m/--mult <2S+1>] \
         [--freeze-links {True|False}] [--mep-mode {gsm|dmf}] [--max-nodes <int>] [--max-cycles <int>] \
         [--climb {True|False}] [--opt-mode {light|heavy}] [--dump {True|False}] \
         [--convert-files {True|False}] [--refine-path {True|False}] [--thresh <preset>] \
@@ -19,10 +19,10 @@ Usage (CLI)
         [--hessian-calc-mode {Analytical|FiniteDifference}] [--out-dir <dir>] \
         [--tsopt {True|False}] [--thermo {True|False}] [--dft {True|False}] \
         [--tsopt-max-cycles <int>] [--freq-* overrides] [--dft-* overrides] \
-        [--dft-engine {gpu|cpu|auto}] [--scan-lists "[(...)]" ...]
+        [--dft-engine {gpu|cpu|auto}] [--scan-lists '[(...)]' ...]
 
     # Single-structure scan builder (repeat --scan-lists to define sequential stages; works with or without extraction)
-    pdb2reaction all -i INPUT.pdb [-c <substrate-spec>] --scan-lists "[(...)]" [...]
+    pdb2reaction all -i INPUT.pdb [-c <substrate-spec>] --scan-lists '[(...)]' [...]
 
     # Single-structure TSOPT-only mode (no MEP search) when --scan-lists is omitted and --tsopt True
     pdb2reaction all -i INPUT.pdb [-c <substrate-spec>] --tsopt True [other options]
@@ -31,22 +31,22 @@ Usage (CLI)
 Examples
 --------
     # Minimal end-to-end run with explicit substrate and ligand charges (multi-structure)
-    pdb2reaction all -i reactant.pdb product.pdb -c "GPP,MMT" \
-        --ligand-charge "GPP:-3,MMT:-1"
+    pdb2reaction all -i reactant.pdb product.pdb -c 'GPP,MMT' \
+        --ligand-charge 'GPP:-3,MMT:-1'
 
     # Full ensemble with an intermediate, residue-ID substrate spec, and full post-processing
-    pdb2reaction all -i A.pdb B.pdb C.pdb -c "308,309" --ligand-charge "-1" \
+    pdb2reaction all -i A.pdb B.pdb C.pdb -c '308,309' --ligand-charge '-1' \
         --mult 1 --freeze-links True --max-nodes 10 --max-cycles 100 --climb True \
         --opt-mode light --dump False --args-yaml params.yaml --preopt True \
         --out-dir result_all --tsopt True --thermo True --dft True
 
     # Single-structure + staged scan to build an ordered series before the MEP step + post-processing
-    pdb2reaction all -i A.pdb -c "308,309" \
-        --scan-lists "[(10,55,2.20),(23,34,1.80)]" --mult 1 --out-dir result_scan_all \
+    pdb2reaction all -i A.pdb -c '308,309' \
+        --scan-lists '[(10,55,2.20),(23,34,1.80)]' --mult 1 --out-dir result_scan_all \
         --tsopt True --thermo True --dft True
 
     # Single-structure TSOPT-only mode (skips the MEP step entirely)
-    pdb2reaction all -i A.pdb -c "GPP,MMT" --ligand-charge "GPP:-3,MMT:-1" \
+    pdb2reaction all -i A.pdb -c 'GPP,MMT' --ligand-charge 'GPP:-3,MMT:-1' \
         --tsopt True --thermo True --dft True --out-dir result_tsopt_only
 
 
@@ -55,7 +55,7 @@ Description
 Runs a one-shot pipeline centered on pocket models. The command is intentionally permissive about how
 ``-i/--input`` is given: it accepts repeated ``-i`` flags and the sloppy form ``-i A.pdb B.pdb C.pdb``.
 ``--scan-lists`` accepts repeated flags or the sloppy form
-``--scan-lists "[(...)]" "[(...)]"`` to define sequential scan stages.
+``--scan-lists '[(...)]' '[(...)]'`` to define sequential scan stages.
 
 Pipeline overview
 -----------------
@@ -67,8 +67,8 @@ Pipeline overview
 (1) **Active-site pocket extraction** *(enabled when ``-c/--center`` is provided)*
     - Define the substrate/center by:
         • a PDB path,
-        • residue IDs like ``"123,124"`` or ``"A:123,B:456"`` (insertion codes allowed: ``"123A"`` / ``"A:123A"``),
-        • residue names like ``"GPP,MMT"``.
+        • residue IDs like ``'123,124'`` or ``'A:123,B:456'`` (insertion codes allowed: ``'123A'`` / ``'A:123A'``),
+        • residue names like ``'GPP,MMT'``.
     - The extractor writes per-input pocket PDBs under ``<out-dir>/pockets/`` as ``pocket_<stem>.pdb``.
     - The extractor’s **model #1 total pocket charge** is used as the workflow charge for later stages,
       cast to the nearest integer; if rounding occurs a NOTE is printed.
@@ -76,7 +76,7 @@ Pipeline overview
       ``--exclude-backbone``, ``--add-linkH``, ``--selected_resn``, ``--verbose``.
     - ``--ligand-charge`` can be either:
         • a numeric total charge (distributed across unknown residues), or
-        • a residue-name mapping like ``"GPP:-3,MMT:-1"``.
+        • a residue-name mapping like ``'GPP:-3,MMT:-1'``.
 
 (1′) **Extraction skipped** *(when ``-c/--center`` is omitted)*
     - No pocket is built; the **full input structure(s)** are used directly as the “pocket inputs”.
@@ -92,7 +92,7 @@ Pipeline overview
       (**ATOM/HETATM file order**, 1-based) and are **auto-mapped** onto the extracted pocket using structural atom identity
       (chain/residue/atom name, etc.) with occurrence counting for duplicates.
     - For PDB inputs, each ``(i, j, target)`` entry can use integer indices or selector strings like
-      ``"TYR,285,CA"`` / ``"MMT,309,C10"`` (resname, resseq, atom).
+      ``'TYR,285,CA'`` / ``'MMT,309,C10'`` (resname, resseq, atom).
     - Stage endpoints are collected as ``scan/stage_XX/result.(pdb|xyz|gjf)`` and appended to the ordered
       input series for the MEP step:
       ``[initial pocket (or full input), stage_01/result.*, stage_02/result.*, ...]``.
@@ -2099,9 +2099,9 @@ def _irc_and_match(
         "Python-like list of (i,j,target_Å) per stage for **single-structure** scan. Repeatable; "
         "when repeated, stages run **sequentially**, each starting from the prior stage's relaxed "
         "structure. "
-        'Example: "[(12,45,1.35)]" "--scan-lists \'[(10,55,2.20),(23,34,1.80)]\'". '
+        "Example: '[(12,45,1.35)]' --scan-lists '[(10,55,2.20),(23,34,1.80)]'. "
         "You may also pass a single --scan-lists followed by multiple values "
-        '(e.g., "--scan-lists \'[(12,45,1.35)]\' \'[(10,55,2.20)]\'"). '
+        "(e.g., '--scan-lists \\'[(12,45,1.35)]\\' \\'[(10,55,2.20)]\\''). "
         "Indices refer to the original full input PDB (1-based). When extraction is used, they are "
         "auto-mapped to the pocket after extraction. Stage results feed into the MEP step (path_search or path_opt)."
     ),

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -7,17 +7,17 @@ dft — Single-point DFT calculation
 Usage (CLI)
 -----------
     pdb2reaction dft -i INPUT.{pdb|xyz|gjf|...} [-q <charge>] [-m <multiplicity>] \
-        [--func-basis "FUNC/BASIS"] [--max-cycle <int>] [--conv-tol <hartree>] \
+        [--func-basis 'FUNC/BASIS'] [--max-cycle <int>] [--conv-tol <hartree>] \
         [--grid-level <int>] [--out-dir <dir>] [--engine {gpu|cpu|auto}] \
         [--convert-files {True|False}] [--args-yaml <file>]
 
 Examples
 --------
     # Default GPU-first policy with an explicit functional/basis pair
-    pdb2reaction dft -i input.pdb -q 0 -m 1 --func-basis "wb97m-v/6-31g**"
+    pdb2reaction dft -i input.pdb -q 0 -m 1 --func-basis 'wb97m-v/6-31g**'
 
     # Tight SCF controls with a larger basis and CPU-only fallback
-    pdb2reaction dft -i input.pdb -q 0 -m 2 --func-basis "wb97m-v/def2-tzvpd" \
+    pdb2reaction dft -i input.pdb -q 0 -m 2 --func-basis 'wb97m-v/def2-tzvpd' \
         --max-cycle 150 --conv-tol 1e-9 --engine cpu
 
 Description
@@ -31,7 +31,7 @@ Description
 - RKS/UKS is selected automatically from the spin multiplicity (2S+1).
 - Inputs: any structure format supported by pysisyphus.helpers.geom_loader (.pdb, .xyz, .trj, …).
   The geometry is written back unchanged as input_geometry.xyz.
-- Functional/basis specified as "FUNC/BASIS" via --func-basis (e.g., "wb97m-v/6-31g**", "wb97m-v/def2-svp", "wb97m-v/def2-tzvpd").
+- Functional/basis specified as 'FUNC/BASIS' via --func-basis (e.g., 'wb97m-v/6-31g**', 'wb97m-v/def2-svp', 'wb97m-v/def2-tzvpd').
   Names are case-insensitive in PySCF.
 - Density fitting (DF) is enabled via PySCF's density_fit(); the auxiliary basis is left to
   PySCF's default selection.
@@ -130,7 +130,7 @@ DFT_KW: Dict[str, Any] = {
 
 def _parse_func_basis(s: str) -> Tuple[str, str]:
     """
-    Parse "FUNC/BASIS" into (xc, basis).
+    Parse 'FUNC/BASIS' into (xc, basis).
     Mixed case is accepted (PySCF is case-insensitive for common names).
     """
     if not s or "/" not in s:
@@ -396,7 +396,7 @@ def _compute_atomic_spin_densities(mol, mf) -> Dict[str, Optional[List[float]]]:
     type=str,
     default=f"{DFT_DEFAULT_FUNC}/{DFT_DEFAULT_BASIS}",
     show_default=True,
-    help='Exchange–correlation functional and basis set as "FUNC/BASIS" (e.g., "wb97m-v/6-31g**", "wb97m-v/def2-tzvpd").',
+    help="Exchange–correlation functional and basis set as 'FUNC/BASIS' (e.g., 'wb97m-v/6-31g**', 'wb97m-v/def2-tzvpd').",
 )
 @click.option("--max-cycle", type=int, default=DFT_KW["max_cycle"], show_default=True, help="Maximum SCF iterations.")
 @click.option("--conv-tol", type=float, default=DFT_KW["conv_tol"], show_default=True, help="SCF convergence tolerance (Eh).")

--- a/pdb2reaction/extract.py
+++ b/pdb2reaction/extract.py
@@ -23,16 +23,16 @@ Examples
     pdb2reaction extract -i complex.pdb -c '123' -o pocket.pdb --ligand-charge -3
 
     # Substrate provided as a PDB; per-resname charge mapping (others remain 0)
-    pdb2reaction extract -i complex.pdb -c substrate.pdb -o pocket.pdb --ligand-charge "GPP:-3,SAM:1"
+    pdb2reaction extract -i complex.pdb -c substrate.pdb -o pocket.pdb --ligand-charge 'GPP:-3,SAM:1'
 
     # Name-based substrate selection including all matches (WARNING is logged)
-    pdb2reaction extract -i complex.pdb -c "GPP,SAM" -o pocket.pdb --ligand-charge "GPP:-3,SAM:1"
+    pdb2reaction extract -i complex.pdb -c 'GPP,SAM' -o pocket.pdb --ligand-charge 'GPP:-3,SAM:1'
 
     # Multi-structure to single multi-MODEL output with hetero-hetero proximity enabled
-    pdb2reaction extract -i complex1.pdb complex2.pdb -c "GPP,SAM" -o pocket_multi.pdb --radius-het2het 2.6 --ligand-charge "GPP:-3,SAM:1"
+    pdb2reaction extract -i complex1.pdb complex2.pdb -c 'GPP,SAM' -o pocket_multi.pdb --radius-het2het 2.6 --ligand-charge 'GPP:-3,SAM:1'
 
     # Multi-structure to multi outputs with hetero-hetero proximity enabled
-    pdb2reaction extract -i complex1.pdb complex2.pdb -c "GPP,SAM" -o pocket1.pdb pocket2.pdb --ligand-charge "GPP:-3,SAM:1"
+    pdb2reaction extract -i complex1.pdb complex2.pdb -c 'GPP,SAM' -o pocket1.pdb pocket2.pdb --ligand-charge 'GPP:-3,SAM:1'
 
 Description
 -----------
@@ -159,7 +159,7 @@ Residues are categorized as:
 ``--ligand-charge`` handling (applies only to **unknown** residues):
 - ``--ligand-charge <number>``: assign the given total charge equally across **unknown substrate residues**;
   if there are none, distribute across **all unknown residues** in the pocket.
-- ``--ligand-charge "RES1:Q1,RES2:Q2"``: per-resname charges for unknown residues; unspecified unknowns remain 0.
+- ``--ligand-charge 'RES1:Q1,RES2:Q2'``: per-resname charges for unknown residues; unspecified unknowns remain 0.
 
 The logged summary includes:
 - net protein charge, net unknown/ligand charge, ion list and net ion charge, and total pocket charge.
@@ -198,10 +198,10 @@ Substrate specification
   inputs by residue IDs (chain/resseq/icode), so numbering must be consistent across inputs.
 
 - a list of **residue IDs** (comma/space separated):
-  ``"123,124"``, ``"A:123,B:456"``, ``"123A"``, ``"A:123A"`` (insertion codes supported).
+  ``'123,124'``, ``'A:123,B:456'``, ``'123A'``, ``'A:123A'`` (insertion codes supported).
   Chain may be omitted (matches all chains); insertion code may be omitted (matches any insertion code for that resseq).
 
-- a list of **residue names** (comma/space separated, case-insensitive), e.g., ``"GPP,SAM"``.
+- a list of **residue names** (comma/space separated, case-insensitive), e.g., ``'GPP,SAM'``.
   If multiple residues share the same residue name, **all** matches are included and a WARNING is logged.
 
 Outputs (& Paths)
@@ -1292,7 +1292,7 @@ def compute_charge_summary(structure,
         Residues designated as substrate.
     ligand_charge : float | str | dict[str,float] | None
         - float: total charge to assign across **unknown residues** (preferring unknown substrate).
-        - str  : numeric string (total) or mapping like "GPP:-3,SAM:1" (per‑resname).
+        - str  : numeric string (total) or mapping like 'GPP:-3,SAM:1' (per‑resname).
         - dict : mapping {RESNAME: charge}. In mapping mode, other unknown residues remain 0.
 
     Returns

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -8,7 +8,7 @@ Usage (CLI)
 -----------
     pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [-m <multiplicity>] \
         [--opt-mode {light|heavy}] [--freeze-links {True|False}] \
-        [--dist-freeze "[(I,J,TARGET_A), ...]"] [--one-based {True|False}] \
+        [--dist-freeze '[(I,J,TARGET_A), ...]'] [--one-based {True|False}] \
         [--bias-k <float>] [--dump {True|False}] [--out-dir <dir>] \
         [--workers <int>] [--workers-per-node <int>] \
         [--max-cycles <int>] [--thresh <preset>] [--args-yaml <file>] \

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -7,7 +7,7 @@ scan — Bond‑length–driven staged scan with harmonic distance restraints an
 Usage (CLI)
 -----------
     pdb2reaction scan -i INPUT.{pdb|xyz|trj|...} [-q <charge>] \
-        [--scan-lists "[(I,J,TARGET_ANG), ...]" ...] [-m <spin>] \
+        [--scan-lists '[(I,J,TARGET_ANG), ...]' ...] [-m <spin>] \
         [--one-based {True|False}] [--max-step-size <float>] \
         [--bias-k <float>] [--relax-max-cycles <int>] \
         [--opt-mode {light|heavy}] [--freeze-links {True|False}] \
@@ -18,12 +18,12 @@ Usage (CLI)
 Examples
 --------
     # Single-stage, minimal inputs (PDB)
-    pdb2reaction scan -i input.pdb -q 0 --scan-lists "[(12,45,1.35)]"
+    pdb2reaction scan -i input.pdb -q 0 --scan-lists '[(12,45,1.35)]'
 
     # Two stages, LBFGS, dumping trajectories
     pdb2reaction scan -i input.pdb -q 0 \
-        --scan-lists "[(12,45,1.35)]" \
-        --scan-lists "[(10,55,2.20),(23,34,1.80)]" \
+        --scan-lists '[(12,45,1.35)]' \
+        --scan-lists '[(10,55,2.20),(23,34,1.80)]' \
         --max-step-size 0.2 --dump True --out-dir ./result_scan/ --opt-mode light \
         --preopt True --endopt True
 
@@ -34,7 +34,7 @@ Runs a staged, bond‑length–driven scan. At each step, harmonic distance well
 specified atom pairs and the full structure is relaxed. This implementation supports only
 the UMA calculator via `uma_pysis` and removes general-purpose handling to reduce overhead.
 For PDB inputs, scan tuples can use integer indices or selector strings such as
-``"TYR,285,CA"`` and ``"MMT,309,C10"`` to reference atoms (resname, resseq, atom).
+``'TYR,285,CA'`` and ``'MMT,309,C10'`` to reference atoms (resname, resseq, atom).
 
 Scheduling
   - For scan tuples [(i, j, target_Å)], compute the Å‑space displacement Δ = target − current_distance_Å.
@@ -221,7 +221,7 @@ def _parse_scan_lists(
 ) -> List[List[Tuple[int, int, float]]]:
     """
     Parse multiple Python-like list strings:
-      ["[(0,1,1.5), (2,3,2.0)]", "[(5,7,1.2)]", ...]
+      ['[(0,1,1.5), (2,3,2.0)]', '[(5,7,1.2)]', ...]
     Returns: [[(i,j,t), ...], [(i,j,t), ...], ...] with 0-based indices.
     """
     if not args:
@@ -405,8 +405,8 @@ def _snapshot_geometry(g) -> Any:
 @click.option(
     "--scan-lists", "scan_lists_raw",
     type=str, multiple=True, required=True,
-    help='Python-like list of (i,j,target) per stage. Repeatable. Example: '
-         '"[(0,1,1.50),(2,3,2.00)]" "[(5,7,1.20)]".',
+    help="Python-like list of (i,j,target) per stage. Repeatable. Example: "
+         "'[(0,1,1.50),(2,3,2.00)]' '[(5,7,1.20)]'.",
 )
 @click.option("--one-based", "one_based", type=click.BOOL, default=True, show_default=True,
               help="Interpret (i,j) indices in --scan-lists as 1-based (default) or 0-based.")

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -7,7 +7,7 @@ scan2d — Two-distance 2D scan with harmonic restraints
 Usage (CLI)
 -----------
     pdb2reaction scan2d -i INPUT.{pdb,xyz,trj,...} [-q <charge>] [-m <multiplicity>] \
-        --scan-list "[(I1,J1,LOW1,HIGH1),(I2,J2,LOW2,HIGH2)]" \
+        --scan-list '[(I1,J1,LOW1,HIGH1),(I2,J2,LOW2,HIGH2)]' \
         [--one-based {True|False}] \
         [--max-step-size FLOAT] \
         [--bias-k FLOAT] \
@@ -27,11 +27,11 @@ Examples
 --------
     # Minimal example (two distance ranges)
     pdb2reaction scan2d -i input.pdb -q 0 \
-        --scan-list "[(12,45,1.30,3.10),(10,55,1.20,3.20)]"
+        --scan-list '[(12,45,1.30,3.10),(10,55,1.20,3.20)]'
 
     # LBFGS with trajectory dumping and PNG + HTML plots
     pdb2reaction scan2d -i input.pdb -q 0 \
-        --scan-list "[(12,45,1.30,3.10),(10,55,1.20,3.20)]" \
+        --scan-list '[(12,45,1.30,3.10),(10,55,1.20,3.20)]' \
         --max-step-size 0.20 --dump True --out-dir ./result_scan2d/ --opt-mode light \
         --preopt True --baseline min
 
@@ -41,7 +41,7 @@ Description
 - Provide exactly one Python-like list `[(i1, j1, low1, high1), (i2, j2, low2, high2)]` via **--scan-list**.
   - Indices are **1-based by default**; pass **--one-based False** to interpret them as 0-based.
   - For PDB inputs, each atom entry can be an integer index or a selector string such as
-    ``"TYR,285,CA"`` or ``"MMT,309,C10"`` (resname, resseq, atom).
+    ``'TYR,285,CA'`` or ``'MMT,309,C10'`` (resname, resseq, atom).
 - Step schedule (h = `--max-step-size` in Å):
   - `N1 = ceil(|high1 - low1| / h)`, `N2 = ceil(|high2 - low2| / h)`.
   - `d1_values = linspace(low1, high1, N1 + 1)` (or `[low1]` if the span is ~0)
@@ -377,7 +377,7 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
     "scan_list_raw",
     type=str,
     required=True,
-    help='Python-like list with two quadruples: "[(i1,j1,low1,high1),(i2,j2,low2,high2)]".',
+    help="Python-like list with two quadruples: '[(i1,j1,low1,high1),(i2,j2,low2,high2)]'.",
 )
 @click.option(
     "--one-based",

--- a/pdb2reaction/scan3d.py
+++ b/pdb2reaction/scan3d.py
@@ -8,7 +8,7 @@ Usage (CLI)
 -----------
     pdb2reaction scan3d -i INPUT.{pdb,xyz,trj,...} [-q CHARGE] \
         [-m MULTIPLICITY] \
-        --scan-list "[(I1,J1,LOW1,HIGH1),(I2,J2,LOW2,HIGH2),(I3,J3,LOW3,HIGH3)]" \
+        --scan-list '[(I1,J1,LOW1,HIGH1),(I2,J2,LOW2,HIGH2),(I3,J3,LOW3,HIGH3)]' \
         [--one-based {True|False}] \
         [--max-step-size FLOAT] \
         [--bias-k FLOAT] \
@@ -29,17 +29,17 @@ Examples
 --------
     # Minimal example (three distance ranges)
     pdb2reaction scan3d -i input.pdb -q 0 \
-        --scan-list "[(12,45,1.30,3.10),(10,55,1.20,3.20),(15,60,1.10,3.00)]"
+        --scan-list '[(12,45,1.30,3.10),(10,55,1.20,3.20),(15,60,1.10,3.00)]'
 
     # LBFGS with inner-path trajectory dumping and 3D energy isosurface plot
     pdb2reaction scan3d -i input.pdb -q 0 \
-        --scan-list "[(12,45,1.30,3.10),(10,55,1.20,3.20),(15,60,1.10,3.00)]" \
+        --scan-list '[(12,45,1.30,3.10),(10,55,1.20,3.20),(15,60,1.10,3.00)]' \
         --max-step-size 0.20 --dump True --out-dir ./result_scan3d/ --opt-mode light \
         --preopt True --baseline min
 
     # Plot only from an existing surface.csv (skip new energy evaluation)
     pdb2reaction scan3d -i input.pdb -q 0 \
-        --scan-list "[(12,45,1.30,3.10),(10,55,1.20,3.20),(15,60,1.10,3.00)]" \
+        --scan-list '[(12,45,1.30,3.10),(10,55,1.20,3.20),(15,60,1.10,3.00)]' \
         --csv ./result_scan3d/surface.csv --out-dir ./result_scan3d/
 
 Description
@@ -50,7 +50,7 @@ Description
   via **--scan-list**.
   - Indices are **1-based by default**; pass **--one-based False** to interpret them as 0-based.
   - For PDB inputs, each atom entry can be an integer index or a selector string such as
-    ``"TYR,285,CA"`` or ``"MMT,309,C10"`` (resname, resseq, atom).
+    ``'TYR,285,CA'`` or ``'MMT,309,C10'`` (resname, resseq, atom).
 - `-q/--charge` is required for non-`.gjf` inputs **unless** ``--ligand-charge`` is provided; `.gjf` templates supply
   charge/spin when available. When ``-q`` is omitted but ``--ligand-charge`` is set, the full complex is treated as an
   enzyme–substrate system and the total charge is inferred using ``extract.py``’s residue-aware logic. Explicit ``-q``
@@ -435,8 +435,8 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
     type=str,
     required=True,
     help=(
-        'Python-like list with three quadruples: '
-        '"[(i1,j1,low1,high1),(i2,j2,low2,high2),(i3,j3,low3,high3]".'
+        "Python-like list with three quadruples: "
+        "'[(i1,j1,low1,high1),(i2,j2,low2,high2),(i3,j3,low3,high3)]'."
     ),
 )
 @click.option(

--- a/pdb2reaction/trj2fig.py
+++ b/pdb2reaction/trj2fig.py
@@ -137,8 +137,8 @@ def recompute_energies(
 def _parse_reference_spec(spec: str | None) -> str | int | None:
     """
     Normalize the reference specification:
-      - "init" (case-insensitive) -> "init"
-      - "none"/"null"             -> None
+      - 'init' (case-insensitive) -> 'init'
+      - 'none'/'null'             -> None
       - integer-like string       -> int
     """
     if spec is None:
@@ -153,7 +153,7 @@ def _parse_reference_spec(spec: str | None) -> str | int | None:
         return int(s)
     except ValueError:
         raise ValueError(
-            f'Invalid -r/--reference: {spec!r}. Use "init", "None", or an integer index.'
+            f"Invalid -r/--reference: {spec!r}. Use 'init', 'None', or an integer index."
         )
 
 
@@ -325,7 +325,7 @@ def parse_cli() -> argparse.Namespace:
         "-r",
         "--reference",
         default="init",
-        help='Reference: "init" (initial frame; last frame if --reverse-x), "None" (absolute E), or an integer index.',
+        help="Reference: 'init' (initial frame; last frame if --reverse-x), 'None' (absolute E), or an integer index.",
     )
     p.add_argument("-q", "--charge", type=int, required=False, help="Total charge (recompute energies when provided)")
     p.add_argument(
@@ -423,7 +423,7 @@ def main() -> None:
     "-r",
     "--reference",
     default="init",
-    help='Reference: "init" (initial frame; last frame if --reverse-x), "None" (absolute E), or an integer index.',
+    help="Reference: 'init' (initial frame; last frame if --reverse-x), 'None' (absolute E), or an integer index.",
 )
 @click.option(
     "-q",


### PR DESCRIPTION
### Motivation
- Standardize how CLI example arguments are quoted across the project to reduce confusion when copying examples into shells.  
- Use single quotes for outer quoting in examples so embedded commas/asterisks/paths are preserved on common shells.  
- When examples contained nested quotes, flip inner/outer quoting so examples remain valid (outer single → inner double, and vice versa).  
- Keep all changes limited to docstrings, markdown, and help text so there are no behavioral changes to runtime logic.

### Description
- Replaced double-quote wrappers with single-quote wrappers in CLI examples and help text across `README.md`, `docs/*`, and CLI source files.  
- Updated docstrings and `click`/argparse help strings in files such as `pdb2reaction/scan.py`, `scan2d.py`, `scan3d.py`, `all.py`, `dft.py`, `opt.py`, `extract.py`, `trj2fig.py`, and `pdb2reaction/*` docs to reflect the new quoting convention.  
- Adjusted examples containing nested quotes so inner quoting is appropriate (e.g., `--scan-lists '[("TYR,285,CA",...)]'`).  
- No functional code paths or runtime logic were modified (only textual/help/content changes). 

### Testing
- No automated tests were run because the change set is documentation and help-string only.  
- A quick search/grep was used to verify occurrences of the previous double-quote patterns were updated project-wide.  
- No behavioral changes expected; CLI parsing and unit logic were not modified.  
- Manual inspection of updated files confirmed consistent quoting in examples and help text."}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e8a0d08c8832db6fb88e488ab8cd0)