### PR TITLE
Add `--opt-mode-post` CLI flag to control post-processing optimizer mode in `all`

### DIFF
--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -13,7 +13,8 @@ Usage (CLI)
     pdb2reaction all -i INPUT1 [INPUT2 ...] [-c <substrate-spec>] \
         [--ligand-charge <number|'RES:Q,...'>] [-q/--charge <forced_net_charge>] [-m/--mult <2S+1>] \
         [--freeze-links {True|False}] [--mep-mode {gsm|dmf}] [--max-nodes <int>] [--max-cycles <int>] \
-        [--climb {True|False}] [--opt-mode {light|heavy}] [--dump {True|False}] \
+        [--climb {True|False}] [--opt-mode {light|heavy}] [--opt-mode-post {light|heavy}] \
+        [--dump {True|False}] \
         [--convert-files {True|False}] [--refine-path {True|False}] [--thresh <preset>] \
         [--thresh-post <preset>] \
         [--args-yaml <file>] [--preopt {True|False}] \
@@ -141,8 +142,8 @@ Pipeline overview
         • Run **IRC (EulerPC)** from the optimized TS,
         • Map IRC endpoints onto the segment’s left/right MEP endpoints (bond-state matching first,
           RMSD fallback) to assign backward/forward consistently across segments,
-        • Optimize both IRC endpoints to minima (LBFGS/RFO depending on ``--opt-mode``; threshold preset
-          controlled by ``--thresh-post``, default ``baker``),
+        • Optimize both IRC endpoints to minima (LBFGS/RFO depending on ``--opt-mode-post`` if set,
+          otherwise ``--opt-mode``; threshold preset controlled by ``--thresh-post``, default ``baker``),
         • Use these optimized minima as the final R and P for downstream analyses.
         • Write per-segment UMA energy diagram: ``post_seg_XX/energy_diagram_UMA.png``.
         • Copy the TS structure to ``<out-dir>/ts_seg_XX.pdb`` (when a PDB representation is available)
@@ -207,13 +208,15 @@ Inputs
 Forwarded / relevant options
 ----------------------------
   - MEP search: ``--mult``, ``--freeze-links``, ``--mep-mode``, ``--max-nodes``, ``--max-cycles``,
-    ``--climb``, ``--opt-mode``, ``--dump``, ``--thresh``, ``--preopt``, ``--args-yaml``, ``--out-dir``.
+    ``--climb``, ``--opt-mode``, ``--opt-mode-post``, ``--dump``, ``--thresh``, ``--preopt``, ``--args-yaml``,
+    ``--out-dir``.
   - File conversion: ``--convert-files {True|False}`` toggles conversion of XYZ/TRJ outputs into
     PDB/GJF companions when possible.
   - Scan (single-structure): inherits charge/spin and shared knobs; per-stage/scan overrides include
     ``--scan-out-dir``, ``--scan-one-based``, ``--scan-max-step-size``, ``--scan-bias-k``,
     ``--scan-relax-max-cycles``, ``--scan-preopt``, ``--scan-endopt``.
   - TS optimization / IRC: ``--tsopt``, ``--tsopt-max-cycles``, ``--tsopt-out-dir`` and shared knobs above.
+    ``--opt-mode-post`` (if set; otherwise ``--opt-mode``) controls TSOPT and post-IRC endpoint optimizers.
     ``--hessian-calc-mode`` is forwarded to TSOPT and freq.
   - Frequency analysis: ``--freq-out-dir``, ``--freq-max-write``, ``--freq-amplitude-ang``,
     ``--freq-n-frames``, ``--freq-sort``, ``--freq-temperature``, ``--freq-pressure`` plus shared knobs.
@@ -2007,6 +2010,16 @@ def _irc_and_match(
     ),
 )
 @click.option(
+    "--opt-mode-post",
+    type=click.Choice(["light", "heavy"], case_sensitive=False),
+    default=None,
+    show_default=False,
+    help=(
+        "Optimizer mode for post-processing TSOPT/endpoint optimizations. "
+        "If omitted, falls back to --opt-mode."
+    ),
+)
+@click.option(
     "--dump",
     type=click.BOOL,
     default=False,
@@ -2302,6 +2315,7 @@ def cli(
     max_cycles: int,
     climb: bool,
     opt_mode: str,
+    opt_mode_post: Optional[str],
     dump: bool,
     convert_files: bool,
     refine_path: bool,
@@ -2390,7 +2404,8 @@ def cli(
             "or use a single structure with --scan-lists, or a single structure with --tsopt True."
         )
 
-    tsopt_opt_mode_default = opt_mode.lower()
+    opt_mode_post_use = opt_mode_post.lower() if opt_mode_post is not None else opt_mode.lower()
+    tsopt_opt_mode_default = opt_mode_post_use
     tsopt_overrides: Dict[str, Any] = {}
     if tsopt_max_cycles is not None:
         tsopt_overrides["max_cycles"] = int(tsopt_max_cycles)


### PR DESCRIPTION
### Motivation

- Allow separate control of optimizer behavior used for TS optimization and endpoint minimizations after IRC, distinct from the main MEP/scan `--opt-mode`.
- Provide a way to run lighter or heavier endpoint optimizations (LBFGS vs RFO) without changing the optimizer used during path search or scans.

### Description

- Added a new CLI option `--opt-mode-post` (choices: `light`/`heavy`) to `pdb2reaction all` and documented its precedence in the command help text and forwarded options.
- The code now computes `opt_mode_post_use = opt_mode_post.lower() if opt_mode_post is not None else opt_mode.lower()` and uses that value by setting `tsopt_opt_mode_default` accordingly so TSOPT and endpoint optimizers honor the override.
- Updated help/usage blocks and forwarded-options listing to mention `--opt-mode-post` and its fallback behavior to `--opt-mode` when omitted.
- All changes are contained in `pdb2reaction/all.py` and wire the new flag into existing TSOPT/post-IRC flows by reusing the existing `tsopt_overrides` and `tsopt_opt_mode_default` plumbing.

### Testing

- No automated tests were executed as part of this change.
- Basic static checks: file `pdb2reaction/all.py` was modified and the CLI option appears in the help text and option parsing paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696629d1e960832da456fcfff2a2c44d)