### PR TITLE
Unify --scan-list(s) parsing, align docs/CLI for charge/spin, and improve CLI robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pdb2reaction -i R.pdb P.pdb -c 'SAM,GPP' --ligand-charge 'SAM:1,GPP:-3' --tsopt 
 ```
 ---
 
-Given **(i) two or more full protein–ligand PDBs** `.pdb` (R → … → P), **or (ii) one PDB with `--scan-lists`**, **or (iii) one TS candidate with `--tsopt True`**, `pdb2reaction` automatically:
+Given **(i) two or more full protein–ligand PDBs** `.pdb` (R → … → P), **or (ii) one PDB with `--scan-list(s)`**, **or (iii) one TS candidate with `--tsopt True`**, `pdb2reaction` automatically:
 
 - extracts an **active site** around user‑defined substrates to build a **cluster model**,
 - explores **minimum‑energy paths (MEPs)** with path optimization methods such as the Growing String Method (GSM) and Direct Max Flux (DMF),
@@ -207,7 +207,7 @@ This is the recommended mode when you can generate reasonably spaced intermediat
 
 Use this when you only have **one PDB structure**, but you know which inter‑atomic distances should change along the reaction.
 
-Provide a single `-i` together with `--scan-lists`:
+Provide a single `-i` together with `--scan-list(s)`:
 
 **Minimal example**
 
@@ -223,11 +223,11 @@ pdb2reaction -i SINGLE.pdb -c 'SAM,GPP' --scan-lists '[("TYR 285 CA","MMT 309 C1
 
 Key points:
 
-- `--scan-lists` describes **staged distance scans** on the extracted cluster model.
+- `--scan-list(s)` describes **staged distance scans** on the extracted cluster model.
 - Each tuple `(i, j, target_Å)` is:
   - a PDB atom selector string like `'TYR,285,CA'` (**delimiters can be: space/comma/slash/backtick/backslash ` ` `,` `/` `` ` `` `\`**) **or** a 1‑based atom index,  
   - automatically remapped to the cluster-model indices.
-- Supplying one `--scan-lists` literal runs a single scan stage; multiple literals run sequential stages. It’s simplest to pass multiple literals after a single `--scan-lists`.
+- Supplying one `--scan-list(s)` literal runs a single scan stage; multiple literals run sequential stages. It’s simplest to pass multiple literals after a single `--scan-list(s)`.
 - Each stage writes a `stage_XX/result.pdb`, which is treated as a candidate intermediate or product.
 - The default `all` workflow refines the concatenated stages with recursive `path_search`.
 - With `--refine-path False`, it instead performs a single-pass `path-opt` chain and skips the recursive refiner (no merged `mep_w_ref*.pdb`).
@@ -238,7 +238,7 @@ This mode is useful for building reaction paths starting from a single structure
 
 ### 3.3 Single‑structure TSOPT‑only mode
 
-Use this when you already have a **transition state candidate** and only want to refine it and procced following IRC calculation.
+Use this when you already have a **transition state candidate** and only want to refine it and proceed following IRC calculation.
 
 Provide exactly one PDB and enable `--tsopt`:
 
@@ -264,7 +264,7 @@ Behavior:
 
 Outputs such as `energy_diagram_*_all.png` and `irc_plot_all.png` are mirrored under the top‑level `--out-dir`.
 
-> **Important:** Single‑input runs require **either** `--scan-lists` (staged scan → GSM) **or** `--tsopt True` (TSOPT‑only). Supplying only a single `-i` without one of these will not trigger a full workflow.
+> **Important:** Single‑input runs require **either** `--scan-list(s)` (staged scan → GSM) **or** `--tsopt True` (TSOPT‑only). Supplying only a single `-i` without one of these will not trigger a full workflow.
 
 ---
 
@@ -276,7 +276,7 @@ Below are the most commonly used options across workflows.
   Input structures. Interpretation depends on how many you provide:
 
   - **≥ 2 PDBs** → MEP search (GSM by default, DMF with `--mep-mode dmf`) (reactant/intermediates/product).
-  - **1 PDB + `--scan-lists`** → staged scan → GSM.
+  - **1 PDB + `--scan-list(s)`** → staged scan → GSM.
   - **1 PDB + `--tsopt True`** → TSOPT‑only mode.
 
   If `--center/-c` is omitted, cluster extraction is skipped and the **full input structure** is used directly. In this mode, `.xyz` and `.gjf` inputs are also accepted; when using these file formats, omit `--center/-c` and `--ligand-charge`.
@@ -308,9 +308,9 @@ Below are the most commonly used options across workflows.
 - `--mult INT`  
   Spin multiplicity for QM regions (e.g., `--mult 1` for singlet). Used for scan and GSM runs.
 
-> If you have charge and multiplicity in .gjf input, -q and -m can be omitted.
+> If you have charge and multiplicity in a .gjf input, `-q` and `-m` can be omitted.
 
-- `--scan-lists TEXT...`  
+- `--scan-list(s) TEXT...`  
   One or more Python‑style lists describing **staged scans** for single‑input runs. A single literal runs one stage; multiple literals run sequential stages. Example:
 
   ```bash
@@ -339,8 +339,10 @@ Below are the most commonly used options across workflows.
 
   When `--refine-path True` (default) and full‑system PDB templates are available, merged MEP snapshots (`mep_w_ref*.pdb`) are written under `<out-dir>/path_search/`.
 
-- `--opt-mode (If you have charge and multiplicity in .gjf input, -q and -m can be omitted) | heavy`
-  Switch optimization / TS refinement methods between Light (LBFGS and Dimer) and Heavy (Hessian-using RFO and RS-I-RFO) algorithms. Option `light` is recommended.  
+- `--opt-mode {light|heavy}` (default: light)
+  Switch optimization / TS refinement methods between Light (LBFGS and Dimer) and Heavy (Hessian-using RFO and RS-I-RFO) algorithms. Option `light` is recommended.
+- `--opt-mode-post {light|heavy}` (default: heavy)
+  Sets the post-IRC/TSOPT optimizer preset.
 
 - `--hessian-calc-mode Analytical|FiniteDifference`  
   **When you have ample VRAM available, setting `--hessian-calc-mode` to `Analytical` is strongly recommended in `all`, `tsopt`, `freq` and `irc`**

--- a/docs/all.md
+++ b/docs/all.md
@@ -5,9 +5,9 @@
 
 Key modes:
 - **End-to-end ensemble** – Supply ≥2 PDBs/GJFs/XYZ files in reaction order plus a substrate definition; the command extracts pockets, runs GSM/DMF MEP search, merges to the parent PDB(s), and optionally runs TSOPT/freq/DFT per reactive segment.
-- **Single-structure + staged scan** – Provide one structure plus one or more `--scan-lists`; UMA scans on the extracted pocket generate intermediates that become MEP endpoints.
-- A single `--scan-lists` literal runs a one-stage scan; multiple literals run sequential stages, typically supplied as multiple values after one `--scan-lists` flag.
-- **TSOPT-only pocket refinement** – Provide one input structure, omit `--scan-lists`, and enable `--tsopt True`; the command extracts the pocket (if `-c/--center` is given) and only runs TS optimization + IRC (with optional freq/DFT) on that single system.
+- **Single-structure + staged scan** – Provide one structure plus one or more `--scan-list(s)`; UMA scans on the extracted pocket generate intermediates that become MEP endpoints.
+- A single `--scan-list(s)` literal runs a one-stage scan; multiple literals run sequential stages, typically supplied as multiple values after one `--scan-list`/`--scan-lists` flag.
+- **TSOPT-only pocket refinement** – Provide one input structure, omit `--scan-list(s)`, and enable `--tsopt True`; the command extracts the pocket (if `-c/--center` is given) and only runs TS optimization + IRC (with optional freq/DFT) on that single system.
 
 ## Usage
 ```bash
@@ -40,8 +40,8 @@ pdb2reaction all -i reactant.pdb -c 'GPP,MMT' \
    - The **first pocket’s total charge** is propagated to scan/MEP/TSOPT.
 
 2. **Optional staged scan (single-input only)**
-   - Each `--scan-lists` argument is a Python-like list of `(i,j,target_Å)` tuples describing a UMA scan stage. Atom indices refer to the original input ordering (1-based) and are remapped to the pocket ordering. For PDB inputs, `i`/`j` can be integer indices or selector strings like `'TYR,285,CA'`; selectors accept spaces/commas/slashes/backticks/backslashes (` ` `,` `/` `` ` `` `\`) as delimiters and allow unordered tokens (fallback assumes resname, resseq, atom).
-   - A single literal runs a one-stage scan; multiple literals run **sequentially** so stage 2 begins from stage 1's result, and so on. Supplying multiple literals after a single `--scan-lists` flag is the most convenient, intended form.
+   - Each `--scan-list(s)` argument is a Python-like list of `(i,j,target_Å)` tuples describing a UMA scan stage. Atom indices refer to the original input ordering (1-based) and are remapped to the pocket ordering. For PDB inputs, `i`/`j` can be integer indices or selector strings like `'TYR,285,CA'`; selectors accept spaces/commas/slashes/backticks/backslashes (` ` `,` `/` `` ` `` `\`) as delimiters and allow unordered tokens (fallback assumes resname, resseq, atom).
+   - A single literal runs a one-stage scan; multiple literals run **sequentially** so stage 2 begins from stage 1's result, and so on. Supplying multiple literals after a single `--scan-list`/`--scan-lists` flag is the most convenient, intended form.
    - Scan inherits charge/spin, `--freeze-links`, the UMA optimizer preset (`--opt-mode`), `--dump`, `--args-yaml`, and `--preopt`. Overrides such as `--scan-out-dir`, `--scan-one-based`, `--scan-max-step-size`, `--scan-bias-k`, `--scan-relax-max-cycles`, `--scan-preopt`, and `--scan-endopt` apply per run.
    - Stage endpoints (`stage_XX/result.pdb`) become the ordered intermediates that feed the subsequent MEP step.
 
@@ -60,12 +60,12 @@ pdb2reaction all -i reactant.pdb -c 'GPP,MMT' \
    - Shared overrides include `--opt-mode`, `--hessian-calc-mode`, `--tsopt-max-cycles`, `--tsopt-out-dir`, `--freq-*`, `--dft-*`, and `--dft-engine` (GPU-first by default).
    - When you have ample VRAM available, setting `--hessian-calc-mode` to `Analytical` is strongly recommended.
 
-6. **TSOPT-only mode** (single input, `--tsopt True`, no `--scan-lists`)
+6. **TSOPT-only mode** (single input, `--tsopt True`, no `--scan-list(s)`)
    - Skips the MEP/merge stages. Runs `tsopt` on the pocket (or full input if extraction is skipped), performs EulerPC IRC, identifies the higher-energy endpoint as reactant (R), and generates the same set of energy diagrams plus optional freq/DFT outputs.
 
 ### Charge and spin precedence
-- With extraction: pocket charge = inhereted extractor charge calculated from `--ligand-charge`; spin comes from `--mult` (default 1).
-- Without extraction: explicit `-q/--charge` wins. If omitted but `--ligand-charge` is provided, the **full complex is treated as an enzyme–substrate adduct** and `extract.py`’s charge summary logic derives the total charge from the supplied substrate charge(s); otherwise the charge written in `.gjf` or the default is 0. Spin precedence becomes explicit `--mult`, else `.gjf`, else 1.
+- With extraction: pocket charge = inherited extractor charge calculated from `--ligand-charge`; spin comes from `--mult` (default 1).
+- Without extraction: explicit `-q/--charge` wins. If omitted but `--ligand-charge` is provided, the **full complex is treated as an enzyme–substrate adduct** and `extract.py`’s charge summary logic derives the total charge from the supplied substrate charge(s); otherwise the charge written in `.gjf` is used when present. Spin precedence becomes explicit `--mult`, else `.gjf`, else 1.
 
 ### Input expectations
 - Extraction enabled (`-c/--center`): inputs must be **PDB** files so residues can be located.
@@ -75,7 +75,7 @@ pdb2reaction all -i reactant.pdb -c 'GPP,MMT' \
 ## CLI options
 | Option | Description | Default |
 | --- | --- | --- |
-| `-i, --input PATH...` | Two or more full structures in reaction order (single input allowed only with `--scan-lists` or `--tsopt True`). | Required |
+| `-i, --input PATH...` | Two or more full structures in reaction order (single input allowed only with `--scan-list(s)` or `--tsopt True`). | Required |
 | `-c, --center TEXT` | Substrate specification (PDB path, residue IDs like `123,124` / `A:123,B:456`, or residue names like `GPP,MMT`). | Required for extraction |
 | `--out-dir PATH` | Top-level output directory. | `./result_all/` |
 | `-r, --radius FLOAT` | Pocket inclusion cutoff (Å). | `2.6` |
@@ -88,11 +88,11 @@ pdb2reaction all -i reactant.pdb -c 'GPP,MMT' \
 | `--ligand-charge TEXT` | Total charge or residue-specific mapping for unknown residues (recommended). When `-q` is omitted, triggers extract-style charge derivation on the full complex. | `None` |
 | `-q, --charge INT` | Force the total system charge, overriding extractor rounding / `.gjf` metadata / `--ligand-charge` (logs a warning). | _None_ |
 | `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
