### PR TITLE
Document `--ligand-charge` in CLI usage and make charge optional for path commands

### DIFF
--- a/docs/dft.md
+++ b/docs/dft.md
@@ -5,7 +5,7 @@ Run single-point DFT calculations with a GPU (GPU4PySCF when available, CPU PySC
 
 ## Usage
 ```bash
-pdb2reaction dft -i INPUT.{pdb|xyz|gjf|...} -q CHARGE [-m MULTIPLICITY] \
+pdb2reaction dft -i INPUT.{pdb|xyz|gjf|...} -q CHARGE [--ligand-charge <number|'RES:Q,...'>] [-m MULTIPLICITY] \
                  --func-basis 'FUNC/BASIS' \
                  [--max-cycle N] [--conv-tol Eh] [--grid-level L] \
                  [--out-dir DIR] [--engine gpu|cpu|auto] [--convert-files {True|False}] \

--- a/docs/freq.md
+++ b/docs/freq.md
@@ -11,7 +11,7 @@ template can drive both standalone runs and workflows launched by other subcomma
 
 ## Usage
 ```bash
-pdb2reaction freq -i INPUT.{pdb|xyz|trj|...} [-q CHARGE] [-m 2S+1] \
+pdb2reaction freq -i INPUT.{pdb|xyz|trj|...} [-q CHARGE] [--ligand-charge <number|'RES:Q,...'>] [-m 2S+1] \
                   [--freeze-links {True|False}] \
                   [--max-write N] [--amplitude-ang Å] [--n-frames N] \
                   [--sort value|abs] [--out-dir DIR] [--args-yaml FILE] \

--- a/docs/irc.md
+++ b/docs/irc.md
@@ -5,7 +5,7 @@ Run EulerPC-based Intrinsic Reaction Coordinate (IRC) integrations with UMA. The
 
 ## Usage
 ```bash
-pdb2reaction irc -i INPUT.{pdb|xyz|trj|...} [-q CHARGE] [-m 2S+1]
+pdb2reaction irc -i INPUT.{pdb|xyz|trj|...} [-q CHARGE] [--ligand-charge <number|'RES:Q,...'>] [-m 2S+1]
                  [--max-cycles N] [--step-size Δs] [--root k]
                  [--forward True|False] [--backward True|False]
                  [--freeze-links True|False]

--- a/docs/opt.md
+++ b/docs/opt.md
@@ -11,7 +11,7 @@ A Gaussian `.gjf` template seeds the charge/spin defaults and enables automatic 
 
 ## Usage
 ```bash
-pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} -q CHARGE -m MULT \
+pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} -q CHARGE [--ligand-charge <number|'RES:Q,...'>] -m MULT \
                  [--opt-mode light|heavy] [--freeze-links BOOL] \
                  [--dist-freeze '[(i,j,target_A), ...]'] [--one-based {True|False}] \
                  [--bias-k K_eV_per_A2] [--dump BOOL] [--out-dir DIR] \

--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -5,7 +5,7 @@
 
 ## Usage
 ```bash
-pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} -q CHARGE -m MULT \
+pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} [-q CHARGE] [--ligand-charge <number|'RES:Q,...'>] -m MULT \
                       [--mep-mode {gsm|dmf}] [--freeze-links BOOL] [--max-nodes N] [--max-cycles N] \
                       [--climb BOOL] [--dump BOOL] [--thresh PRESET] \
                       [--out-dir DIR] [--args-yaml FILE] \

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -5,7 +5,7 @@ Construct a continuous minimum-energy path (MEP) across **two or more** structur
 
 ## Usage
 ```bash
-pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--multiplicity 2S+1]
+pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb [-q CHARGE] [--ligand-charge <number|'RES:Q,...'>] [--multiplicity 2S+1]
                          [--mep-mode {gsm|dmf}] [--freeze-links BOOL] [--thresh PRESET]
                          [--refine-mode {peak|minima}]
                          [--max-nodes N] [--max-cycles N] [--climb BOOL]

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -14,7 +14,7 @@ relaxed result.
 
 ## Usage
 ```bash
-pdb2reaction scan -i INPUT.{pdb|xyz|trj|...} -q CHARGE [-m MULT] \
+pdb2reaction scan -i INPUT.{pdb|xyz|trj|...} -q CHARGE [--ligand-charge <number|'RES:Q,...'>] [-m MULT] \
                   --scan-lists '[(i,j,targetÅ), ...]' [options]
                   [--convert-files {True|False}]
 ```

