### PR TITLE
Rename UMA ASE calculator to uma_ase and wire it into DMF MEP flow

### DIFF
--- a/pdb2reaction/uma_pysis.py
+++ b/pdb2reaction/uma_pysis.py
@@ -107,7 +107,7 @@ import torch
 import torch.nn as nn
 from ase import Atoms
 
-from fairchem.core import pretrained_mlip
+from fairchem.core import pretrained_mlip, FAIRChemCalculator
 from fairchem.core.datasets.atomic_data import AtomicData
 from fairchem.core.datasets import data_list_collater
 
@@ -778,6 +778,27 @@ class uma_pysis(Calculator):
             "forces": self._au_forces(res_forces_ev),
             "hessian": self._au_hessian(res["hessian"]),
         }
+
+
+class uma_ase(FAIRChemCalculator):
+    def __init__(
+        self,
+        *,
+        model: str = "uma-s-1p1",
+        device: str = "auto",
+        task_name: str = "omol",
+        workers: int = 1,
+        workers_per_node: int = 1,
+    ):
+        if device == "auto":
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        predictor = pretrained_mlip.get_predict_unit(
+            model,
+            device=device,
+            workers=int(workers),
+            workers_per_node=int(workers_per_node),
+        )
+        super().__init__(predictor, task_name=str(task_name))
 
 
 # ---------- CLI ----------------------------------------


### PR DESCRIPTION
### Motivation
- Provide a clear, reusable ASE-compatible calculator class name and centralize UMA predictor instantiation so DMF path optimization can construct the calculator with parallelization settings.

### Description
- Renamed the UMA ASE calculator class from `UMASECalculator` to `uma_ase` and added a constructor that wraps `pretrained_mlip.get_predict_unit` and calls `super().__init__` with the predictor.
- The new `uma_ase` constructor accepts `model`, `device`, `task_name`, `workers`, and `workers_per_node` and resolves `device=="auto"` to `cuda` or `cpu` via `torch.cuda.is_available()`.
- Updated `pdb2reaction/path_opt.py` to import `uma_ase` and to instantiate `uma_ase(...)` (passing `model`, `device`, `task_name`, `workers`, and `workers_per_node`) instead of calling `pretrained_mlip.get_predict_unit` directly.
- Minor message text adjustment in DMF dependency error to reference `fairchem (via uma_pysis)`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dd90b5328832dbd5451eb425435b6)