-| `-m, --mult INT` | Spin multiplicity forwarded to all downstream steps. | `1` |
+| `-m, --mult INT` | Spin multiplicity forwarded to all downstream steps. | GJF template or `1` |
 | `--freeze-links BOOLEAN` | Freeze link parents in pocket PDBs (reused by scan/tsopt/freq). | `True` |
 | `--max-nodes INT` | MEP internal nodes per segment (GSM string images or DMF images). | `10` |
 | `--max-cycles INT` | MEP maximum optimization cycles (GSM/DMF). | `300` |
-| `--climb BOOLEAN` | Enable TS climbing for the first segment in each pair. | `True` |
+| `--climb BOOLEAN` | Enable TS climbing for all GSM segments (bridge segments excluded). | `True` |
 | `--opt-mode [light\|heavy]` | Optimizer preset shared across scan, tsopt, and path_search (light → LBFGS/Dimer, heavy → RFO/RSIRFO). | `light` |
 | `--dump BOOLEAN` | Dump MEP (GSM/DMF) and single-structure trajectories (propagates to scan/tsopt/freq). | `False` |
 | `--convert-files {True|False}` | Global toggle for XYZ/TRJ → PDB/GJF companions when templates are available. | `True` |
@@ -104,20 +104,20 @@ pdb2reaction all -i reactant.pdb -c 'GPP,MMT' \
 | `--dft BOOLEAN` | Run single-point DFT on R/TS/P and build DFT energy + optional DFT//UMA diagrams. | `False` |
 | `--dft-engine [gpu\|cpu\|auto]` | Preferred backend for the DFT stage (`auto` tries GPU then CPU). | `gpu` |
 | `--tsopt-max-cycles INT` | Override `tsopt --max-cycles` for each refinement. | _None_ |
-| `--tsopt-out-dir PATH` | Custom tsopt subdirectory (resolved against `<out-dir>` when relative). | _None_ |
+| `--tsopt-out-dir PATH` | Custom tsopt subdirectory (resolved against the default stage directory when relative). | _None_ |
 | `--freq-out-dir PATH` | Base directory override for freq outputs. | _None_ |
 | `--freq-max-write INT` | Override `freq --max-write`. | _None_ |
 | `--freq-amplitude-ang FLOAT` | Override `freq --amplitude-ang` (Å). | _None_ |
 | `--freq-n-frames INT` | Override `freq --n-frames`. | _None_ |
 | `--freq-sort [value\|abs]` | Override freq mode sorting behavior. | _None_ |
-| `--freq-temperature FLOAT` | Override freq thermochemistry temperature (K). | `298.15` |
-| `--freq-pressure FLOAT` | Override freq thermochemistry pressure (atm). | `1.0` |
+| `--freq-temperature FLOAT` | Override freq thermochemistry temperature (K). | _None_ (uses freq default: 298.15 K) |
+| `--freq-pressure FLOAT` | Override freq thermochemistry pressure (atm). | _None_ (uses freq default: 1.0 atm) |
 | `--dft-out-dir PATH` | Base directory override for DFT outputs. | _None_ |
 | `--dft-func-basis TEXT` | Override `dft --func-basis`. | _None_ |
 | `--dft-max-cycle INT` | Override `dft --max-cycle`. | _None_ |
 | `--dft-conv-tol FLOAT` | Override `dft --conv-tol`. | _None_ |
 | `--dft-grid-level INT` | Override `dft --grid-level`. | _None_ |
-| `--scan-lists TEXT...` | One or more Python-like lists describing staged scans on the extracted pocket (single-input runs only). Each element is `(i,j,target_Å)`; a single literal runs one stage, multiple literals run sequential stages. `i`/`j` can be integer indices or PDB atom selectors like `'TYR,285,CA'` and are remapped internally. | _None_ |
+| `--scan-list(s) TEXT...` | One or more Python-like lists describing staged scans on the extracted pocket (single-input runs only). Each element is `(i,j,target_Å)`; a single literal runs one stage, multiple literals run sequential stages. `i`/`j` can be integer indices or PDB atom selectors like `'TYR,285,CA'` and are remapped internally. | _None_ |
 | `--scan-one-based BOOLEAN` | Force scan indexing to 1-based (`True`) or 0-based (`False`); `None` keeps the scan default (1-based). | _None_ |
 | `--scan-max-step-size FLOAT` | Override scan `--max-step-size` (Å). | _None_ |
 | `--scan-bias-k FLOAT` | Override the harmonic bias strength `k` (eV/Å²). | _None_ |
@@ -131,7 +131,7 @@ out_dir/ (default: ./result_all/)
 ├─ summary.log               # formatted summary for quick inspection
 ├─ summary.yaml              # YAML version summary
 ├─ pockets/                  # Per-input pocket PDBs when extraction runs
-├─ scan/                     # Staged pocket scan results (present when --scan-lists is provided)
+├─ scan/                     # Staged pocket scan results (present when --scan-list(s) is provided)
 ├─ path_search/              # MEP results (GSM/DMF): trajectories, merged PDBs, diagrams, summary.yaml, per-segment folders
 ├─ path_search/tsopt_seg_XX/ # Post-processing outputs (TS optimization, IRC, freq, DFT, diagrams)
 └─ tsopt_single/             # TSOPT-only outputs with IRC endpoints and optional freq/DFT directories
@@ -158,7 +158,7 @@ The YAML is a compact, machine-readable summary. Common top-level keys include:
 - Always provide `--ligand-charge` (numeric or per-residue mapping) when formal charges cannot be inferred so the correct total charge propagates to scan/MEP/TSOPT/DFT.
 - Reference PDB templates for merging are derived automatically from the original inputs; the explicit `--ref-full-pdb` option of `path_search` is intentionally hidden in this wrapper.
 - Energies in diagrams are reported relative to the first state (reactant) in kcal/mol.
-- Omitting `-c/--center` skips extraction and feeds the entire input structures directly to the MEP/tsopt/freq/DFT stages; single-structure runs still require either `--scan-lists` or `--tsopt True`.
+- Omitting `-c/--center` skips extraction and feeds the entire input structures directly to the MEP/tsopt/freq/DFT stages; single-structure runs still require either `--scan-list(s)` or `--tsopt True`.
 - `--args-yaml` lets you coordinate all calculators from a single configuration file. YAML values override CLI flags.
 
 ## YAML configuration (`--args-yaml`)

--- a/docs/dft.md
+++ b/docs/dft.md
@@ -23,7 +23,7 @@ pdb2reaction dft -i input.pdb -q 1 -m 2 --func-basis 'wb97m-v/def2-tzvpd' --max-
 
 ## Workflow
 1. **Input handling** – Any file loadable by `geom_loader` (.pdb/.xyz/.trj/…) is accepted. Coordinates are re-exported as `input_geometry.xyz`.
-2. **Configuration merge** – Defaults → CLI → YAML (`dft` block). YAML overrides take precedence over CLI flags. Charge/multiplicity inherit `.gjf` metadata when present. If `-q` is omitted but `--ligand-charge` is provided, the structure is treated as an enzyme–substrate complex and `extract.py`’s charge summary derives the total charge; explicit `-q` still overrides. Otherwise charge defaults to `0` and multiplicity to `1`.
+2. **Configuration merge** – Defaults → CLI → YAML (`dft` block). YAML overrides take precedence over CLI flags. Charge/multiplicity inherit `.gjf` metadata when present. For non-`.gjf` inputs, `-q/--charge` is required unless `--ligand-charge` is provided (then `extract.py` derives the total charge); explicit `-q` still overrides. Spin defaults to `1` when no template is present.
 3. **SCF build** – `--func-basis` is parsed into functional and basis. Density fitting is enabled automatically with PySCF defaults. `--engine` controls GPU/CPU preference (`gpu` tries GPU4PySCF before falling back; `cpu` forces CPU; `auto` tries GPU then CPU). Nonlocal corrections (e.g., VV10) are not configured explicitly beyond the backend defaults.
 4. **Population analysis & outputs** – After convergence (or failure) the command writes `result.yaml` summarizing energy (Hartree/kcal·mol⁻¹), convergence metadata, timing, backend info, and per-atom Mulliken/meta-Löwdin/IAO charges and spin densities (UKS only for spins). Any failed analysis column is set to `null` with a warning.
 
