### PR TITLE
Set tsopt default convergence preset to `baker` (code + docs)

### DIFF
--- a/docs/tsopt.md
+++ b/docs/tsopt.md
@@ -84,7 +84,7 @@ pdb2reaction tsopt -i ts_cand.pdb -q 0 -m 1 --opt-mode heavy \
 | `--opt-mode TEXT` | Light/Heavy aliases listed above. | `light` |
 | `--dump BOOL` | Explicit `True`/`False`. Dump trajectories. | `False` |
 | `--out-dir TEXT` | Output directory. | `./result_tsopt/` |
-| `--thresh TEXT` | Override convergence preset (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | _None_ |
+| `--thresh TEXT` | Override convergence preset (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | `baker` (if omitted) |
 | `--hessian-calc-mode CHOICE` | UMA Hessian mode (`Analytical` or `FiniteDifference`). | _None_ (uses YAML/default of `FiniteDifference`) |
 | `--convert-files {True|False}` | Toggle XYZ/TRJ → PDB/GJF companions for PDB or Gaussian inputs. | `True` |
 | `--args-yaml FILE` | YAML overrides (`geom`, `calc`, `opt`, `hessian_dimer`, `rsirfo`). | _None_ |
@@ -139,7 +139,7 @@ calc:
   hessian_calc_mode: FiniteDifference   # Hessian mode selection
   return_partial_hessian: false         # full Hessian (avoids shape mismatches)
 opt:
-  thresh: gau                # convergence preset (Gaussian/Baker-style)
+  thresh: baker              # convergence preset (Gaussian/Baker-style)
   max_cycles: 10000          # optimizer cycle cap
   print_every: 100           # logging stride
   min_step_norm: 1.0e-08     # minimum norm for step acceptance
@@ -158,7 +158,7 @@ opt:
   out_dir: ./result_tsopt/   # output directory
 hessian_dimer:
   thresh_loose: gau_loose    # loose convergence preset
-  thresh: gau                # main convergence preset
+  thresh: baker              # main convergence preset
   update_interval_hessian: 500   # Hessian rebuild cadence
   neg_freq_thresh_cm: 5.0    # negative frequency threshold (cm^-1)
   flatten_amp_ang: 0.1       # flattening amplitude (Å)
@@ -190,7 +190,7 @@ hessian_dimer:
     write_orientations: true  # write rotation orientations
     forward_hessian: true     # propagate Hessian forward
   lbfgs:
-    thresh: gau                # LBFGS convergence preset
+    thresh: baker              # LBFGS convergence preset
     max_cycles: 10000          # iteration limit
     print_every: 100           # logging stride
     min_step_norm: 1.0e-08     # minimum accepted step norm
@@ -216,7 +216,7 @@ hessian_dimer:
     mu_reg: null               # regularization strength
     max_mu_reg_adaptions: 10   # cap on mu adaptations
 rsirfo:
-  thresh: gau                # RS-IRFO convergence preset
+  thresh: baker              # RS-IRFO convergence preset
   max_cycles: 10000          # iteration cap
   print_every: 100           # logging stride
   min_step_norm: 1.0e-08     # minimum accepted step norm

--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -581,7 +581,7 @@ class HessianDimer:
                  fn: str,
                  out_dir: str = "./result_dimer",
                  thresh_loose: str = "gau_loose",
-                 thresh: str = "gau",
+                 thresh: str = "baker",
                  update_interval_hessian: int = 100,
                  neg_freq_thresh_cm: float = 10.0,
                  flatten_amp_ang: float = 0.20,
@@ -1113,7 +1113,7 @@ LBFGS_TS_KW: Dict[str, Any] = dict(_LBFGS_KW)
 # HessianDimer defaults (CLI-level)
 hessian_dimer_KW = {
     "thresh_loose": "gau_loose",      # loose threshold preset for first pass
-    "thresh": "gau",                  # main threshold preset for TS search
+    "thresh": "baker",                # main threshold preset for TS search
     "update_interval_hessian": 500,   # LBFGS cycles per Hessian refresh for direction
     "neg_freq_thresh_cm": 5.0,        # treat ν < -this as imaginary (cm^-1)
     "flatten_amp_ang": 0.10,          # mass-scaled displacement amplitude for flattening (Å)
@@ -1131,6 +1131,7 @@ hessian_dimer_KW = {
 # RSIRFO (TS Hessian optimizer) defaults (subset; additional keys may be provided)
 RSIRFO_KW: Dict[str, Any] = dict(_RFO_KW)
 RSIRFO_KW.update({
+    "thresh": "baker",
     "roots": [0],               # mode indices to follow uphill
     "hessian_ref": None,        # reference Hessian file (HDF5)
     "rx_modes": None,           # reaction-mode definitions for projection
@@ -1358,7 +1359,7 @@ def cli(
                 fn=str(geom_input_path),
                 out_dir=str(out_dir_path),
                 thresh_loose=simple_cfg.get("thresh_loose", "gau_loose"),
-                thresh=simple_cfg.get("thresh", "gau"),
+                thresh=simple_cfg.get("thresh", "baker"),
                 update_interval_hessian=int(simple_cfg.get("update_interval_hessian", 200)),
                 neg_freq_thresh_cm=float(simple_cfg.get("neg_freq_thresh_cm", 5.0)),
                 flatten_amp_ang=float(simple_cfg.get("flatten_amp_ang", 0.10)),


### PR DESCRIPTION
### Motivation
- Make the transition-state optimization convergence preset consistent by using the `baker` rule as the default across TS workflows.
- Ensure CLI-level fallbacks and internal defaults match so omitting `--thresh` yields the same behavior everywhere.
- Reflect the new default in user-facing documentation and YAML examples.

### Description
- Changed the `HessianDimer` constructor default `thresh` from `"gau"` to `"baker"` in `pdb2reaction/tsopt.py` (constructor signature).
- Updated the CLI-level defaults: `hessian_dimer_KW["thresh"]` and `RSIRFO_KW["thresh"]` are set to `"baker"` in `pdb2reaction/tsopt.py` and the CLI runner now uses `simple_cfg.get("thresh", "baker")` when constructing `HessianDimer`.
- Updated `docs/tsopt.md` to document `--thresh` default as `baker` and changed YAML example defaults for `opt`, `hessian_dimer`, `lbfgs`, and `rsirfo` to `baker`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69625178278c832daeccae48fd6d7e5e)