### PR TITLE
Rename path_search pocket ref option to --ref-pdb and propagate through workflows

### DIFF
--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -100,6 +100,7 @@ from .utils import (
     format_geom_for_echo,
     format_elapsed,
     prepare_input_structure,
+    apply_ref_pdb_override,
     resolve_charge_spin_or_raise,
     set_convert_file_enabled,
 )
@@ -391,6 +392,12 @@ def _compute_atomic_spin_densities(mol, mf) -> Dict[str, Optional[List[float]]]:
     help="Convert XYZ/TRJ outputs into PDB/GJF companions based on the input format.",
 )
 @click.option(
+    "--ref-pdb",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    default=None,
+    help="Reference PDB topology to use when the input is XYZ/GJF (keeps XYZ coordinates).",
+)
+@click.option(
     "--func-basis",
     "func_basis",
     type=str,
@@ -421,6 +428,7 @@ def cli(
     ligand_charge: Optional[str],
     spin: Optional[int],
     convert_files: bool,
+    ref_pdb: Optional[Path],
     func_basis: str,
     max_cycle: int,
     conv_tol: float,
@@ -431,6 +439,7 @@ def cli(
 ) -> None:
     set_convert_file_enabled(convert_files)
     prepared_input = prepare_input_structure(input_path)
+    apply_ref_pdb_override(prepared_input, ref_pdb)
     geom_input_path = prepared_input.geom_path
     charge, spin = resolve_charge_spin_or_raise(
         prepared_input,

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -14,7 +14,7 @@ Usage (CLI)
                             [--convert-files {True|False}]
                             [--out-dir DIR] [--preopt BOOL]
                             [--align {True|False}] [--ref-full-pdb FILE ...]
-                            [--pocket-ref-pdb FILE ...]
+                            [--ref-pdb FILE ...]
                             [--args-yaml FILE]
 
 Core inputs (strongly recommended):
@@ -52,7 +52,7 @@ Recommended/common:
         (gau_loose|gau|gau_tight|gau_vtight|baker|never).
     --ref-full-pdb PATH [...]
         Full template PDB(s) for final merge (see Notes).
-    --pocket-ref-pdb PATH [...]
+    --ref-pdb PATH [...]
         Pocket reference PDB(s) for the final merge when --input uses XYZ/GJF.
     --out-dir PATH
         Output directory; default ./result_path_search/
@@ -97,7 +97,7 @@ Workflow
    - If the interface itself shows covalent changes, insert a **new recursive segment** instead of a bridge.
 6) Optional alignment & merge: after pre‑opt, when `--align` (default), rigidly co‑align all inputs and
    refine `freeze_atoms` to match the first input. If `--ref-full-pdb` is supplied, merge pocket trajectories
-   into full templates and annotate segments (requires PDB pocket inputs or `--pocket-ref-pdb`).
+   into full templates and annotate segments (requires PDB pocket inputs or `--ref-pdb`).
 
 Outputs (& Directory Layout)
 ----------------------------
@@ -1727,7 +1727,7 @@ def _merge_final_and_write(final_images: List[Any],
     if pocket_ref_pdbs is None:
         pocket_ref_pdbs = pocket_inputs
     if len(pocket_ref_pdbs) != len(pocket_inputs):
-        raise click.BadParameter("--pocket-ref-pdb must match the number of --input after preprocessing.")
+        raise click.BadParameter("--ref-pdb must match the number of --input after preprocessing.")
 
     structs, aligned_coords, _atoms_list, keymaps = _load_structures_and_chain_align(ref_pdbs)
 
@@ -2024,7 +2024,7 @@ def _merge_final_and_write(final_images: List[Any],
           "in the final merge (you may pass just one).")
 )
 @click.option(
-    "--pocket-ref-pdb",
+    "--ref-pdb",
     "pocket_ref_pdb_paths",
     type=click.Path(path_type=Path, exists=True, dir_okay=False),
     multiple=True,
@@ -2065,7 +2065,7 @@ def cli(
     _PRIMARY_GJF_TEMPLATE = None
     command_str = " ".join(sys.argv)
 
-    # Robustly accept both styles for -i/--input, --ref-full-pdb, and --pocket-ref-pdb
+    # Robustly accept both styles for -i/--input, --ref-full-pdb, and --ref-pdb
     def _collect_option_values(argv: Sequence[str], names: Sequence[str]) -> List[str]:
         vals: List[str] = []
         i = 0
@@ -2108,7 +2108,7 @@ def cli(
             ref_parsed.append(p)
         ref_pdb_paths = tuple(ref_parsed)
 
-    pocket_ref_vals = _collect_option_values(argv_all, ("--pocket-ref-pdb",))
+    pocket_ref_vals = _collect_option_values(argv_all, ("--ref-pdb",))
     if pocket_ref_vals:
         pocket_ref_parsed: List[Path] = []
         for tok in pocket_ref_vals:
@@ -2116,7 +2116,7 @@ def cli(
             if (not p.exists()) or p.is_dir():
                 raise click.BadParameter(
                     f"Pocket reference PDB path '{tok}' not found or is a directory. "
-                    f"When using '--pocket-ref-pdb', multiple files may follow a single option."
+                    f"When using '--ref-pdb', multiple files may follow a single option."
                 )
             pocket_ref_parsed.append(p)
         pocket_ref_pdb_paths = tuple(pocket_ref_parsed)
@@ -2144,7 +2144,7 @@ def cli(
                     raise click.BadParameter("--ref-full-pdb must be given for each --input (same count and order). "
                                              "Alternatively, use --align to allow using only the first reference PDB for all pairs.")
             if pocket_ref_pdb_paths and len(pocket_ref_pdb_paths) != len(input_paths):
-                raise click.BadParameter("--pocket-ref-pdb must be given for each --input (same count and order).")
+                raise click.BadParameter("--ref-pdb must be given for each --input (same count and order).")
 
         p_list = [Path(p) for p in input_paths]
         prepared_inputs = [prepare_input_structure(p) for p in p_list]

--- a/pdb2reaction/scan3d.py
+++ b/pdb2reaction/scan3d.py
@@ -163,6 +163,7 @@ from .utils import (
     merge_freeze_atom_indices,
     normalize_choice,
     prepare_input_structure,
+    apply_ref_pdb_override,
     resolve_charge_spin_or_raise,
     set_convert_file_enabled,
     convert_xyz_like_outputs,
@@ -552,6 +553,12 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
     help="Convert XYZ/TRJ outputs into PDB/GJF companions based on the input format.",
 )
 @click.option(
+    "--ref-pdb",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    default=None,
+    help="Reference PDB topology to use when the input is XYZ/GJF (keeps XYZ coordinates).",
+)
+@click.option(
     "--out-dir",
     type=str,
     default="./result_scan3d/",
@@ -625,6 +632,7 @@ def cli(
     freeze_links: bool,
     dump: bool,
     convert_files: bool,
+    ref_pdb: Optional[Path],
     out_dir: str,
     csv_path: Optional[Path],
     thresh: Optional[str],
@@ -639,13 +647,16 @@ def cli(
     set_convert_file_enabled(convert_files)
     prepared_input = None
     geom_input_path = None
+    source_path = None
     if csv_path is None:
         if input_path is None:
             raise click.ClickException("-i/--input is required unless --csv is provided.")
         if scan_list_raw is None:
             raise click.ClickException("--scan-list is required unless --csv is provided.")
         prepared_input = prepare_input_structure(input_path)
+        apply_ref_pdb_override(prepared_input, ref_pdb)
         geom_input_path = prepared_input.geom_path
+        source_path = prepared_input.source_path
 
         charge, spin = resolve_charge_spin_or_raise(
             prepared_input,
@@ -721,8 +732,8 @@ def cli(
         d2_label_csv = None
         d3_label_csv = None
         if csv_path is None:
-            if input_path.suffix.lower() == ".pdb":
-                pdb_atom_meta = load_pdb_atom_metadata(input_path)
+            if source_path and source_path.suffix.lower() == ".pdb":
+                pdb_atom_meta = load_pdb_atom_metadata(source_path)
 
             (
                 (i1, j1, low1, high1),
@@ -758,8 +769,8 @@ def cli(
         final_dir = out_dir_path
 
         ref_pdb_path = None
-        if csv_path is None and input_path.suffix.lower() == ".pdb":
-            ref_pdb_path = input_path
+        if csv_path is None and source_path and source_path.suffix.lower() == ".pdb":
+            ref_pdb_path = source_path
 
         # ==== Either load existing surface.csv, or run the full 3D scan ====
         if csv_path is not None:
@@ -778,8 +789,8 @@ def cli(
             _ensure_dir(tmp_opt_dir)
 
             freeze = merge_freeze_atom_indices(geom_cfg)
-            if freeze_links and input_path.suffix.lower() == ".pdb":
-                detected = detect_freeze_links_safe(input_path)
+            if freeze_links and source_path and source_path.suffix.lower() == ".pdb":
+                detected = detect_freeze_links_safe(source_path)
                 if detected:
                     freeze = merge_freeze_atom_indices(geom_cfg, detected)
                     if freeze:

--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -179,6 +179,7 @@ from .utils import (
     merge_freeze_atom_indices,
     normalize_choice,
     prepare_input_structure,
+    apply_ref_pdb_override,
     resolve_charge_spin_or_raise,
     set_convert_file_enabled,
     convert_xyz_like_outputs,
@@ -1200,6 +1201,12 @@ RSIRFO_KW.update({
     show_default=True,
     help="Convert XYZ/TRJ outputs into PDB/GJF companions based on the input format.",
 )
+@click.option(
+    "--ref-pdb",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    default=None,
+    help="Reference PDB topology to use when the input is XYZ/GJF (keeps XYZ coordinates).",
+)
 @click.option("--max-cycles", type=int, default=10000, show_default=True, help="Max cycles / steps cap")
 @click.option(
     "--flatten-imag-mode",
@@ -1247,6 +1254,7 @@ def cli(
     spin: Optional[int],
     freeze_links: bool,
     convert_files: bool,
+    ref_pdb: Optional[Path],
     max_cycles: int,
     flatten_imag_mode: bool,
     opt_mode: str,
@@ -1258,6 +1266,7 @@ def cli(
 ) -> None:
     set_convert_file_enabled(convert_files)
     prepared_input = prepare_input_structure(input_path)
+    apply_ref_pdb_override(prepared_input, ref_pdb)
     geom_input_path = prepared_input.geom_path
     source_path = prepared_input.source_path
     charge, spin = resolve_charge_spin_or_raise(

--- a/pdb2reaction/utils.py
+++ b/pdb2reaction/utils.py
@@ -761,6 +761,42 @@ def prepare_input_structure(path: Path) -> PreparedInputStructure:
     )
 
 
+def _read_atom_count(path: Path, format_hint: Optional[str] = None) -> int:
+    try:
+        if format_hint is not None:
+            atoms = read(path, index=0, format=format_hint)
+        else:
+            atoms = read(path, index=0)
+    except Exception as e:
+        raise click.ClickException(f"Failed to read '{path}' for --ref-pdb validation: {e}")
+    return len(atoms)
+
+
+def _validate_ref_pdb_atom_count(geom_path: Path, ref_pdb_path: Path) -> None:
+    geom_format = "xyz" if geom_path.suffix.lower() in {".xyz", ".trj"} else None
+    geom_count = _read_atom_count(geom_path, geom_format)
+    ref_count = _read_atom_count(ref_pdb_path, "pdb")
+    if geom_count != ref_count:
+        raise click.ClickException(
+            f"--ref-pdb atom count ({ref_count}) does not match input ({geom_count})."
+        )
+
+
+def apply_ref_pdb_override(
+    prepared_input: PreparedInputStructure,
+    ref_pdb: Optional[Path],
+) -> Optional[Path]:
+    """Use a reference PDB topology while keeping XYZ coordinates for geometry loading."""
+    if ref_pdb is None:
+        return None
+    ref_pdb = Path(ref_pdb).resolve()
+    if ref_pdb.suffix.lower() != ".pdb":
+        raise click.BadParameter("--ref-pdb must be a .pdb file.")
+    _validate_ref_pdb_atom_count(prepared_input.geom_path, ref_pdb)
+    prepared_input.source_path = ref_pdb
+    return ref_pdb
+
+
 def fill_charge_spin_from_gjf(
     charge: Optional[int],
     spin: Optional[int],


### PR DESCRIPTION
### Motivation
- Standardize the pocket reference option name to `--ref-pdb` and use it consistently in help text, parsing, and validation. 
- Allow workflows that operate on pocket-only XYZ/GJF inputs to forward a full-system PDB template for freeze-atom detection and PDB/GJF conversion. 
- Preserve high-precision XYZ coordinates while still providing a PDB topology for downstream steps that require chain/atom metadata. 
- Avoid confusion between similarly named flags by unifying callers and subcommands on a single `--ref-pdb` flag.

### Description
- Renamed the `--pocket-ref-pdb` occurrences to `--ref-pdb` in the `path_search` CLI usage, option definition, parsing, and validation logic in `pdb2reaction/path_search.py` and updated the error messages. 
- Updated the `all` workflow to forward pocket reference PDBs as `--ref-pdb` when invoking `path_search` and to pass `--ref-pdb` to the `scan` invocation when the scan input is a PDB. 
- Added `apply_ref_pdb_override` and validation helpers in `pdb2reaction/utils.py` to validate a provided `--ref-pdb` and swap the prepared input `source_path` while preserving geometry coordinates. 
- Added `--ref-pdb` options and `apply_ref_pdb_override` usage (and propagated `ref_pdb` through calls) across multiple CLI modules (`scan`, `scan2d`, `scan3d`, `tsopt`, `irc`, `freq`, `dft`, `opt`, etc.) so the reference topology is honored for freeze-atom detection, conversions, and downstream calculations.

### Testing
- No automated tests or CI jobs were executed for this change. 
- No unit tests were added or run as part of this update. 
- The change includes textual/help and runtime-path modifications and should be covered by functional integration tests in CI before release. 
- Manual/local invocation testing was not requested or performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69637edd8e7c832dbd8d2e1eae7f2aa2)