@@ -78,7 +78,7 @@ Accepts a mapping with top-level key `dft`. YAML values override CLI values.
 - `verbose` (`0`): PySCF verbosity (0–9). The CLI constructs the configuration with this quiet default unless overridden.
 - `out_dir` (`"./result_dft/"`): Output directory root.
 
-_Functional/basis selection defaults to `wb97m-v/def2-tzvpd` but can be overridden on the CLI. Charge/spin inherit `.gjf` template metadata when present. If `-q` is omitted but `--ligand-charge` is provided, the input is treated as an enzyme–substrate complex and `extract.py`’s charge summary computes the total charge; explicit `-q` still overrides. Otherwise charge defaults to `0` and spin to `1`. Set them explicitly for non-default states._
+_Functional/basis selection defaults to `wb97m-v/def2-tzvpd` but can be overridden on the CLI. Charge/spin inherit `.gjf` template metadata when present. For non-`.gjf` inputs, `-q/--charge` is required unless `--ligand-charge` is provided (then `extract.py` derives the total charge); explicit `-q` still overrides. Spin defaults to `1` when no template is present. Set them explicitly for non-default states._
 
 ```yaml
 dft:

--- a/docs/freq.md
+++ b/docs/freq.md
@@ -58,10 +58,10 @@ pdb2reaction freq -i a.xyz -q -1 --args-yaml ./args.yaml --out-dir ./result_freq
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
-| `-q, --charge INT` | Total charge. When omitted, charge can be inferred from `--ligand-charge`; explicit `-q` overrides any derived value. | Required unless a `.gjf` template or `--ligand-charge` supplies it |
+| `-q, --charge INT` | Total charge. Required unless a `.gjf` template or `--ligand-charge` supplies it. | Required when not in template |
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
 | `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
-| `-m, --multiplicity INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
+| `-m, --multiplicity INT` | Spin multiplicity (2S+1). | GJF template or `1` |
 | `--freeze-links BOOL` | PDB-only. Freeze parents of link hydrogens and merge with `geom.freeze_atoms`. | `True` |
 | `--max-write INT` | Number of modes to export. | `10` |
 | `--amplitude-ang FLOAT` | Mode animation amplitude (Å). | `0.8` |
@@ -89,11 +89,11 @@ out_dir/ (default: ./result_freq/)
 - Imaginary modes are reported as negative frequencies. `freq` prints how many were detected
   and dumps details when `--dump True`.
 - `--hessian-calc-mode` overrides `calc.hessian_calc_mode` after YAML merging.
-- Charge/spin inherit `.gjf` metadata when available. If `-q` is omitted but
-  `--ligand-charge` is provided, the input is treated as an enzyme–substrate
-  complex and `extract.py`’s charge summary computes the total charge; explicit
-  `-q` still overrides. Otherwise charge defaults to `0` and multiplicity to `1`.
-  Override them explicitly to ensure the intended state.
+- Charge/spin inherit `.gjf` metadata when available. For non-`.gjf` inputs,
+  `-q/--charge` is required unless `--ligand-charge` is provided (then
+  `extract.py` derives the total charge); explicit `-q` still overrides. Spin
+  defaults to `1` when no template is present. Override them explicitly to
+  ensure the intended state.
 
 ## YAML configuration (`--args-yaml`)
 Provide a mapping; YAML values override both defaults and CLI switches (highest

--- a/docs/irc.md
+++ b/docs/irc.md
@@ -27,7 +27,7 @@ pdb2reaction irc -i ts.pdb -q 0 -m 1 --max-cycles 50 --out-dir ./result_irc/
 
 ## Workflow
 1. **Input preparation** – Any format supported by `geom_loader` is accepted. If the source is `.pdb`, EulerPC trajectories are automatically converted to PDB using the original topology, and `--freeze-links` augments `geom.freeze_atoms` by freezing parents of link hydrogens.
-2. **Configuration merge** – Defaults → CLI → YAML (`geom`, `calc`, `irc`). Charge/multiplicity inherit `.gjf` template metadata when available. If `-q` is omitted but `--ligand-charge` is provided, the structure is treated as an enzyme–substrate complex and `extract.py`’s charge summary derives the total charge; explicit `-q` still overrides. Otherwise charge defaults to `0` and multiplicity to `1`. Always set them explicitly to remain on the intended PES.
+2. **Configuration merge** – Defaults → CLI → YAML (`geom`, `calc`, `irc`). Charge/multiplicity inherit `.gjf` template metadata when available. For non-`.gjf` inputs, `-q/--charge` is required unless `--ligand-charge` is provided (in which case `extract.py`’s charge summary derives the total charge); explicit `-q` still overrides. Spin defaults to `1` when no template is present. Always set them explicitly to remain on the intended PES.
 3. **IRC integration** – EulerPC integrates forward/backward branches according to `irc.forward/backward`, `irc.step_length`, `irc.root`, and the Hessian workflow configured through UMA (`calc.*`, `--hessian-calc-mode`). Hessians are updated with the configured scheme (`bofill` by default) and can be recalculated periodically.
 4. **Outputs** – Trajectories (`finished`, `forward`, `backward`) are written as `.trj` and, for PDB inputs, mirrored to `.pdb`. Optional HDF5 dumps capture per-step frames when `dump_every` > 0.
 
@@ -38,7 +38,7 @@ pdb2reaction irc -i ts.pdb -q 0 -m 1 --max-cycles 50 --out-dir ./result_irc/
 | `-q, --charge INT` | Total charge; overrides `calc.charge`. Required unless the input is a `.gjf` template with charge metadata. Overrides `--ligand-charge` when both are set. | Required when not in template |
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
 | `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
-| `-m, --multiplicity INT` | Spin multiplicity (2S+1); overrides `calc.spin`. | `.gjf` template value or `1` |
+| `-m, --multiplicity INT` | Spin multiplicity (2S+1); overrides `calc.spin`. | GJF template or `1` |
 | `--max-cycles INT` | Maximum IRC steps; overrides `irc.max_cycles`. | _None_ (use YAML/default `125`) |
 | `--step-size FLOAT` | Step length in mass-weighted coordinates; overrides `irc.step_length`. | _None_ (default `0.10`) |
 | `--root INT` | Imaginary-mode index for the initial displacement; overrides `irc.root`. | _None_ (default `0`) |
@@ -65,7 +65,7 @@ out_dir/ (default: ./result_irc/)
 - CLI booleans (`--forward`, `--backward`) must be spelled out (`True`/`False`) to be merged into YAML when desired.
 - UMA is reused throughout the IRC; aggressive `step_length` values can destabilise EulerPC.
 - When you have ample VRAM available, setting `--hessian-calc-mode` to `Analytical` is strongly recommended.
-- Charge/spin inherit `.gjf` metadata when possible. If `-q` is omitted but `--ligand-charge` is provided, the input is treated as an enzyme–substrate complex and `extract.py`’s charge summary computes the total charge; explicit `-q` still overrides. Otherwise charge defaults to `0` and multiplicity to `1`. Override them explicitly for non-standard states.
+- Charge/spin inherit `.gjf` metadata when possible. For non-`.gjf` inputs, `-q/--charge` is required unless `--ligand-charge` is provided (then `extract.py` derives the total charge); explicit `-q` still overrides. Spin defaults to `1` when no template is present. Override them explicitly for non-standard states.
 - `--freeze-links` only applies to PDB inputs, keeping parent atoms of link hydrogens frozen during Hessian construction.
 
 ## YAML configuration (`--args-yaml`)