--- a/docs/scan2d.md
+++ b/docs/scan2d.md
@@ -13,7 +13,7 @@ or RFOptimizer when `--opt-mode heavy`.
 
 ## Usage
 ```bash
-pdb2reaction scan2d -i INPUT.{pdb|xyz|trj|...} -q CHARGE [-m MULT] \
+pdb2reaction scan2d -i INPUT.{pdb|xyz|trj|...} -q CHARGE [--ligand-charge <number|'RES:Q,...'>] [-m MULT] \
                     --scan-list '[(i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ)]' [options]
                     [--convert-files {True|False}]
 ```

--- a/docs/scan3d.md
+++ b/docs/scan3d.md
@@ -16,7 +16,7 @@ option to load the CSV after the scan finishes and changing `--zmin` and `--zmax
 
 ## Usage
 ```bash
-pdb2reaction scan3d -i INPUT.{pdb|xyz|trj|...} -q CHARGE [-m MULT] \
+pdb2reaction scan3d -i INPUT.{pdb|xyz|trj|...} -q CHARGE [--ligand-charge <number|'RES:Q,...'>] [-m MULT] \
                     --scan-list '[(i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ)]' [options] \
                     [--convert-files {True|False}]
 ```

--- a/docs/tsopt.md
+++ b/docs/tsopt.md
@@ -15,7 +15,7 @@ companions and Gaussian templates receive multi-geometry `.gjf` exports.
 
 ## Usage
 ```bash
-pdb2reaction tsopt -i INPUT.{pdb|xyz|trj|...} [-q CHARGE] [-m 2S+1] \
+pdb2reaction tsopt -i INPUT.{pdb|xyz|trj|...} [-q CHARGE] [--ligand-charge <number|'RES:Q,...'>] [-m 2S+1] \
                     [--opt-mode light|heavy] \
                     [--freeze-links {True|False}] [--max-cycles N] [--thresh PRESET] \
                     [--dump {True|False}] [--out-dir DIR] [--args-yaml FILE] \

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -6,7 +6,7 @@ dft — Single-point DFT calculation
 
 Usage (CLI)
 -----------
-    pdb2reaction dft -i INPUT.{pdb|xyz|gjf|...} [-q <charge>] [-m <multiplicity>] \
+    pdb2reaction dft -i INPUT.{pdb|xyz|gjf|...} [-q <charge>] [--ligand-charge <number|'RES:Q,...'>] [-m <multiplicity>] \
         [--func-basis 'FUNC/BASIS'] [--max-cycle <int>] [--conv-tol <hartree>] \
         [--grid-level <int>] [--out-dir <dir>] [--engine {gpu|cpu|auto}] \
         [--convert-files {True|False}] [--args-yaml <file>]

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -6,7 +6,7 @@ freq — Vibrational frequency analysis, mode export, and thermochemistry
 
 Usage (CLI)
 -----------
-    pdb2reaction freq -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [-m <spin>] \
+    pdb2reaction freq -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [--ligand-charge <number|'RES:Q,...'>] [-m <spin>] \
         [--freeze-links {True|False}] [--max-write <int>] \
         [--amplitude-ang <float>] [--n-frames <int>] [--sort {value|abs}] \
         [--out-dir <dir>] [--args-yaml <file>] [--temperature <K>] \

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -6,7 +6,7 @@ irc — IRC calculations with the EulerPC algorithm
 
 Usage (CLI)
 -----------
-    pdb2reaction irc -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [-m <multiplicity>] \
+    pdb2reaction irc -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [--ligand-charge <number|'RES:Q,...'>] [-m <multiplicity>] \
         [--max-cycles <int>] [--step-size <float>] [--root <int>] \
         [--forward {True|False}] [--backward {True|False}] \
         [--freeze-links {True|False}] [--convert-files {True|False}] \

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -6,7 +6,7 @@ opt — Single-structure geometry optimization (LBFGS or RFO)
 
 Usage (CLI)
 -----------
-    pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [-m <multiplicity>] \
+    pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [--ligand-charge <number|'RES:Q,...'>] [-m <multiplicity>] \
         [--opt-mode {light|heavy}] [--freeze-links {True|False}] \
         [--dist-freeze '[(I,J,TARGET_A), ...]'] [--one-based {True|False}] \
         [--bias-k <float>] [--dump {True|False}] [--out-dir <dir>] \

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -6,7 +6,7 @@ path_opt — Minimum-energy path (MEP) optimization via GSM or DMF with a UMA ca
 
 Usage (CLI)
 -----------
-    pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} -q CHARGE -m MULT \
+    pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} [-q CHARGE] [--ligand-charge <number|'RES:Q,...'>] -m MULT \
                         [--mep-mode {gsm|dmf}] [--freeze-links BOOL] [--max-nodes N] [--max-cycles N] \
                         [--climb BOOL] [--dump BOOL] [--thresh PRESET] \
                         [--convert-files {True|False}] \

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -6,7 +6,7 @@ path_search — Recursive MEP segmentation (GSM/DMF) to build a continuous multi
 
 Usage (CLI)
 -----------
