### PR TITLE
Recommend Analytical Hessians when VRAM is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,9 @@ Below are the most commonly used options across workflows.
 - `--opt-mode (If you have charge and multiplicity in .gjf input, -q and -m can be omitted) | heavy`
   Switch optimization / TS refinement methods between Light (LBFGS and Dimer) and Heavy (Hessian-using RFO and RS-I-RFO) algorithms. Option `light` is recommended.  
 
+- `--hessian-calc-mode Analytical|FiniteDifference`
+  When you have ample VRAM available, setting `--hessian-calc-mode` to `Analytical` is strongly recommended.
+
 - `--mep-mode gsm | dmf`
   Switch MEP refinement between the Growing String Method (GSM) and Direct Max Flux (DMF).
 

--- a/docs/all.md
+++ b/docs/all.md
@@ -58,6 +58,7 @@ pdb2reaction all -i reactant.pdb -c 'GPP,MMT' \
    - `--thermo True`: call `freq` on (R, TS, P) to obtain vibrational/thermochemistry data and a UMA Gibbs diagram.
    - `--dft True`: launch single-point DFT on (R, TS, P) and build a DFT diagram. When combined with `--thermo True`, a DFT//UMA Gibbs diagram (DFT energies + UMA thermal correction) is also produced.
    - Shared overrides include `--opt-mode`, `--hessian-calc-mode`, `--tsopt-max-cycles`, `--tsopt-out-dir`, `--freq-*`, `--dft-*`, and `--dft-engine` (GPU-first by default).
+   - When you have ample VRAM available, setting `--hessian-calc-mode` to `Analytical` is strongly recommended.
 
 6. **TSOPT-only mode** (single input, `--tsopt True`, no `--scan-lists`)
    - Skips the MEP/merge stages. Runs `tsopt` on the pocket (or full input if extraction is skipped), performs EulerPC IRC, identifies the higher-energy endpoint as reactant (R), and generates the same set of energy diagrams plus optional freq/DFT outputs.

--- a/docs/freq.md
+++ b/docs/freq.md
@@ -36,6 +36,7 @@ pdb2reaction freq -i a.xyz -q -1 --args-yaml ./args.yaml --out-dir ./result_freq
   `geom.freeze_atoms`; the merged list is echoed and propagated to UMA and PHVA.
 - **UMA calculator**: `--hessian-calc-mode` selects analytical or finite-difference Hessians.
   UMA may return a partial (active) Hessian block whenever atoms are frozen.
+  When you have ample VRAM available, setting `--hessian-calc-mode` to `Analytical` is strongly recommended.
 - **PHVA & TR projection**: with frozen atoms, eigenanalysis occurs inside the active
   subspace with translation/rotation modes projected there. Both 3N×3N and active-block
   Hessians are accepted, and frequencies are reported in cm⁻¹ (negatives = imaginary).

--- a/docs/tsopt.md
+++ b/docs/tsopt.md
@@ -52,6 +52,7 @@ pdb2reaction tsopt -i ts_cand.pdb -q 0 -m 1 --opt-mode heavy \
 - **UMA Hessians**: `--hessian-calc-mode` toggles between analytical and finite-difference
   evaluations; both honor active (PHVA) subspaces. UMA may return only the active block when
   frozen atoms are present.
+  When you have ample VRAM available, setting `--hessian-calc-mode` to `Analytical` is strongly recommended.
 - **Light mode details**:
   - The Hessian Dimer stage periodically refreshes the dimer direction by evaluating an exact
     Hessian (active subspace, TR-projected) and prefers `torch.lobpcg` for the lowest


### PR DESCRIPTION
### Motivation
- Clarify best-practice for Hessian evaluation when using the UMA calculator to help users choose the more accurate option when hardware allows. 
- Reduce user confusion about the `--hessian-calc-mode` choice by surfacing a practical recommendation in the CLI and workflow documentation. 
- Encourage use of analytical Hessians when GPU memory permits to improve accuracy/performance of `tsopt`/`freq` workflows. 

### Description
- Added a recommendation sentence advising `--hessian-calc-mode` be set to `Analytical` when ample VRAM is available to `README.md` near the CLI options. 
- Inserted the same recommendation into `docs/all.md` under the per-segment post-processing section to highlight the advice for end-to-end workflows. 
- Added the recommendation to `docs/freq.md` in the `UMA calculator`/workflow section and to `docs/tsopt.md` in the `UMA Hessians` section so `freq` and `tsopt` users see it in context. 
- Files updated: `README.md`, `docs/all.md`, `docs/freq.md`, and `docs/tsopt.md` (documentation-only changes). 

### Testing
- No automated tests were run because this is a documentation-only change. 
- Changes were limited to text additions and do not affect runtime code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696170e953cc832daeae8c5c00f54c5c)