--- a/docs/opt.md
+++ b/docs/opt.md
@@ -22,7 +22,7 @@ pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} -q CHARGE [--ligand-charge <number|'
 ## Workflow
 - **Optimizers**: `--opt-mode light` (default) → L-BFGS; `--opt-mode heavy` → rational-function optimizer with trust-region control.
 - **Restraints**: `--dist-freeze` consumes Python-literal tuples `(i, j, target_A)`; omitting the third element restrains the starting distance. `--bias-k` sets a global harmonic strength (eV·Å⁻²). Indices default to 1-based but can be flipped to 0-based with `--one-based False`.
-- **Charge/spin resolution**: CLI `-q/-m` override `.gjf` template metadata, which in turn override the `calc` defaults. If `-q` is omitted but `--ligand-charge` is provided, the input is treated as an enzyme–substrate complex and `extract.py`’s charge summary derives the total charge; explicit `-q` still overrides. If no template or ligand-charge hint exists, the fallback is `0/1`. Always pass the physically correct values explicitly.
+- **Charge/spin resolution**: CLI `-q/-m` override `.gjf` template metadata, which in turn override the `calc` defaults. For non-`.gjf` inputs, `-q/--charge` is required unless `--ligand-charge` is provided (then `extract.py` derives the total charge); explicit `-q` still overrides. Spin defaults to `1` when no template is present. Always pass the physically correct values explicitly.
 - **Freeze atoms**: CLI freeze-link logic is merged with YAML `geom.freeze_atoms`, then propagated to the UMA calculator (`calc.freeze_atoms`).
 - **Dumping & conversion**: `--dump True` mirrors `opt.dump=True` and writes `optimization.trj`; when conversion is enabled, trajectories are mirrored to `.pdb` for PDB inputs. `opt.dump_restart` can emit restart YAML snapshots.
 - **Exit codes**: `0` success, `2` zero step (step norm < `min_step_norm`), `3` optimizer failure, `130` keyboard interrupt, `1` unexpected error.
@@ -34,7 +34,7 @@ pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} -q CHARGE [--ligand-charge <number|'
 | `-q, --charge INT` | Total charge. Required unless the input is a `.gjf` template that already encodes charge. Overrides `--ligand-charge` when both are set. | Required when not in template |
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
 | `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
-| `-m, --multiplicity INT` | Spin multiplicity (2S+1). Falls back to `.gjf` template or `1`. | Template/`1` |
+| `-m, --multiplicity INT` | Spin multiplicity (2S+1). Falls back to a `.gjf` template value or `1`. | GJF template or `1` |
 | `--dist-freeze TEXT` | Repeatable string parsed as Python literal describing `(i,j,target_A)` tuples for harmonic restraints. | _None_ |
 | `--one-based {True|False}` | Interpret `--dist-freeze` indices as 1-based (default) or 0-based. | `True` |
 | `--bias-k FLOAT` | Harmonic bias strength applied to every `--dist-freeze` tuple (eV·Å⁻²). | `10.0` |

--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -1,7 +1,7 @@
 # `path-opt` subcommand
 
 ## Overview
-`pdb2reaction path-opt` searches for a minimum-energy path (MEP) between two endpoint structures using pysisyphus' Growing String method (GSM) or Direct Max Flux (DMF) selected via `--mep-mode`. UMA supplies energies/gradients/Hessians for every image, while an external rigid-body alignment routine keeps the string well behaved before the optimizer begins. Configuration follows the precedence **CLI > `--args-yaml` > defaults** across the `geom`, `calc`, `gs`, and `opt` sections. When `--convert-files` is enabled (default), outputs are mirrored to `.pdb` or multi-geometry `.gjf` companions when the endpoints originate from PDBs or Gaussian templates. GSM is the default path generator, and single-structure optimizations default to the `light` (LBFGS) preset.
+`pdb2reaction path-opt` searches for a minimum-energy path (MEP) between two endpoint structures using pysisyphus' Growing String method (GSM) or Direct Max Flux (DMF) selected via `--mep-mode`. UMA supplies energies/gradients/Hessians for every image, while an external rigid-body alignment routine keeps the string well behaved before the optimizer begins. Configuration follows the precedence **defaults → CLI → `--args-yaml`** across the `geom`, `calc`, `gs`, and `opt` sections. When `--convert-files` is enabled (default), outputs are mirrored to `.pdb` or multi-geometry `.gjf` companions when the endpoints originate from PDBs or Gaussian templates. GSM is the default path generator, and single-structure optimizations default to the `light` (LBFGS) preset.
 
 ## Usage
 ```bash
@@ -23,7 +23,7 @@ pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} [-q CHARGE] [--lig
 
 ### Key behaviors
 - **Endpoints**: Exactly two structures are required. Formats follow `geom_loader`. PDB inputs also enable trajectory/HEI PDB exports.
-- **Charge/spin**: CLI overrides `.gjf` template metadata. If `-q` is omitted but `--ligand-charge` is provided, the endpoints are treated as an enzyme–substrate complex and `extract.py`’s charge summary computes the total charge; explicit `-q` still overrides. When both are omitted, the charge defaults to `0` (spin defaults to `1`). Always set them explicitly for correct states.
+- **Charge/spin**: CLI overrides `.gjf` template metadata. For non-`.gjf` inputs, `-q/--charge` is required unless `--ligand-charge` is provided (in which case `extract.py`’s charge summary derives the total charge). Explicit `-q` still overrides. Spin uses the `.gjf` template when present; otherwise it defaults to `1`.
 - **MEP segments**: `--max-nodes` controls the number of *internal* nodes/images for the GSM string or DMF path (total images = `max_nodes + 2` for GSM). GSM growth and the optional climbing-image refinement share a convergence threshold preset supplied via `--thresh` or YAML (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`).
 - **Climbing image**: `--climb` toggles both the standard climbing step and the Lanczos-based tangent refinement.
 - **Dumping**: `--dump True` mirrors `opt.dump=True` for the StringOptimizer, producing trajectory/restart dumps inside `out_dir`.
@@ -36,7 +36,7 @@ pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} [-q CHARGE] [--lig
 | `-q, --charge INT` | Total charge (`calc.charge`). Required unless the input is a `.gjf` template that already encodes charge. Overrides `--ligand-charge` when both are set. | Required when not in template |
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex even without pocket extraction. | `None` |
 | `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
-| `-m, --multiplicity INT` | Spin multiplicity (`calc.spin`). | Template/`1` |
+| `-m, --multiplicity INT` | Spin multiplicity (`calc.spin`). | GJF template or `1` |
 | `--freeze-links BOOL` | PDB-only: freeze link-H parents (merged with YAML). | `True` |
 | `--max-nodes INT` | Number of internal nodes (string images = `max_nodes + 2`). | `10` |
 | `--mep-mode {gsm\|dmf}` | Select GSM (string-based) or DMF (direct flux) path generator. | `gsm` |

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -35,11 +35,11 @@ pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb [-q CHARGE] [--ligand-charge
 | `-q, --charge INT` | Total charge. Required unless the first input is a `.gjf` template that already stores charge. Overrides `--ligand-charge` when both are set. | Required when not in template |
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex even when pockets are skipped. | `None` |
 | `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
-| `-m, --multiplicity INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
+| `-m, --multiplicity INT` | Spin multiplicity (2S+1). | GJF template or `1` |
 | `--freeze-links BOOL` | Explicit `True`/`False`. When loading PDB pockets, freeze the parent atoms of link hydrogens. | `True` |
 | `--max-nodes INT` | Internal nodes per MEP segment (GSM string images or DMF images). | `10` |
 | `--max-cycles INT` | Maximum MEP optimization cycles (GSM/DMF). | `300` |
-| `--climb BOOL` | Explicit `True`/`False`. Enable climbing image for the first segment in each pair (GSM only). | `True` |
+| `--climb BOOL` | Explicit `True`/`False`. Enable climbing image for all GSM segments (bridge segments excluded). | `True` |
 | `--opt-mode TEXT` | Single-structure optimizer for HEI±1/kink nodes. `light` maps to LBFGS; `heavy` maps to RFO. | `light` |
 | `--mep-mode {gsm\|dmf}` | Segment generator: GSM (string-based) or DMF (direct flux). | `gsm` |
 | `--refine-mode {peak\|minima}` | Seeds for refinement: `peak` optimizes HEI±1; `minima` searches outward from the HEI toward the nearest local minima on each side. Defaults to `peak` for GSM and `minima` for DMF when omitted. | _Auto_ |
@@ -84,7 +84,7 @@ out_dir/ (default: ./result_path_search/)
 - `--ref-full-pdb` can be given once followed by multiple filenames; with `--align`, only the first template is reused for merges.
 - All UMA calculators are shared across structures for efficiency.
 - When `--dump` is set, MEP (GSM/DMF) and single-structure optimizations emit trajectories and restart YAML files.
-- Charge/spin inherit `.gjf` template metadata when available. If `-q` is omitted but `--ligand-charge` is provided, the inputs are treated as an enzyme–substrate complex and `extract.py`’s charge summary computes the total charge; explicit `-q` still overrides. Otherwise charge defaults to 0 and multiplicity to `1`.
+- Charge/spin inherit `.gjf` template metadata when available. For non-`.gjf` inputs, `-q/--charge` is required unless `--ligand-charge` is provided (then `extract.py` derives the total charge); explicit `-q` still overrides. Spin defaults to `1` when no template is present.
 
 ## YAML configuration (`--args-yaml`)
 The YAML root must be a mapping. YAML parameters override the CLI values. Shared sections reuse [`opt`](opt.md#yaml-configuration-args-yaml): `geom`/`calc` mirror single-structure options (with `--freeze-links` augmenting `geom.freeze_atoms` for PDBs), and `opt` inherits the StringOptimizer knobs documented for `path_opt`.

--- a/docs/scan3d.md
+++ b/docs/scan3d.md
@@ -2,7 +2,7 @@
 
 ## Overview
 `scan3d` performs a three-distance grid scan with harmonic restraints using the
-UMA calculator. You provide exactly one `--scan-list` literal containing three
+UMA calculator. You provide exactly one `--scan-list(s)` literal containing three
 quadruples `(i, j, lowÅ, highÅ)`. The tool builds linear grids for each distance
 with `--max-step-size`, reorders the values so that those nearest to the
 (pre‑optimized) starting structure are visited first, and then nests the loops
@@ -17,7 +17,7 @@ option to load the CSV after the scan finishes and changing `--zmin` and `--zmax
 ## Usage
 ```bash
 pdb2reaction scan3d -i INPUT.{pdb|xyz|trj|...} -q CHARGE [--ligand-charge <number|'RES:Q,...'>] [-m MULT] \
-                    --scan-list '[(i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ)]' [options] \
+                    --scan-list(s) '[(i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ)]' [options] \
                     [--convert-files {True|False}]
 ```
 
@@ -42,9 +42,9 @@ pdb2reaction scan3d -i input.pdb -q 0 \
 ## Workflow
 1. Load the structure through `geom_loader`, resolve charge/spin from CLI or
    embedded Gaussian templates, and optionally run an unbiased preoptimization
-   when `--preopt True`. If `-q` is omitted but `--ligand-charge` is provided, the
-   structure is treated as an enzyme–substrate complex and `extract.py`’s charge
-   summary derives the total charge before scanning.
+   when `--preopt True`. For non-`.gjf` inputs, `-q/--charge` is required unless
+   `--ligand-charge` is provided (then `extract.py` derives the total charge).
+   Spin defaults to `1` when no template is present.
 2. Parse the single `--scan-list` literal (default 1-based indices unless
    `--one-based False` is passed) into three quadruples. For PDB inputs, each
    atom entry can be an integer index or a selector string like `'TYR,285,CA'`;
@@ -69,11 +69,11 @@ pdb2reaction scan3d -i input.pdb -q 0 \
 | Option | Description | Default |
 | --- | --- | --- |
 | `-i, --input PATH` | Structure file accepted by `geom_loader`. | Required |
-| `-q, --charge INT` | Total charge (CLI > template > 0). Overrides `--ligand-charge` when both are set. | Required when not in template |
+| `-q, --charge INT` | Total charge. Overrides `--ligand-charge` when both are set. | Required when not in template |
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
 | `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
-| `-m, --multiplicity INT` | Spin multiplicity 2S+1. | `1` |
-| `--scan-list TEXT` | **Single** Python literal with three quadruples `(i,j,lowÅ,highÅ)`. `i`/`j` can be integer indices or PDB atom selectors like `'TYR,285,CA'`. | Required |
+| `-m, --multiplicity INT` | Spin multiplicity 2S+1. | GJF template or `1` |
+| `--scan-list(s) TEXT` | **Single** Python literal with three quadruples `(i,j,lowÅ,highÅ)`. `i`/`j` can be integer indices or PDB atom selectors like `'TYR,285,CA'`. | Required |
 | `--one-based {True|False}` | Interpret `(i, j)` indices as 1- or 0-based. | `True` |
 | `--max-step-size FLOAT` | Maximum change allowed per distance increment (Å). Controls grid density. | `0.20` |
 | `--bias-k FLOAT` | Harmonic bias strength `k` in eV·Å⁻². Overrides `bias.k`. | `100` |

--- a/docs/tsopt.md
+++ b/docs/tsopt.md
@@ -41,10 +41,10 @@ pdb2reaction tsopt -i ts_cand.pdb -q 0 -m 1 --opt-mode heavy \
 
 ## Workflow
 - **Charge/spin resolution**: when the input is `.gjf`, charge and multiplicity inherit the
-  template values. If `-q` is omitted but `--ligand-charge` is provided, the structure is
-  treated as an enzyme–substrate complex and `extract.py`’s charge summary derives the total
-  charge; explicit `-q` still overrides. Otherwise `-q/--charge` is required and multiplicity
-  defaults to `1`. Override them explicitly to ensure UMA runs on the intended state.
+  template values. For non-`.gjf` inputs, `-q/--charge` is required unless `--ligand-charge`
+  is provided (then `extract.py` derives the total charge); explicit `-q` still overrides.
+  Spin defaults to `1` when no template is present. Override them explicitly to ensure UMA
+  runs on the intended state.
 - **Geometry loading & freeze-links**: structures are read via
   `pysisyphus.helpers.geom_loader`. On PDB inputs, `--freeze-links True` finds link hydrogens
   and freezes their parent atoms. The merged set is echoed, stored in `geom.freeze_atoms`, and
@@ -79,7 +79,7 @@ pdb2reaction tsopt -i ts_cand.pdb -q 0 -m 1 --opt-mode heavy \
 | `-q, --charge INT` | Total charge. Required unless the input is a `.gjf` template with charge metadata. Overrides `--ligand-charge` when both are set. | Required when not in template |
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
 | `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
-| `-m, --multiplicity INT` | Spin multiplicity (2S+1). | `.gjf` template value or `1` |
+| `-m, --multiplicity INT` | Spin multiplicity (2S+1). | GJF template or `1` |
 | `--freeze-links BOOL` | PDB-only. Freeze parents of link hydrogens (merged into `geom.freeze_atoms`). | `True` |
 | `--max-cycles INT` | Macro-cycle cap forwarded to `opt.max_cycles`. | `10000` |
 | `--opt-mode TEXT` | Light/Heavy aliases listed above. | `light` |

--- a/pdb2reaction/add_elem_info.py
+++ b/pdb2reaction/add_elem_info.py
@@ -48,7 +48,8 @@ Outputs
 Notes
 -----
 - Only element columns are modified; coordinates, occupancies, B-factors, charges, altlocs,
-  insertion codes, and record ordering stay untouched.
+  and insertion codes are preserved. Biopython typically maintains record ordering, but
+  re-serialization can reformat or reorder records in some cases.
 - Supports ATOM and HETATM records across all models/chains/residues.
 - Depends on Biopython (`Bio.PDB`) and Click; deuterium labels map to hydrogen; selenium (`SE*`) and
   halogens are recognized automatically.

--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -72,7 +72,7 @@ Pipeline overview
         • a PDB path,
         • residue IDs like ``'123,124'`` or ``'A:123,B:456'`` (insertion codes allowed: ``'123A'`` / ``'A:123A'``),
         • residue names like ``'GPP,MMT'``.
-    - The extractor writes per-input pocket PDBs under ``<out-dir>/pockets/`` as ``pocket_<stem>.pdb``.
+    - The extractor writes per-input pocket PDBs under ``<out-dir>/pockets/`` as ``pocket_XX_<stem>.pdb``.
     - The extractor’s **model #1 total pocket charge** is used as the workflow charge for later stages,
       cast to the nearest integer; if rounding occurs a NOTE is printed.
     - Common extractor knobs: ``--radius``, ``--radius-het2het``, ``--include-H2O``,
@@ -233,8 +233,8 @@ Outputs (& Directory Layout)
   │   ├─ <input1>.pdb
   │   └─ ...
   ├─ pockets/                            # created when extraction (-c/--center) is used
-  │   ├─ pocket_<input1_stem>.pdb
-  │   ├─ pocket_<input2_stem>.pdb
+  │   ├─ pocket_01_<input1_stem>.pdb
+  │   ├─ pocket_02_<input2_stem>.pdb
   │   └─ ...
   ├─ scan/                               # present only in single-structure + scan mode
   │   ├─ stage_01/result.(pdb|xyz|gjf)
@@ -349,6 +349,7 @@ from .trj2fig import run_trj2fig
 from .summary_log import write_summary_log
 from .utils import (
     build_energy_diagram,
+    collect_option_values,
     convert_xyz_like_outputs,
     detect_freeze_links_safe,
     format_elapsed,
@@ -386,26 +387,6 @@ def _close_matplotlib_figures() -> None:
 
 def _ensure_dir(p: Path) -> None:
     p.mkdir(parents=True, exist_ok=True)
-
-
-def _collect_option_values(argv: Sequence[str], names: Sequence[str]) -> List[str]:
-    """
-    Robustly collect values following a flag that may appear **once** followed by multiple space-separated values,
-    e.g., "-i A B C". This mirrors the bauavior implemented in `path_search.cli`.
-    """
-    vals: List[str] = []
-    i = 0
-    while i < len(argv):
-        tok = argv[i]
-        if tok in names:
-            j = i + 1
-            while j < len(argv) and not argv[j].startswith("-"):
-                vals.append(argv[j])
-                j += 1
-            i = j
-        else:
-            i += 1
-    return vals
 
 
 def _append_cli_arg(args: List[str], flag: str, value: Any | None) -> None:
@@ -1959,8 +1940,8 @@ def _irc_and_match(
     "--mult",
     "spin",
     type=int,
-    default=1,
-    show_default=True,
+    default=None,
+    show_default="GJF template or 1",
     help="Multiplicity (2S+1).",
 )
 @click.option(
@@ -1997,7 +1978,7 @@ def _irc_and_match(
     type=click.BOOL,
     default=True,
     show_default=True,
-    help="Enable transition-state climbing after growth for the **first** segment in each pair.",
+    help="Enable transition-state climbing for all GSM segments (bridge segments excluded).",
 )
 @click.option(
     "--opt-mode",
@@ -2044,7 +2025,7 @@ def _irc_and_match(
     show_default=True,
     help=(
         "If True, run recursive path_search on the full ordered series; if False, run a single-pass "
-        "path-opt GSM between each adjacent pair and concatenate the segments (no path_search)."
+        "path-opt GSM/DMF between each adjacent pair and concatenate the segments (no path_search)."
     ),
 )
 @click.option(
@@ -2225,6 +2206,7 @@ def _irc_and_match(
 )
 @click.option(
     "--scan-lists",
+    "--scan-list",
     "scan_lists_raw",
     type=str,
     multiple=True,
@@ -2233,9 +2215,9 @@ def _irc_and_match(
         "Python-like list of (i,j,target_Å) per stage for **single-structure** scan. A single "
         "literal runs one stage; multiple literals run **sequentially**, each starting from the "
         "prior stage's relaxed structure. "
-        "Example: '[(12,45,1.35)]' --scan-lists '[(10,55,2.20),(23,34,1.80)]'. "
-        "You may also pass a single --scan-lists followed by multiple values "
-        "(e.g., '--scan-lists \\'[(12,45,1.35)]\\' \\'[(10,55,2.20)]\\''). "
+        "Example: '[(12,45,1.35)]' --scan-list '[(10,55,2.20),(23,34,1.80)]'. "
+        "You may also pass a single --scan-list/--scan-lists followed by multiple values "
+        "(e.g., '--scan-list \\'[(12,45,1.35)]\\' \\'[(10,55,2.20)]\\''). "
         "Indices refer to the original full input PDB (1-based). When extraction is used, they are "
         "auto-mapped to the pocket after extraction. For non-PDB single-structure scans, only integer "
         "indices are supported (1-based by default). Stage results feed into the MEP step (path_search or path_opt)."
@@ -2359,8 +2341,8 @@ def cli(
       - with --scan-lists: run staged scan and use stage results as inputs for path_search,
       - with --tsopt True and no --scan-lists: run TSOPT-only mode (no path_search).
 
-    With ``--refine-path True``, the recursive ``path_search`` workflow is used. When ``False`` (default),
-    a single-pass ``path-opt`` GSM is run between each adjacent pair of inputs and the segments are
+    With ``--refine-path True``, the recursive ``path_search`` workflow is used. When ``False``,
+    a single-pass ``path-opt`` (GSM/DMF) is run between each adjacent pair of inputs and the segments are
     concatenated into the final MEP without invoking ``path_search``.
     """
     set_convert_file_enabled(convert_files)
@@ -2376,7 +2358,7 @@ def cli(
         dump_override_requested = False
 
     argv_all = sys.argv[1:]
-    i_vals = _collect_option_values(argv_all, ("-i", "--input"))
+    i_vals = collect_option_values(argv_all, ("-i", "--input"))
     if i_vals:
         i_parsed: List[Path] = []
         for tok in i_vals:
@@ -2389,7 +2371,7 @@ def cli(
             i_parsed.append(p)
         input_paths = tuple(i_parsed)
 
-    scan_vals = _collect_option_values(argv_all, ("--scan-lists",))
+    scan_vals = collect_option_values(argv_all, ("--scan-list", "--scan-lists"))
     if scan_vals:
         scan_lists_raw = tuple(scan_vals)
 
@@ -2498,8 +2480,8 @@ def cli(
 
     pocket_outputs: List[Path] = []
     if not skip_extract:
-        for p in extract_inputs:
-            pocket_outputs.append((pockets_dir / f"pocket_{p.stem}.pdb").resolve())
+        for idx, p in enumerate(extract_inputs, start=1):
+            pocket_outputs.append((pockets_dir / f"pocket_{idx:02d}_{p.stem}.pdb").resolve())
 
     q_from_flow: Optional[int] = None
 
@@ -2635,6 +2617,9 @@ def cli(
         if (not user_provided_spin) and (gjf_spin is not None):
             spin = int(gjf_spin)
             click.echo(f"[all] Spin multiplicity set from GJF: {spin}")
+        if spin is None:
+            spin = 1
+            click.echo("[all] Spin multiplicity defaulting to 1.")
 
     if charge_override is not None:
         q_int = int(charge_override)

--- a/pdb2reaction/cli.py
+++ b/pdb2reaction/cli.py
@@ -2,10 +2,12 @@
 
 import click
 
+
 class DefaultGroup(click.Group):
-    def __init__(self, *args, default: str | None = None, **kwargs):
+    def __init__(self, *args, default: str | None = None, command_loaders=None, **kwargs):
         super().__init__(*args, **kwargs)
         self._default_cmd = default
+        self._command_loaders = command_loaders or {}
 
     def parse_args(self, ctx, args):
         if any(a in ("-h", "--help") for a in args):
@@ -16,20 +18,94 @@ class DefaultGroup(click.Group):
                 args.insert(0, self._default_cmd)
         return super().parse_args(ctx, args)
 
+    def get_command(self, ctx, cmd_name):
+        if cmd_name in self._command_loaders:
+            cmd = self._command_loaders[cmd_name]()
+            self.add_command(cmd, name=cmd_name)
+            return cmd
+        return super().get_command(ctx, cmd_name)
 
-from .all import cli as all_cmd
-from .scan import cli as scan_cmd
-from .opt import cli as opt_cmd
-from .path_opt import cli as path_opt_cmd
-from .path_search import cli as path_search_cmd
-from .tsopt import cli as tsopt_cmd
-from .freq import cli as freq_cmd
-from .irc import cli as irc_cmd
-from .trj2fig import cli as trj2fig_cmd
-from .add_elem_info import cli as add_elem_info_cmd
-from .dft import cli as dft_cmd
-from .scan2d import cli as scan2d_cmd
-from .scan3d import cli as scan3d_cmd
+
+def _load_all():
+    from .all import cli as cmd
+    return cmd
+
+
+def _load_scan():
+    from .scan import cli as cmd
+    return cmd
+
+
+def _load_opt():
+    from .opt import cli as cmd
+    return cmd
+
+
+def _load_path_opt():
+    from .path_opt import cli as cmd
+    return cmd
+
+
+def _load_path_search():
+    from .path_search import cli as cmd
+    return cmd
+
+
+def _load_tsopt():
+    from .tsopt import cli as cmd
+    return cmd
+
+
+def _load_freq():
+    from .freq import cli as cmd
+    return cmd
+
+
+def _load_irc():
+    from .irc import cli as cmd
+    return cmd
+
+
+def _load_trj2fig():
+    from .trj2fig import cli as cmd
+    return cmd
+
+
+def _load_add_elem_info():
+    from .add_elem_info import cli as cmd
+    return cmd
+
+
+def _load_dft():
+    from .dft import cli as cmd
+    return cmd
+
+
+def _load_scan2d():
+    from .scan2d import cli as cmd
+    return cmd
+
+
+def _load_scan3d():
+    from .scan3d import cli as cmd
+    return cmd
+
+
+COMMAND_LOADERS = {
+    "all": _load_all,
+    "scan": _load_scan,
+    "opt": _load_opt,
+    "path-opt": _load_path_opt,
+    "path-search": _load_path_search,
+    "tsopt": _load_tsopt,
+    "freq": _load_freq,
+    "irc": _load_irc,
+    "trj2fig": _load_trj2fig,
+    "add-elem-info": _load_add_elem_info,
+    "dft": _load_dft,
+    "scan2d": _load_scan2d,
+    "scan3d": _load_scan3d,
+}
 
 
 @click.group(
@@ -37,6 +113,7 @@ from .scan3d import cli as scan3d_cmd
     default="all",
     help="pdb2reaction: Root command to execute each subcommands.",
     context_settings={"help_option_names": ["-h", "--help"]},
+    command_loaders=COMMAND_LOADERS,
 )
 def cli() -> None:
     pass
@@ -66,20 +143,7 @@ def extract_cmd(ctx: click.Context) -> None:
         sys.argv = argv_backup
 
 
-cli.add_command(all_cmd, name="all")
-cli.add_command(scan_cmd, name="scan")
-cli.add_command(opt_cmd, name="opt")
-cli.add_command(path_opt_cmd, name="path-opt")
-cli.add_command(path_search_cmd, name="path-search")
-cli.add_command(tsopt_cmd, name="tsopt")
-cli.add_command(freq_cmd, name="freq")
-cli.add_command(irc_cmd, name="irc")
 cli.add_command(extract_cmd, name="extract")
-cli.add_command(trj2fig_cmd, name="trj2fig")
-cli.add_command(add_elem_info_cmd, name="add-elem-info")
-cli.add_command(dft_cmd, name="dft")
-cli.add_command(scan2d_cmd, name="scan2d")
-cli.add_command(scan3d_cmd, name="scan3d")
 
 # Disable pysisyphus logging
 import logging

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -543,7 +543,15 @@ THERMO_KW = {
     show_default=False,
     help="Total charge or per-resname mapping (e.g., GPP:-3,SAM:1) for unknown residues.",
 )
-@click.option("-m", "--multiplicity", "spin", type=int, default=1, show_default=True, help="Spin multiplicity (2S+1) for the ML region.")
+@click.option(
+    "-m",
+    "--multiplicity",
+    "spin",
+    type=int,
+    default=None,
+    show_default="GJF template or 1",
+    help="Spin multiplicity (2S+1) for the ML region.",
+)
 @click.option("--freeze-links", type=click.BOOL, default=True, show_default=True,
               help="Freeze parent atoms of link hydrogens (PDB only).")
 @click.option(

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -33,14 +33,14 @@ Description
 - Charge/spin defaults: `-q/--charge` and `-m/--multiplicity` inherit values from `.gjf` templates when provided. For non-`.gjf`
   inputs, omitting `-q/--charge` is allowed only when ``--ligand-charge`` is set: the full complex is treated as an
   enzyme–substrate system and its total charge is derived with ``extract.py``’s residue-aware logic. Otherwise the CLI aborts;
-  multiplicity still defaults to 1 when unspecified, and an explicit `-q` overrides any derived charge.
+  spin defaults to 1 when no template is present, and an explicit `-q` overrides any derived charge.
 
 CLI options
 -----------
   - `-i/--input PATH` (required): Structure file (.pdb/.xyz/.trj/…).
   - `-q/--charge INT`: Total charge; sets `calc.charge`. Required for non-`.gjf` inputs; `.gjf` templates
     supply defaults when available.
-  - `-m/--multiplicity INT` (default 1): Spin multiplicity (2S+1); sets `calc.spin` and defaults to the template multiplicity or `1`.
+  - `-m/--multiplicity INT`: Spin multiplicity (2S+1); sets `calc.spin` and defaults to the template multiplicity or `1`.
   - `--max-cycles INT`: Max number of IRC steps; sets `irc.max_cycles`.
   - `--step-size FLOAT`: Step length in mass-weighted coordinates; sets `irc.step_length`.
   - `--root INT`: Imaginary mode index for the initial displacement; sets `irc.root`.
@@ -210,7 +210,15 @@ def _echo_convert_trj_if_exists(
     show_default=False,
     help="Total charge or per-resname mapping (e.g., GPP:-3,SAM:1) for unknown residues.",
 )
-@click.option("-m", "--multiplicity", "spin", type=int, default=1, show_default=True, help="Spin multiplicity (2S+1) for the ML region.")
+@click.option(
+    "-m",
+    "--multiplicity",
+    "spin",
+    type=int,
+    default=None,
+    show_default="GJF template or 1",
+    help="Spin multiplicity (2S+1) for the ML region.",
+)
 @click.option("--max-cycles", type=int, default=None, help="Maximum number of IRC steps; overrides irc.max_cycles from YAML.")
 @click.option("--step-size", type=float, default=None, help="Step length in mass-weighted coordinates; overrides irc.step_length from YAML.")
 @click.option("--root", type=int, default=None, help="Imaginary mode index used for the initial displacement; overrides irc.root from YAML.")

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -44,7 +44,7 @@ Key options (YAML keys → meaning; defaults)
   - `freeze_atoms`: list[int], 0‑based indices to freeze (default: []).
 
 - Calculator (`calc`, UMA via `uma_pysis`):
-  - `charge` / `spin`: by default taken from `-q/--charge` (required unless the input is `.gjf`) and `-m/--multiplicity` (default `1`)
+  - `charge` / `spin`: `-q/--charge` is required unless the input is `.gjf` or `--ligand-charge` is supplied; `-m/--multiplicity` defaults to a `.gjf` template value when available, otherwise `1`.
     and reconciled with any `.gjf` template via `resolve_charge_spin_or_raise`.
   - `model`: "uma-s-1p1" (default) | "uma-m-1p1"; `task_name`: "omol".
   - `device`: "auto" (GPU if available) | "cuda" | "cpu".
@@ -499,8 +499,8 @@ def _maybe_convert_outputs(
     "--multiplicity",
     "spin",
     type=int,
-    default=1,
-    show_default=True,
+    default=None,
+    show_default="GJF template or 1",
     help="Spin multiplicity (2S+1) for the ML region.",
 )
 @click.option(

--- a/pdb2reaction/path_opt.py
+++ b/pdb2reaction/path_opt.py
@@ -49,7 +49,7 @@ out_dir/ (default: ./result_path_opt/)
 
 Notes
 -----
-- Charge/spin: `-q/--charge` (recommended for non-`.gjf` inputs; otherwise defaults to 0) and `-m/--multiplicity`
+- Charge/spin: `-q/--charge` (required unless the input is `.gjf` or `--ligand-charge` is supplied) and `-m/--multiplicity`
   are reconciled with any `.gjf` template values: explicit CLI options win. When ``-q`` is omitted but ``--ligand-charge`` is set,
   the full complex is treated as an enzyme–substrate system and the total charge is inferred using ``extract.py``’s residue-aware
   logic. If neither `-q` nor `--ligand-charge` is supplied, the charge falls back to 0; set it explicitly to avoid unphysical
@@ -567,8 +567,8 @@ def _optimize_single(
     "--multiplicity",
     "spin",
     type=int,
-    default=1,
-    show_default=True,
+    default=None,
+    show_default="GJF template or 1",
     help="Spin multiplicity (2S+1) for the ML region.",
 )
 @click.option(

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -28,7 +28,7 @@ Core inputs (strongly recommended):
         charge.
 
 Recommended/common:
-    -m/--mult
+    -m/--multiplicity
         Spin multiplicity (2S+1); defaults to a .gjf template value when available,
         otherwise 1 when omitted.
     --opt-mode
@@ -1953,7 +1953,7 @@ def _merge_final_and_write(final_images: List[Any],
     "spin",
     type=int,
     default=None,
-    show_default=False,
+    show_default="GJF template or 1",
     help="Spin multiplicity (2S+1) for the ML region (defaults from a .gjf template when available, otherwise 1).",
 )
 @click.option("--freeze-links", "freeze_links_flag", type=click.BOOL, default=True, show_default=True,

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -66,10 +66,10 @@ Optional optimizations
   - By default, both `--preopt` and `--endopt` are enabled.
 
 Charge/spin resolution
-  - `-q/--charge` is required unless the input is a `.gjf` template **or** ``--ligand-charge`` is provided.
+  - For non-`.gjf` inputs, `-q/--charge` is required unless ``--ligand-charge`` is provided.
     When ``-q`` is omitted but ``--ligand-charge`` is set, the full complex is treated as an enzyme–substrate
-    system and the total charge is inferred using ``extract.py``’s residue-aware logic. Multiplicity defaults to 1
-    when omitted, and an explicit `-q` overrides any derived charge.
+    system and the total charge is inferred using ``extract.py``’s residue-aware logic. Spin defaults to 1
+    when no template is present, and an explicit `-q` overrides any derived charge.
 
 Outputs (& Directory Layout)
 ----------------------------
@@ -139,6 +139,7 @@ from .opt import (
 from .utils import (
     convert_xyz_like_outputs,
     detect_freeze_links_safe,
+    collect_option_values,
     load_yaml_dict,
     apply_yaml_overrides,
     pretty_block,
@@ -231,7 +232,7 @@ def _parse_scan_lists(
 ) -> List[List[Tuple[int, int, float]]]:
     """
     Parse multiple Python-like list strings:
-      ['[(0,1,1.5), (2,3,2.0)]', '[(5,7,1.2)]', ...]
+      ['[(1,2,1.5), (3,4,2.0)]', '[(6,8,1.2)]', ...]
     Returns: [[(i,j,t), ...], [(i,j,t), ...], ...] with 0-based indices.
     """
     if not args:
@@ -241,11 +242,17 @@ def _parse_scan_lists(
         if isinstance(value, (int, np.integer)):
             idx_val = int(value)
             if one_based:
+                if idx_val < 1:
+                    raise click.BadParameter(
+                        f"Atom index must be >= 1 in --scan-lists #{stage_idx}; "
+                        "use --one-based False for 0-based indices."
+                    )
                 idx_val -= 1
-            if idx_val < 0:
-                raise click.BadParameter(
-                    f"Negative atom index in --scan-lists #{stage_idx}: {idx_val} (0-based expected)."
-                )
+            else:
+                if idx_val < 0:
+                    raise click.BadParameter(
+                        f"Atom index must be >= 0 in --scan-lists #{stage_idx} for 0-based indices."
+                    )
             return idx_val
         if isinstance(value, str):
             if not atom_meta:
@@ -379,7 +386,7 @@ def _snapshot_geometry(g) -> Any:
 
 @click.command(
     help="Bond-length driven scan with staged harmonic restraints and relaxation.",
-    context_settings={"help_option_names": ["-h", "--help"]},
+    context_settings={"help_option_names": ["-h", "--help"], "allow_extra_args": True},
 )
 @click.option(
     "-i", "--input",
@@ -411,13 +418,23 @@ def _snapshot_geometry(g) -> Any:
     show_default=False,
     help="Total charge or per-resname mapping (e.g., GPP:-3,SAM:1) for unknown residues.",
 )
-@click.option("-m", "--multiplicity", "spin", type=int, default=1, show_default=True, help="Spin multiplicity (2S+1) for the ML region.")
 @click.option(
-    "--scan-lists", "scan_lists_raw",
+    "-m",
+    "--multiplicity",
+    "spin",
+    type=int,
+    default=None,
+    show_default="GJF template or 1",
+    help="Spin multiplicity (2S+1) for the ML region.",
+)
+@click.option(
+    "--scan-lists",
+    "--scan-list",
+    "scan_lists_raw",
     type=str, multiple=True, required=True,
     help="Python-like list of (i,j,target) per stage. One literal runs a single stage; "
-         "multiple literals run sequential stages. Prefer a single --scan-lists followed by "
-         "multiple values, e.g. '[(0,1,1.50),(2,3,2.00)]' '[(5,7,1.20)]'.",
+         "multiple literals run sequential stages. Prefer a single --scan-list/--scan-lists followed by "
+         "multiple values, e.g. '[(1,2,1.50),(3,4,2.00)]' '[(6,8,1.20)]'.",
 )
 @click.option("--one-based", "one_based", type=click.BOOL, default=True, show_default=True,
               help="Interpret (i,j) indices in --scan-lists as 1-based (default) or 0-based.")
@@ -471,7 +488,9 @@ def _snapshot_geometry(g) -> Any:
               help="Preoptimize initial structure without bias before the scan.")
 @click.option("--endopt", type=click.BOOL, default=True, show_default=True,
               help="After each stage, run an additional unbiased optimization of the stage result.")
+@click.pass_context
 def cli(
+    ctx: click.Context,
     input_path: Path,
     charge: Optional[int],
     ligand_charge: Optional[str],
@@ -494,6 +513,15 @@ def cli(
     preopt: bool,
     endopt: bool,
 ) -> None:
+    scan_vals = collect_option_values(sys.argv[1:], ("--scan-list", "--scan-lists"))
+    if scan_vals:
+        scan_lists_raw = tuple(scan_vals)
+    if ctx.args:
+        unexpected = [arg for arg in ctx.args if arg not in scan_lists_raw]
+        if unexpected:
+            raise click.ClickException(f"Unexpected extra argument(s): {' '.join(unexpected)}")
+    if not scan_lists_raw:
+        raise click.BadParameter("--scan-list(s) must be provided at least once.")
     set_convert_file_enabled(convert_files)
     prepared_input = prepare_input_structure(input_path)
     apply_ref_pdb_override(prepared_input, ref_pdb)

--- a/pdb2reaction/scan3d.py
+++ b/pdb2reaction/scan3d.py
@@ -47,15 +47,15 @@ Description
 - A 3D grid scan driven by harmonic restraints on three inter-atomic distances (d1, d2, d3).
 - Provide exactly one Python-like list
       [(i1, j1, low1, high1), (i2, j2, low2, high2), (i3, j3, low3, high3)]
-  via **--scan-list**.
+  via **--scan-list/--scan-lists**.
   - Indices are **1-based by default**; pass **--one-based False** to interpret them as 0-based.
   - For PDB inputs, each atom entry can be an integer index or a selector string such as
     ``'TYR,285,CA'`` or ``'MMT,309,C10'`` (resname, resseq, atom).
 - `-q/--charge` is required for non-`.gjf` inputs **unless** ``--ligand-charge`` is provided; `.gjf` templates supply
   charge/spin when available. When ``-q`` is omitted but ``--ligand-charge`` is set, the full complex is treated as an
   enzyme–substrate system and the total charge is inferred using ``extract.py``’s residue-aware logic. Explicit ``-q``
-  always overrides any derived charge.
-  `-m/--multiplicity` specifies the spin multiplicity (2S+1) and defaults to 1 if omitted.
+  always overrides any derived charge. `-m/--multiplicity` specifies the spin multiplicity (2S+1) and defaults to the
+  `.gjf` template value when available, otherwise `1`.
 - Step schedule (h = `--max-step-size` in Å):
   - `N1 = ceil(|high1 - low1| / h)`, `N2 = ceil(|high2 - low2| / h)`, `N3 = ceil(|high3 - low3| / h)`.
   - `d1_values = linspace(low1, high1, N1 + 1)` (or `[low1]` if the span is ~0)
@@ -157,6 +157,7 @@ from .opt import (
 from .utils import (
     detect_freeze_links_safe,
     pretty_block,
+    collect_option_values,
     format_geom_for_echo,
     format_freeze_atoms_for_echo,
     format_elapsed,
@@ -302,11 +303,16 @@ def _parse_scan_list(
         if isinstance(value, (int, np.integer)):
             idx_val = int(value)
             if one_based:
+                if idx_val < 1:
+                    raise click.BadParameter(
+                        "Atom index must be >= 1 in --scan-list; use --one-based False for 0-based indices."
+                    )
                 idx_val -= 1
-            if idx_val < 0:
-                raise click.BadParameter(
-                    f"Negative atom index after base conversion: {idx_val} (0-based expected)."
-                )
+            else:
+                if idx_val < 0:
+                    raise click.BadParameter(
+                        "Atom index must be >= 0 in --scan-list for 0-based indices."
+                    )
             return idx_val
         if isinstance(value, str):
             if not atom_meta:
@@ -446,7 +452,7 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
 
 @click.command(
     help="3D distance scan with harmonic restraints.",
-    context_settings={"help_option_names": ["-h", "--help"]},
+    context_settings={"help_option_names": ["-h", "--help"], "allow_extra_args": True},
 )
 @click.option(
     "-i", "--input",
@@ -481,17 +487,20 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
 @click.option(
     "-m", "--multiplicity", "spin",
     type=int,
-    default=1,
-    show_default=True,
+    default=None,
+    show_default="GJF template or 1",
     help="Spin multiplicity (2S+1) for the ML region.",
 )
 @click.option(
-    "--scan-list", "scan_list_raw",
+    "--scan-list",
+    "--scan-lists",
+    "scan_list_raw",
     type=str,
     required=False,
     help=(
         "Python-like list with three quadruples: "
-        "'[(i1,j1,low1,high1),(i2,j2,low2,high2),(i3,j3,low3,high3)]'."
+        "'[(i1,j1,low1,high1),(i2,j2,low2,high2),(i3,j3,low3,high3)]'. "
+        "This subcommand accepts exactly one list value."
     ),
 )
 @click.option(
@@ -616,7 +625,9 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
     show_default=False,
     help="Upper bound of color scale for plots (kcal/mol).",
 )
+@click.pass_context
 def cli(
+    ctx: click.Context,
     input_path: Optional[Path],
     charge: Optional[int],
     ligand_charge: Optional[str],
@@ -644,6 +655,15 @@ def cli(
 ) -> None:
     from .utils import load_yaml_dict, apply_yaml_overrides
 
+    scan_vals = collect_option_values(sys.argv[1:], ("--scan-list", "--scan-lists"))
+    if scan_vals:
+        scan_list_raw = scan_vals[0] if scan_vals else scan_list_raw
+    if ctx.args:
+        unexpected = [arg for arg in ctx.args if arg not in (scan_vals or [])]
+        if unexpected:
+            raise click.ClickException(f"Unexpected extra argument(s): {' '.join(unexpected)}")
+    if scan_vals and len(scan_vals) != 1:
+        raise click.BadParameter("--scan-list(s) must contain exactly one list for scan3d.")
     set_convert_file_enabled(convert_files)
     prepared_input = None
     geom_input_path = None
@@ -652,7 +672,7 @@ def cli(
         if input_path is None:
             raise click.ClickException("-i/--input is required unless --csv is provided.")
         if scan_list_raw is None:
-            raise click.ClickException("--scan-list is required unless --csv is provided.")
+            raise click.ClickException("--scan-list(s) is required unless --csv is provided.")
         prepared_input = prepare_input_structure(input_path)
         apply_ref_pdb_override(prepared_input, ref_pdb)
         geom_input_path = prepared_input.geom_path

--- a/pdb2reaction/summary_log.py
+++ b/pdb2reaction/summary_log.py
@@ -9,7 +9,6 @@ post-processing energies, and key output paths in a single place.
 from __future__ import annotations
 
 import textwrap
-import subprocess
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence
 

--- a/pdb2reaction/trj2fig.py
+++ b/pdb2reaction/trj2fig.py
@@ -88,7 +88,7 @@ def read_energies_xyz(fname: Path | str) -> List[float]:
     Extract Hartree energies from the second-line comment of each XYZ frame.
 
     The first decimal number found on the comment line is used
-    (scientific notation/exponents are not parsed).
+    (supports scientific notation with E/D exponents).
     """
     energies: List[float] = []
     with open(fname, encoding="utf-8") as fh:
@@ -98,10 +98,10 @@ def read_energies_xyz(fname: Path | str) -> List[float]:
             except ValueError:  # reached a non-XYZ header
                 break
             comment = fh.readline().strip()
-            m = re.search(r"(-?\d+(?:\.\d+)?)", comment)
+            m = re.search(r"(-?\d+(?:\.\d+)?(?:[eEdD][+-]?\d+)?)", comment)
             if not m:
                 raise RuntimeError(f"Energy not found in comment: {comment}")
-            energies.append(float(m.group(1)))
+            energies.append(float(m.group(1).replace("D", "E").replace("d", "E")))
             for _ in range(nat):  # skip coordinates
                 fh.readline()
     if not energies:

--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -113,11 +113,11 @@ out_dir/ (default: ./result_tsopt/)
 
 Notes
 -----
-- **Charge/spin**: `-q/--charge` and `-m/--mult` inherit `.gjf` template values when the input
+- **Charge/spin**: `-q/--charge` and `-m/--multiplicity` inherit `.gjf` template values when the input
   is `.gjf`; for non-`.gjf` inputs, omitting `-q/--charge` is allowed only when ``--ligand-charge`` is
   provided. In that case the full complex is treated as an enzyme–substrate system and the total charge is
-  inferred using ``extract.py``’s residue-aware logic. Otherwise the CLI aborts. Multiplicity still defaults
-  to 1 when unspecified, and explicit CLI values override any template or derived metadata.
+  inferred using ``extract.py``’s residue-aware logic. Otherwise the CLI aborts. Spin defaults to 1 when no
+  template is present, and explicit CLI values override any template or derived metadata.
 
 - `--opt-mode light` runs Hessian Dimer with periodic Hessian-based direction refresh;
   `--opt-mode heavy` runs RS-I-RFO.
@@ -1279,7 +1279,15 @@ RSIRFO_KW.update({
     show_default=False,
     help="Total charge or per-resname mapping (e.g., GPP:-3,SAM:1) for unknown residues.",
 )
-@click.option("-m", "--multiplicity", "spin", type=int, default=1, show_default=True, help="Spin multiplicity (2S+1) for the ML region.")
+@click.option(
+    "-m",
+    "--multiplicity",
+    "spin",
+    type=int,
+    default=None,
+    show_default="GJF template or 1",
+    help="Spin multiplicity (2S+1) for the ML region.",
+)
 @click.option("--freeze-links", type=click.BOOL, default=True, show_default=True,
               help="Freeze parent atoms of link hydrogens (PDB only).")
 @click.option(

--- a/pdb2reaction/utils.py
+++ b/pdb2reaction/utils.py
@@ -123,7 +123,6 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, List, Tuple, Callable, TypeVar
 
 import click
-import math
 import yaml
 from ase.data import chemical_symbols
 from ase.io import read, write
@@ -200,9 +199,29 @@ def format_elapsed(prefix: str, start_time: float, end_time: Optional[float] = N
     return f"{prefix}: {int(hours):02d}:{int(minutes):02d}:{seconds:06.3f}"
 
 
+def collect_option_values(argv: _Sequence[str], names: _Sequence[str]) -> List[str]:
+    """
+    Collect values following a flag that may appear once with multiple space-separated values,
+    e.g., ``-i A B C``. Mirrors the sloppy-form behavior used in several CLI entry points.
+    """
+    vals: List[str] = []
+    i = 0
+    while i < len(argv):
+        tok = argv[i]
+        if tok in names:
+            j = i + 1
+            while j < len(argv) and not argv[j].startswith("-"):
+                vals.append(argv[j])
+                j += 1
+            i = j
+        else:
+            i += 1
+    return vals
+
+
 def merge_freeze_atom_indices(
     geom_cfg: Dict[str, Any],
-    *indices: _Iterable[int],
+    *indices: _Iterable[int] | str | bytes | None,
 ) -> List[int]:
     """Merge one or more iterables of indices into ``geom_cfg['freeze_atoms']``.
 
@@ -211,12 +230,19 @@ def merge_freeze_atom_indices(
     """
     merged: set[int] = set()
     base = geom_cfg.get("freeze_atoms", [])
-    if isinstance(base, _Iterable):
+    if isinstance(base, (str, bytes)):
+        text = base.decode() if isinstance(base, bytes) else base
+        merged.update(int(i) for i in re.findall(r"-?\d+", text))
+    elif isinstance(base, _Iterable):
         merged.update(int(i) for i in base)
     for seq in indices:
         if seq is None:
             continue
-        merged.update(int(i) for i in seq)
+        if isinstance(seq, (str, bytes)):
+            text = seq.decode() if isinstance(seq, bytes) else seq
+            merged.update(int(i) for i in re.findall(r"-?\d+", text))
+        else:
+            merged.update(int(i) for i in seq)
     result = sorted(merged)
     geom_cfg["freeze_atoms"] = result
     return result
@@ -1195,8 +1221,7 @@ def detect_freeze_links(pdb_path):
     Returns:
         List of 0-based indices into the sequence of non-LKH atoms ("others") corresponding
         to the nearest neighbors (link parents). Returns an empty list if no LKH/HL atoms
-        are present. When the input contains link hydrogens but no other atoms, the list
-        will contain ``-1`` entries to indicate missing parents.
+        are present. Missing parents are omitted rather than returned as negative indices.
     """
     others, lkhs = parse_pdb_coords(pdb_path)
 
@@ -1206,7 +1231,8 @@ def detect_freeze_links(pdb_path):
     indices = []
     for (x, y, z, line) in lkhs:
         idx, dist = nearest_index((x, y, z), others)
-        indices.append(idx)
+        if idx >= 0:
+            indices.append(idx)
     return indices
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
     "click",
     "plotly",
     "kaleido",
+    "pandas>=2.0",
+    "scipy>=1.10",
     "pyscf>=2.8.0",
     "gpu4pyscf-cuda12x>=1.5.2; platform_machine == 'x86_64'",
     "cupy-cuda12x==13.4.1",


### PR DESCRIPTION
### Motivation
- Standardize `--scan-list` / `--scan-lists` behavior across `all`, `scan`, `scan2d`, and `scan3d` so sloppy/multi-value forms (single flag followed by multiple literals) are officially accepted and parsed uniformly.
- Fix multiple documentation and docstring mismatches that mislead users about configuration precedence, charge/multiplicity defaults, `--climb` semantics, and `--opt-mode` defaults.
- Harden CLI startup and runtime behavior to avoid eager import dependency failures, ambiguous pocket output names, and fragile parsing (energy parsing, freeze-link handling).
- Add missing runtime deps required by `scan2d`/`scan3d` and reduce a few brittle assumptions in utilities.

### Description
- Implemented a shared sloppy-form collector `collect_option_values()` in `pdb2reaction/utils.py` and wired it into `all`, `scan`, `scan2d`, and `scan3d` to accept both `--scan-list` and `--scan-lists` and multiple values after one flag, and updated parsing to reject multi-valued lists where only one is permitted (scan2d/3d). Files: `pdb2reaction/utils.py`, `pdb2reaction/all.py`, `pdb2reaction/scan.py`, `pdb2reaction/scan2d.py`, `pdb2reaction/scan3d.py`.
- Aligned CLI option defaults and docstrings to reflect actual precedence and defaults: changed multiplicity options to default to `None` with `show_default` text "GJF template or 1", clarified that for non-`.gjf` inputs `-q/--charge` is required unless `--ligand-charge` is provided, and adjusted `--climb` wording to match implementation (applies to all GSM segments except bridge segments). Files: `pdb2reaction/*.py` and docs under `docs/*.md` (many files updated: `docs/scan.md`, `docs/scan2d.md`, `docs/scan3d.md`, `docs/all.md`, `docs/path_opt.md`, `docs/path_search.md`, `docs/dft.md`, `docs/irc.md`, `docs/opt.md`, `docs/freq.md`, `docs/tsopt.md`, `README.md`).
- Made CLI imports lazy to avoid eager dependency failures by adding a loader-based `DefaultGroup` in `pdb2reaction/cli.py` and deferred subcommand imports; also added `context_settings` `allow_extra_args` and `@click.pass_context` plumbing where needed to safely collect sloppy args.
- Robustified utilities and parsing: improved `merge_freeze_atom_indices` to accept string/bytes input and parse numeric tokens, prevented returning negative indices from `detect_freeze_links` (omit missing parents), and extended `trj2fig.read_energies_xyz` regex to accept scientific notation (E/D) and normalize `D`/`d` to `E`. Files: `pdb2reaction/utils.py`, `pdb2reaction/trj2fig.py`.
- Avoided name collisions and improved output determinism by prefixing pocket filenames with an index (e.g., `pocket_01_<stem>.pdb`) in `all` and by updating places that reference those outputs.
- Removed an unused `subprocess` import and added `pandas>=2.0` and `scipy>=1.10` to `pyproject.toml` to satisfy `scan2d`/`scan3d` top-level imports.
- Minor doc / text fixes: typos and stronger/softer assertions (e.g., `add_elem_info` note about Biopython re-serialization may reorder/format records), and README cleanup for `--opt-mode` defaults.

### Testing
- No automated tests were run for this PR; changes consist of CLI behavior, docs, and utility refactors and should be validated by exercising the CLI subcommands (`all`, `scan`, `scan2d`, `scan3d`, etc.) in typical workflows and by running the project’s test suite (not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697712b876cc832dac9b941d294f2784)