-    pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb -q CHARGE [--multiplicity 2S+1]
+    pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb [-q CHARGE] [--ligand-charge <number|'RES:Q,...'>] [--multiplicity 2S+1]
                             [--mep-mode {gsm|dmf}] [--freeze-links BOOL] [--thresh PRESET]
                             [--refine-mode peak|minima]
                             [--max-nodes N] [--max-cycles N] [--climb BOOL]

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -6,7 +6,7 @@ scan — Bond‑length–driven staged scan with harmonic distance restraints an
 
 Usage (CLI)
 -----------
-    pdb2reaction scan -i INPUT.{pdb|xyz|trj|...} [-q <charge>] \
+    pdb2reaction scan -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [--ligand-charge <number|'RES:Q,...'>] \
         [--scan-lists '[(I,J,TARGET_ANG), ...]' ...] [-m <spin>] \
         [--one-based {True|False}] [--max-step-size <float>] \
         [--bias-k <float>] [--relax-max-cycles <int>] \

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -6,7 +6,7 @@ scan2d — Two-distance 2D scan with harmonic restraints
 
 Usage (CLI)
 -----------
-    pdb2reaction scan2d -i INPUT.{pdb,xyz,trj,...} [-q <charge>] [-m <multiplicity>] \
+    pdb2reaction scan2d -i INPUT.{pdb,xyz,trj,...} [-q <charge>] [--ligand-charge <number|'RES:Q,...'>] [-m <multiplicity>] \
         --scan-list '[(I1,J1,LOW1,HIGH1),(I2,J2,LOW2,HIGH2)]' \
         [--one-based {True|False}] \
         [--max-step-size FLOAT] \

--- a/pdb2reaction/scan3d.py
+++ b/pdb2reaction/scan3d.py
@@ -6,7 +6,7 @@ scan3d — Three-distance 3D scan with harmonic restraints
 
 Usage (CLI)
 -----------
-    pdb2reaction scan3d -i INPUT.{pdb,xyz,trj,...} [-q CHARGE] \
+    pdb2reaction scan3d -i INPUT.{pdb,xyz,trj,...} [-q CHARGE] [--ligand-charge <number|'RES:Q,...'>] \
         [-m MULTIPLICITY] \
         --scan-list '[(I1,J1,LOW1,HIGH1),(I2,J2,LOW2,HIGH2),(I3,J3,LOW3,HIGH3)]' \
         [--one-based {True|False}] \

--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -6,7 +6,7 @@ tsopt — Transition-state optimization CLI
 
 Usage (CLI)
 -----------
-    pdb2reaction tsopt -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [-m <multiplicity>] \
+    pdb2reaction tsopt -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [--ligand-charge <number|'RES:Q,...'>] [-m <multiplicity>] \
         [--opt-mode {light|heavy}] \
         [--freeze-links {True|False}] [--max-cycles <int>] [--dump {True|False}] \
         [--out-dir <dir>] [--args-yaml <file>] \


### PR DESCRIPTION
### Motivation
- Ensure the CLI Usage text documents the supported `--ligand-charge` flag so users know they can supply a ligand-derived charge hint as an alternative to `-q/--charge`.
- Reflect that charge can be inferred from a ligand mapping for enzyme–substrate workflows, so some subcommands should allow omitting explicit `-q` when `--ligand-charge` is provided.
- Keep the markdown manuals and inline Python docstrings consistent with runtime charge-resolution logic.
- Improve discoverability of the `--ligand-charge` option in both one-line Usage examples and longer CLI option tables.

### Description
- Added `--ligand-charge <number|'RES:Q,...'>` to the Usage blocks in the affected markdown files and to the CLI usage/docstrings in the corresponding modules, updating both `docs/*.md` and `pdb2reaction/*.py` files.
- Made the `-q/--charge` argument optional in the Usage lines for `path-opt` and `path-search` to reflect that `--ligand-charge` can be provided instead.
- Files updated include `docs/opt.md`, `docs/tsopt.md`, `docs/path_opt.md`, `docs/dft.md`, `docs/scan3d.md`, `docs/irc.md`, `docs/scan.md`, `docs/path_search.md`, `docs/scan2d.md`, `docs/freq.md` and the matching `pdb2reaction` modules: `opt.py`, `tsopt.py`, `path_opt.py`, `dft.py`, `scan3d.py`, `irc.py`, `scan.py`, `path_search.py`, `scan2d.py`, and `freq.py`.
- Commit was created updating the documentation and inline usage strings to keep docs consistent with existing runtime behavior.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696182af31d0832d8d8f85a4f90d40cd)