### PR TITLE
Add `--flatten-imag-mode` flag to tsopt and all (defaults True)

### DIFF
--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -1460,6 +1460,7 @@ def _run_tsopt_on_hei(
     _append_cli_arg(ts_args, "--max-cycles", overrides.get("max_cycles"))
     _append_cli_arg(ts_args, "--dump", overrides.get("dump"))
     _append_cli_arg(ts_args, "--thresh", overrides.get("thresh"))
+    _append_cli_arg(ts_args, "--flatten-imag-mode", overrides.get("flatten_imag_mode"))
 
     hess_mode = overrides.get("hessian_calc_mode")
     if hess_mode:
@@ -2007,6 +2008,14 @@ def _irc_and_match(
     help="Override tsopt output subdirectory (relative paths are resolved against the default).",
 )
 @click.option(
+    "--flatten-imag-mode",
+    "flatten_imag_mode",
+    type=click.BOOL,
+    default=True,
+    show_default=True,
+    help="Enable the extra-imaginary-mode flattening loop in tsopt; False forces flatten_max_iter=0.",
+)
+@click.option(
     "--freq-out-dir",
     type=click.Path(path_type=Path, file_okay=False),
     default=None,
@@ -2199,6 +2208,7 @@ def cli(
     scan_endopt_override: Optional[bool],
     tsopt_max_cycles: Optional[int],
     tsopt_out_dir: Optional[Path],
+    flatten_imag_mode: bool,
     freq_out_dir: Optional[Path],
     freq_max_write: Optional[int],
     freq_amplitude_ang: Optional[float],
@@ -2277,6 +2287,7 @@ def cli(
         tsopt_overrides["hessian_calc_mode"] = hessian_calc_mode
     if thresh is not None:
         tsopt_overrides["thresh"] = str(thresh)
+    tsopt_overrides["flatten_imag_mode"] = bool(flatten_imag_mode)
 
     freq_overrides: Dict[str, Any] = {}
     if freq_max_write is not None:

--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -1353,6 +1353,14 @@ RSIRFO_KW.update({
 )
 @click.option("--max-cycles", type=int, default=10000, show_default=True, help="Max cycles / steps cap")
 @click.option(
+    "--flatten-imag-mode",
+    "flatten_imag_mode",
+    type=click.BOOL,
+    default=True,
+    show_default=True,
+    help="Enable the extra-imaginary-mode flattening loop (sets flatten_max_iter; False forces 0).",
+)
+@click.option(
     "--opt-mode",
     type=click.Choice(["light", "heavy"], case_sensitive=False),
     default="light",
@@ -1391,6 +1399,7 @@ def cli(
     freeze_links: bool,
     convert_files: bool,
     max_cycles: int,
+    flatten_imag_mode: bool,
     opt_mode: str,
     dump: bool,
     out_dir: str,
@@ -1449,6 +1458,9 @@ def cli(
             (rsirfo_cfg, (("rsirfo",),)),
         ],
     )
+
+    if not flatten_imag_mode:
+        simple_cfg["flatten_max_iter"] = 0
 
     # Freeze links (PDB only): merge with existing list
     if freeze_links and source_path.suffix.lower() == ".pdb":


### PR DESCRIPTION
### Motivation
- Provide a CLI toggle to enable/disable the extra-imaginary-mode flattening loop used during TS optimization.
- Allow users to disable flattening to force `flatten_max_iter=0` for deterministic or faster runs when desired.
- Expose the toggle both on the `tsopt` command and the higher-level `all` pipeline so it can be propagated automatically.
- Keep the default behavior unchanged (`True`) to preserve current flattening by default.

### Description
- Added a new Click option `--flatten-imag-mode` (mapped to `flatten_imag_mode`) to `pdb2reaction/tsopt.py` with `default=True` and included it in the `cli` signature.
- When `flatten_imag_mode` is `False`, set `simple_cfg["flatten_max_iter"] = 0` so the flatten loop is effectively disabled.
- Added the same Click option to `pdb2reaction/all.py` and added a `flatten_imag_mode` parameter to the `cli` signature.
- Propagated the flag from `all` into `tsopt` by placing `tsopt_overrides["flatten_imag_mode"] = bool(flatten_imag_mode)` and appending `--flatten-imag-mode` to the `tsopt` invocation via `_append_cli_arg`.

### Testing
- No automated tests were executed for these changes.
- Changes were lint/format agnostic and limited to CLI wiring and config propagation.
- Manual inspection of the invocation wiring and configuration assignment was performed during the rollout.
- The patch was committed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960c5c03180832d89817127596fb131)