### PR TITLE
Add ΔE to flatten loop log output

### DIFF
--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -861,7 +861,7 @@ class HessianDimer:
         amp_bohr = self.flatten_amp_ang / BOHR2ANG
 
         # ensure energy reference is set up
-        _ = _calc_energy(self.geom, self.uma_kwargs)
+        E_ref = _calc_energy(self.geom, self.uma_kwargs)
 
         # work in Bohr coordinates
         for idx in targets:
@@ -888,7 +888,11 @@ class HessianDimer:
             use_plus = E_plus <= E_minus
             self.geom.coords = (plus if use_plus else minus).reshape(-1)
             E_keep = E_plus if use_plus else E_minus
-            print(f"[Flatten] mode={idx} freq={freqs_cm[idx]:+.2f} cm^-1 E_disp={E_keep:.8f} Ha")
+            delta_e = E_keep - E_ref
+            print(
+                f"[Flatten] mode={idx} freq={freqs_cm[idx]:+.2f} cm^-1 "
+                f"E_disp={E_keep:.8f} Ha \u0394E={delta_e:+.8f} Ha"
+            )
 
         if torch.cuda.is_available():
             torch.cuda.empty_cache()


### PR DESCRIPTION
### Motivation
- Make the flatten-mode displacement logging more informative by reporting the energy change relative to the starting geometry.
- Provide a clear numeric ΔE alongside the displaced energy to help diagnose whether a mode displacement lowered or raised the energy.

### Description
- Record a reference energy by calling `_calc_energy(self.geom, self.uma_kwargs)` before probing displacements in `_flatten_once_with_modes` in `pdb2reaction/tsopt.py`.
- Compute `delta_e = E_keep - E_ref` after choosing the lower-energy side and include it in the log line.
- Update the printed message to show `E_disp` and `ΔE` (signed, 8 decimal places) in Hartree units.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963b0f1a858832dba6a6db1571395a8)