### PR TITLE
Document and enforce single-flag multi-arg --scan-list(s) usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pdb2reaction -i R.pdb P.pdb -c 'SAM,GPP' --ligand-charge 'SAM:1,GPP:-3' --tsopt 
 ```
 ---
 
-Given **(i) two or more full protein–ligand PDBs** `.pdb` (R → … → P), **or (ii) one PDB with `--scan-lists`**, **or (iii) one TS candidate with `--tsopt True`**, `pdb2reaction` automatically:
+Given **(i) two or more full protein–ligand PDBs** `.pdb` (R → … → P), **or (ii) one PDB with `--scan-list(s)`**, **or (iii) one TS candidate with `--tsopt True`**, `pdb2reaction` automatically:
 
 - extracts an **active site** around user‑defined substrates to build a **cluster model**,
 - explores **minimum‑energy paths (MEPs)** with path optimization methods such as the Growing String Method (GSM) and Direct Max Flux (DMF),
@@ -207,7 +207,7 @@ This is the recommended mode when you can generate reasonably spaced intermediat
 
 Use this when you only have **one PDB structure**, but you know which inter‑atomic distances should change along the reaction.
 
-Provide a single `-i` together with `--scan-lists`:
+Provide a single `-i` together with `--scan-list(s)`:
 
 **Minimal example**
 
@@ -223,11 +223,11 @@ pdb2reaction -i SINGLE.pdb -c 'SAM,GPP' --scan-lists '[("TYR 285 CA","MMT 309 C1
 
 Key points:
 
-- `--scan-lists` describes **staged distance scans** on the extracted cluster model.
+- `--scan-list(s)` describes **staged distance scans** on the extracted cluster model.
 - Each tuple `(i, j, target_Å)` is:
   - a PDB atom selector string like `'TYR,285,CA'` (**delimiters can be: space/comma/slash/backtick/backslash ` ` `,` `/` `` ` `` `\`**) **or** a 1‑based atom index,  
   - automatically remapped to the cluster-model indices.
-- Supplying one `--scan-lists` literal runs a single scan stage; multiple literals run sequential stages. It’s simplest to pass multiple literals after a single `--scan-lists`.
+- Supplying one `--scan-list(s)` literal runs a single scan stage; multiple literals run sequential stages. Pass multiple literals after a single flag (repeated flags are not accepted).
 - Each stage writes a `stage_XX/result.pdb`, which is treated as a candidate intermediate or product.
 - The default `all` workflow refines the concatenated stages with recursive `path_search`.
 - With `--refine-path False`, it instead performs a single-pass `path-opt` chain and skips the recursive refiner (no merged `mep_w_ref*.pdb`).
@@ -264,7 +264,7 @@ Behavior:
 
 Outputs such as `energy_diagram_*_all.png` and `irc_plot_all.png` are mirrored under the top‑level `--out-dir`.
 
-> **Important:** Single‑input runs require **either** `--scan-lists` (staged scan → GSM) **or** `--tsopt True` (TSOPT‑only). Supplying only a single `-i` without one of these will not trigger a full workflow.
+> **Important:** Single‑input runs require **either** `--scan-list(s)` (staged scan → GSM) **or** `--tsopt True` (TSOPT‑only). Supplying only a single `-i` without one of these will not trigger a full workflow.
 
 ---
 
@@ -276,7 +276,7 @@ Below are the most commonly used options across workflows.
   Input structures. Interpretation depends on how many you provide:
 
   - **≥ 2 PDBs** → MEP search (GSM by default, DMF with `--mep-mode dmf`) (reactant/intermediates/product).
-  - **1 PDB + `--scan-lists`** → staged scan → GSM.
+  - **1 PDB + `--scan-list(s)`** → staged scan → GSM.
   - **1 PDB + `--tsopt True`** → TSOPT‑only mode.
 
   If `--center/-c` is omitted, cluster extraction is skipped and the **full input structure** is used directly. In this mode, `.xyz` and `.gjf` inputs are also accepted; when using these file formats, omit `--center/-c` and `--ligand-charge`.
@@ -310,7 +310,7 @@ Below are the most commonly used options across workflows.
 
 > If you have charge and multiplicity in .gjf input, -q and -m can be omitted.
 
-- `--scan-lists TEXT...`  
+- `--scan-list(s) TEXT...`  
   One or more Python‑style lists describing **staged scans** for single‑input runs. A single literal runs one stage; multiple literals run sequential stages. Example:
 
   ```bash

--- a/docs/all.md
+++ b/docs/all.md
@@ -5,8 +5,8 @@
 
 Key modes:
 - **End-to-end ensemble** – Supply ≥2 PDBs/GJFs/XYZ files in reaction order plus a substrate definition; the command extracts pockets, runs GSM/DMF MEP search, merges to the parent PDB(s), and optionally runs TSOPT/freq/DFT per reactive segment.
-- **Single-structure + staged scan** – Provide one structure plus one or more `--scan-lists`; UMA scans on the extracted pocket generate intermediates that become MEP endpoints.
-- A single `--scan-lists` literal runs a one-stage scan; multiple literals run sequential stages, typically supplied as multiple values after one `--scan-lists` flag.
+- **Single-structure + staged scan** – Provide one structure plus one or more `--scan-list(s)`; UMA scans on the extracted pocket generate intermediates that become MEP endpoints.
+- A single `--scan-list(s)` literal runs a one-stage scan; multiple literals run sequential stages, supplied as multiple values after one flag (repeated flags are not accepted).
 - **TSOPT-only pocket refinement** – Provide one input structure, omit `--scan-lists`, and enable `--tsopt True`; the command extracts the pocket (if `-c/--center` is given) and only runs TS optimization + IRC (with optional freq/DFT) on that single system.
 
 ## Usage
@@ -40,8 +40,8 @@ pdb2reaction all -i reactant.pdb -c 'GPP,MMT' \
    - The **first pocket’s total charge** is propagated to scan/MEP/TSOPT.
 
 2. **Optional staged scan (single-input only)**
-   - Each `--scan-lists` argument is a Python-like list of `(i,j,target_Å)` tuples describing a UMA scan stage. Atom indices refer to the original input ordering (1-based) and are remapped to the pocket ordering. For PDB inputs, `i`/`j` can be integer indices or selector strings like `'TYR,285,CA'`; selectors accept spaces/commas/slashes/backticks/backslashes (` ` `,` `/` `` ` `` `\`) as delimiters and allow unordered tokens (fallback assumes resname, resseq, atom).
-   - A single literal runs a one-stage scan; multiple literals run **sequentially** so stage 2 begins from stage 1's result, and so on. Supplying multiple literals after a single `--scan-lists` flag is the most convenient, intended form.
+   - Each `--scan-list(s)` argument is a Python-like list of `(i,j,target_Å)` tuples describing a UMA scan stage. Atom indices refer to the original input ordering (1-based) and are remapped to the pocket ordering. For PDB inputs, `i`/`j` can be integer indices or selector strings like `'TYR,285,CA'`; selectors accept spaces/commas/slashes/backticks/backslashes (` ` `,` `/` `` ` `` `\`) as delimiters and allow unordered tokens (fallback assumes resname, resseq, atom).
+   - A single literal runs a one-stage scan; multiple literals run **sequentially** so stage 2 begins from stage 1's result, and so on. Supply multiple literals after a single flag (repeated flags are not accepted).
    - Scan inherits charge/spin, `--freeze-links`, the UMA optimizer preset (`--opt-mode`), `--dump`, `--args-yaml`, and `--preopt`. Overrides such as `--scan-out-dir`, `--scan-one-based`, `--scan-max-step-size`, `--scan-bias-k`, `--scan-relax-max-cycles`, `--scan-preopt`, and `--scan-endopt` apply per run.
    - Stage endpoints (`stage_XX/result.pdb`) become the ordered intermediates that feed the subsequent MEP step.
 
@@ -75,7 +75,7 @@ pdb2reaction all -i reactant.pdb -c 'GPP,MMT' \
 ## CLI options
 | Option | Description | Default |
 | --- | --- | --- |
-| `-i, --input PATH...` | Two or more full structures in reaction order (single input allowed only with `--scan-lists` or `--tsopt True`). | Required |
+| `-i, --input PATH...` | Two or more full structures in reaction order (single input allowed only with `--scan-list(s)` or `--tsopt True`). | Required |
 | `-c, --center TEXT` | Substrate specification (PDB path, residue IDs like `123,124` / `A:123,B:456`, or residue names like `GPP,MMT`). | Required for extraction |
 | `--out-dir PATH` | Top-level output directory. | `./result_all/` |
 | `-r, --radius FLOAT` | Pocket inclusion cutoff (Å). | `2.6` |
@@ -117,7 +117,7 @@ pdb2reaction all -i reactant.pdb -c 'GPP,MMT' \
 | `--dft-max-cycle INT` | Override `dft --max-cycle`. | _None_ |
 | `--dft-conv-tol FLOAT` | Override `dft --conv-tol`. | _None_ |
 | `--dft-grid-level INT` | Override `dft --grid-level`. | _None_ |
-| `--scan-lists TEXT...` | One or more Python-like lists describing staged scans on the extracted pocket (single-input runs only). Each element is `(i,j,target_Å)`; a single literal runs one stage, multiple literals run sequential stages. `i`/`j` can be integer indices or PDB atom selectors like `'TYR,285,CA'` and are remapped internally. | _None_ |
+| `--scan-list(s) TEXT...` | One or more Python-like lists describing staged scans on the extracted pocket (single-input runs only). Each element is `(i,j,target_Å)`; a single literal runs one stage, multiple literals run sequential stages. `i`/`j` can be integer indices or PDB atom selectors like `'TYR,285,CA'` and are remapped internally. | _None_ |
 | `--scan-one-based BOOLEAN` | Force scan indexing to 1-based (`True`) or 0-based (`False`); `None` keeps the scan default (1-based). | _None_ |
 | `--scan-max-step-size FLOAT` | Override scan `--max-step-size` (Å). | _None_ |
 | `--scan-bias-k FLOAT` | Override the harmonic bias strength `k` (eV/Å²). | _None_ |
@@ -158,7 +158,7 @@ The YAML is a compact, machine-readable summary. Common top-level keys include:
 - Always provide `--ligand-charge` (numeric or per-residue mapping) when formal charges cannot be inferred so the correct total charge propagates to scan/MEP/TSOPT/DFT.
 - Reference PDB templates for merging are derived automatically from the original inputs; the explicit `--ref-full-pdb` option of `path_search` is intentionally hidden in this wrapper.
 - Energies in diagrams are reported relative to the first state (reactant) in kcal/mol.
-- Omitting `-c/--center` skips extraction and feeds the entire input structures directly to the MEP/tsopt/freq/DFT stages; single-structure runs still require either `--scan-lists` or `--tsopt True`.
+- Omitting `-c/--center` skips extraction and feeds the entire input structures directly to the MEP/tsopt/freq/DFT stages; single-structure runs still require either `--scan-list(s)` or `--tsopt True`.
 - `--args-yaml` lets you coordinate all calculators from a single configuration file. YAML values override CLI flags.
 
 ## YAML configuration (`--args-yaml`)

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -8,14 +8,14 @@ are applied, and the entire structure is relaxed with LBFGS (`--opt-mode` light,
 or RFOptimizer (`--opt-mode` heavy). After the biased walk, you can optionally
 run unbiased pre-/post-optimizations to clean up the geometries that get written
 to disk.
-When `--scan-lists` is supplied once the scan runs in a single stage; supplying
+When `--scan-list(s)` is supplied once the scan runs in a single stage; supplying
 multiple literals runs sequential stages, each starting from the previous stage’s
 relaxed result.
 
 ## Usage
 ```bash
 pdb2reaction scan -i INPUT.{pdb|xyz|trj|...} -q CHARGE [--ligand-charge <number|'RES:Q,...'>] [-m MULT] \
-                  --scan-lists '[(i,j,targetÅ), ...]' [options]
+                  --scan-list(s) '[(i,j,targetÅ), ...]' [options]
                   [--convert-files {True|False}]
 ```
 
@@ -25,13 +25,13 @@ pdb2reaction scan -i INPUT.{pdb|xyz|trj|...} -q CHARGE [--ligand-charge <number|
 pdb2reaction scan -i input.pdb -q 0 --scan-lists '[("TYR,285,CA","MMT,309,C10",1.35)]'
 
 # Two stages, LBFGS relaxations, and trajectory dumping
-pdb2reaction scan -i input.pdb -q 0 \
-    --scan-lists '[("TYR,285,CA","MMT,309,C10",1.35)]' \
-    --scan-lists '[("TYR,285,CA","MMT,309,C10",2.20),("TYR,285,CB","MMT,309,C11",1.80)]' \
+pdb2reaction scan -i input.pdb -q 0 --scan-lists \
+    '[("TYR,285,CA","MMT,309,C10",1.35)]' \
+    '[("TYR,285,CA","MMT,309,C10",2.20),("TYR,285,CB","MMT,309,C11",1.80)]' \
     --max-step-size 0.20 --dump True --out-dir ./result_scan/ --opt-mode light \
     --preopt True --endopt True
 
-# (equivalent) supply multiple stage literals after a single --scan-lists
+# Supply multiple stage literals after a single --scan-list(s)
 pdb2reaction scan -i input.pdb -q 0 --scan-lists \
     '[("TYR,285,CA","MMT,309,C10",1.35)]' \
     '[("TYR,285,CA","MMT,309,C10",2.20),("TYR,285,CB","MMT,309,C11",1.80)]'
@@ -45,7 +45,7 @@ pdb2reaction scan -i input.pdb -q 0 --scan-lists \
    charge before any scans.
 2. Optionally run an unbiased preoptimization (`--preopt True`) before any
    biasing so the starting point is relaxed.
-3. For each stage literal supplied via `--scan-lists`, parse and normalize the
+3. For each stage literal supplied via `--scan-list(s)`, parse and normalize the
    `(i, j)` indices (1-based by default). When the input is a PDB, each entry
    may be either an integer index or an atom selector string like `'TYR,285,CA'`;
    selector fields can be separated by spaces, commas, slashes, backticks, or
@@ -70,7 +70,7 @@ pdb2reaction scan -i input.pdb -q 0 --scan-lists \
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
 | `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
 | `-m, --multiplicity INT` | Spin multiplicity 2S+1 (CLI > template > 1). | `.gjf` template value or `1` |
-| `--scan-lists TEXT` | Repeatable Python literal with `(i,j,targetÅ)` tuples. Each literal is one stage. `i`/`j` can be integer indices or PDB atom selectors like `'TYR,285,CA'`. | Required |
+| `--scan-list(s) TEXT` | Python literal with `(i,j,targetÅ)` tuples. Each literal is one stage; supply multiple literals after a single flag. `i`/`j` can be integer indices or PDB atom selectors like `'TYR,285,CA'`. | Required |
 | `--one-based {True|False}` | Interpret atom indices as 1- or 0-based. | `True` |
 | `--max-step-size FLOAT` | Maximum change in any scanned bond per step (Å). Controls the number of integration steps. | `0.20` |
 | `--bias-k FLOAT` | Harmonic bias strength `k` in eV·Å⁻². Overrides `bias.k`. | `100` |
@@ -118,12 +118,10 @@ out_dir/ (default: ./result_scan/)
 - Console summaries of the resolved `geom`, `calc`, `opt`, `bias`, `bond`, and optimizer blocks plus per-stage bond-change reports.
 
 ## Notes
-- `--scan-lists` may be repeated; each literal becomes one stage. Tuples must
-  have positive targets. Atom indices are normalized to 0-based internally. For
+- Provide multiple literals after a single `--scan-list(s)` flag; repeated flags are not accepted.
+  Tuples must have positive targets. Atom indices are normalized to 0-based internally. For
   PDB inputs, `i`/`j` can be selector strings with flexible delimiters
   (space/comma/slash/backtick/backslash) and unordered tokens.
-- You can provide multiple literals after a single `--scan-lists` flag (recommended)
-  instead of repeating the flag; both forms produce sequential stages.
 - `--freeze-links` augments user `freeze_atoms` by adding parents of link-H
   atoms in PDB files so pockets stay rigid.
 - Charge and spin inherit Gaussian template metadata when available. If `-q` is

--- a/docs/scan2d.md
+++ b/docs/scan2d.md
@@ -2,7 +2,7 @@
 
 ## Overview
 `scan2d` performs a two-distance (d₁, d₂) grid scan using harmonic restraints
-and UMA-based relaxations. You supply one `--scan-list` literal with two
+and UMA-based relaxations. You supply one `--scan-list(s)` literal with two
 quadruples `(i, j, lowÅ, highÅ)`; the tool constructs linear grids for both
 ranges using `--max-step-size`, then **reorders each axis so that points closest
 to the (pre)optimized structure are visited first**. Each grid point is relaxed
@@ -14,7 +14,7 @@ or RFOptimizer when `--opt-mode heavy`.
 ## Usage
 ```bash
 pdb2reaction scan2d -i INPUT.{pdb|xyz|trj|...} -q CHARGE [--ligand-charge <number|'RES:Q,...'>] [-m MULT] \
-                    --scan-list '[(i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ)]' [options]
+                    --scan-list(s) '[(i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ)]' [options]
                     [--convert-files {True|False}]
 ```
 
@@ -22,11 +22,11 @@ pdb2reaction scan2d -i INPUT.{pdb|xyz|trj|...} -q CHARGE [--ligand-charge <numbe
 ```bash
 # Minimal two-distance scan
 pdb2reaction scan2d -i input.pdb -q 0 \
-    --scan-list '[("TYR,285,CA","MMT,309,C10",1.30,3.10),("TYR,285,CB","MMT,309,C11",1.20,3.20)]'
+    --scan-list(s) '[("TYR,285,CA","MMT,309,C10",1.30,3.10),("TYR,285,CB","MMT,309,C11",1.20,3.20)]'
 
 # LBFGS, dumped inner trajectories, and Plotly outputs
 pdb2reaction scan2d -i input.pdb -q 0 \
-    --scan-list '[("TYR,285,CA","MMT,309,C10",1.30,3.10),("TYR,285,CB","MMT,309,C11",1.20,3.20)]' \
+    --scan-list(s) '[("TYR,285,CA","MMT,309,C10",1.30,3.10),("TYR,285,CB","MMT,309,C11",1.20,3.20)]' \
     --max-step-size 0.20 --dump True --out-dir ./result_scan2d/ --opt-mode light \
     --preopt True --baseline min
 ```
@@ -38,7 +38,7 @@ pdb2reaction scan2d -i input.pdb -q 0 \
    complex and `extract.py`’s charge summary derives the total charge before the
    scan. The preoptimized structure is saved under `grid/preopt_i###_j###.*` and
    its unbiased energy is stored in `surface.csv` with indices `i = j = -1`.
-2. Parse the single `--scan-list` literal into two quadruples, normalize indices
+2. Parse the single `--scan-list(s)` literal into two quadruples, normalize indices
    (1-based by default). For PDB inputs, each atom entry can be an integer index
    or a selector string like `'TYR,285,CA'`; delimiters may be spaces, commas,
    slashes, backticks, or backslashes, and token order is flexible (fallback
@@ -70,7 +70,7 @@ pdb2reaction scan2d -i input.pdb -q 0 \
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
 | `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
 | `-m, --multiplicity INT` | Spin multiplicity 2S+1 (CLI > template > 1). | `.gjf` template value or `1` |
-| `--scan-list TEXT` | **Single** Python literal with two quadruples `(i,j,lowÅ,highÅ)`. `i`/`j` can be integer indices or PDB atom selectors like `'TYR,285,CA'`. | Required |
+| `--scan-list(s) TEXT` | **Single** Python literal with two quadruples `(i,j,lowÅ,highÅ)`. `i`/`j` can be integer indices or PDB atom selectors like `'TYR,285,CA'`. | Required |
 | `--one-based {True|False}` | Interpret `(i, j)` indices as 1- or 0-based. | `True` |
 | `--max-step-size FLOAT` | Maximum change allowed for either distance per increment (Å). Determines the grid density. | `0.20` |
 | `--bias-k FLOAT` | Harmonic bias strength `k` in eV·Å⁻². Overrides `bias.k`. | `100` |

--- a/docs/scan3d.md
+++ b/docs/scan3d.md
@@ -2,7 +2,7 @@
 
 ## Overview
 `scan3d` performs a three-distance grid scan with harmonic restraints using the
-UMA calculator. You provide exactly one `--scan-list` literal containing three
+UMA calculator. You provide exactly one `--scan-list(s)` literal containing three
 quadruples `(i, j, lowÅ, highÅ)`. The tool builds linear grids for each distance
 with `--max-step-size`, reorders the values so that those nearest to the
 (pre‑optimized) starting structure are visited first, and then nests the loops
@@ -17,7 +17,7 @@ option to load the CSV after the scan finishes and changing `--zmin` and `--zmax
 ## Usage
 ```bash
 pdb2reaction scan3d -i INPUT.{pdb|xyz|trj|...} -q CHARGE [--ligand-charge <number|'RES:Q,...'>] [-m MULT] \
-                    --scan-list '[(i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ)]' [options] \
+                    --scan-list(s) '[(i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ)]' [options] \
                     [--convert-files {True|False}]
 ```
 
@@ -25,17 +25,17 @@ pdb2reaction scan3d -i INPUT.{pdb|xyz|trj|...} -q CHARGE [--ligand-charge <numbe
 ```bash
 # Minimal three-distance scan
 pdb2reaction scan3d -i input.pdb -q 0 \
-    --scan-list '[("TYR,285,CA","MMT,309,C10",1.30,3.10),("TYR,285,CB","MMT,309,C11",1.20,3.20),("TYR,285,CG","MMT,309,C12",1.10,3.00)]'
+    --scan-list(s) '[("TYR,285,CA","MMT,309,C10",1.30,3.10),("TYR,285,CB","MMT,309,C11",1.20,3.20),("TYR,285,CG","MMT,309,C12",1.10,3.00)]'
 
 # LBFGS relaxations, dumped inner trajectories, and HTML isosurface plot
 pdb2reaction scan3d -i input.pdb -q 0 \
-    --scan-list '[("TYR,285,CA","MMT,309,C10",1.30,3.10),("TYR,285,CB","MMT,309,C11",1.20,3.20),("TYR,285,CG","MMT,309,C12",1.10,3.00)]' \
+    --scan-list(s) '[("TYR,285,CA","MMT,309,C10",1.30,3.10),("TYR,285,CB","MMT,309,C11",1.20,3.20),("TYR,285,CG","MMT,309,C12",1.10,3.00)]' \
     --max-step-size 0.20 --dump True --out-dir ./result_scan3d/ --opt-mode light \
     --preopt True --baseline min
 
 # Plot only from an existing surface.csv (skip new energy evaluation)
 pdb2reaction scan3d -i input.pdb -q 0 \
-    --scan-list '[("TYR,285,CA","MMT,309,C10",1.30,3.10),("TYR,285,CB","MMT,309,C11",1.20,3.20),("TYR,285,CG","MMT,309,C12",1.10,3.00)]' \
+    --scan-list(s) '[("TYR,285,CA","MMT,309,C10",1.30,3.10),("TYR,285,CB","MMT,309,C11",1.20,3.20),("TYR,285,CG","MMT,309,C12",1.10,3.00)]' \
     --csv ./result_scan3d/surface.csv --zmin -10 --zmax 40 --out-dir ./result_scan3d/
 ```
 
@@ -45,7 +45,7 @@ pdb2reaction scan3d -i input.pdb -q 0 \
    when `--preopt True`. If `-q` is omitted but `--ligand-charge` is provided, the
    structure is treated as an enzyme–substrate complex and `extract.py`’s charge
    summary derives the total charge before scanning.
-2. Parse the single `--scan-list` literal (default 1-based indices unless
+2. Parse the single `--scan-list(s)` literal (default 1-based indices unless
    `--one-based False` is passed) into three quadruples. For PDB inputs, each
    atom entry can be an integer index or a selector string like `'TYR,285,CA'`;
    delimiters may be spaces, commas, slashes, backticks, or backslashes, and
@@ -73,7 +73,7 @@ pdb2reaction scan3d -i input.pdb -q 0 \
 | `--ligand-charge TEXT` | Total charge or per-resname mapping used when `-q` is omitted. Triggers extract-style charge derivation on the full complex. | `None` |
 | `--workers`, `--workers-per-node` | UMA predictor parallelism (workers > 1 disables analytic Hessians; `workers_per_node` forwarded to the parallel predictor). | `1`, `1` |
 | `-m, --multiplicity INT` | Spin multiplicity 2S+1. | `1` |
-| `--scan-list TEXT` | **Single** Python literal with three quadruples `(i,j,lowÅ,highÅ)`. `i`/`j` can be integer indices or PDB atom selectors like `'TYR,285,CA'`. | Required |
+| `--scan-list(s) TEXT` | **Single** Python literal with three quadruples `(i,j,lowÅ,highÅ)`. `i`/`j` can be integer indices or PDB atom selectors like `'TYR,285,CA'`. | Required |
 | `--one-based {True|False}` | Interpret `(i, j)` indices as 1- or 0-based. | `True` |
 | `--max-step-size FLOAT` | Maximum change allowed per distance increment (Å). Controls grid density. | `0.20` |
 | `--bias-k FLOAT` | Harmonic bias strength `k` in eV·Å⁻². Overrides `bias.k`. | `100` |

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -7,7 +7,7 @@ scan2d — Two-distance 2D scan with harmonic restraints
 Usage (CLI)
 -----------
     pdb2reaction scan2d -i INPUT.{pdb,xyz,trj,...} [-q <charge>] [--ligand-charge <number|'RES:Q,...'>] [-m <multiplicity>] \
-        --scan-list '[(I1,J1,LOW1,HIGH1),(I2,J2,LOW2,HIGH2)]' \
+        --scan-list(s) '[(I1,J1,LOW1,HIGH1),(I2,J2,LOW2,HIGH2)]' \
         [--one-based {True|False}] \
         [--max-step-size FLOAT] \
         [--bias-k FLOAT] \
@@ -27,18 +27,18 @@ Examples
 --------
     # Minimal example (two distance ranges)
     pdb2reaction scan2d -i input.pdb -q 0 \
-        --scan-list '[(12,45,1.30,3.10),(10,55,1.20,3.20)]'
+        --scan-list(s) '[(12,45,1.30,3.10),(10,55,1.20,3.20)]'
 
     # LBFGS with trajectory dumping and PNG + HTML plots
     pdb2reaction scan2d -i input.pdb -q 0 \
-        --scan-list '[(12,45,1.30,3.10),(10,55,1.20,3.20)]' \
+        --scan-list(s) '[(12,45,1.30,3.10),(10,55,1.20,3.20)]' \
         --max-step-size 0.20 --dump True --out-dir ./result_scan2d/ --opt-mode light \
         --preopt True --baseline min
 
 Description
 -----------
 - A 2D grid scan driven by harmonic restraints on two inter-atomic distances (d1, d2).
-- Provide exactly one Python-like list `[(i1, j1, low1, high1), (i2, j2, low2, high2)]` via **--scan-list**.
+- Provide exactly one Python-like list `[(i1, j1, low1, high1), (i2, j2, low2, high2)]` via **--scan-list(s)**.
   - Indices are **1-based by default**; pass **--one-based False** to interpret them as 0-based.
   - For PDB inputs, each atom entry can be an integer index or a selector string such as
     ``'TYR,285,CA'`` or ``'MMT,309,C10'`` (resname, resseq, atom).
@@ -413,6 +413,7 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
 )
 @click.option(
     "--scan-list",
+    "--scan-lists",
     "scan_list_raw",
     type=str,
     required=True,

--- a/pdb2reaction/scan3d.py
+++ b/pdb2reaction/scan3d.py
@@ -8,7 +8,7 @@ Usage (CLI)
 -----------
     pdb2reaction scan3d -i INPUT.{pdb,xyz,trj,...} [-q CHARGE] [--ligand-charge <number|'RES:Q,...'>] \
         [-m MULTIPLICITY] \
-        --scan-list '[(I1,J1,LOW1,HIGH1),(I2,J2,LOW2,HIGH2),(I3,J3,LOW3,HIGH3)]' \
+        --scan-list(s) '[(I1,J1,LOW1,HIGH1),(I2,J2,LOW2,HIGH2),(I3,J3,LOW3,HIGH3)]' \
         [--one-based {True|False}] \
         [--max-step-size FLOAT] \
         [--bias-k FLOAT] \
@@ -29,17 +29,17 @@ Examples
 --------
     # Minimal example (three distance ranges)
     pdb2reaction scan3d -i input.pdb -q 0 \
-        --scan-list '[(12,45,1.30,3.10),(10,55,1.20,3.20),(15,60,1.10,3.00)]'
+        --scan-list(s) '[(12,45,1.30,3.10),(10,55,1.20,3.20),(15,60,1.10,3.00)]'
 
     # LBFGS with inner-path trajectory dumping and 3D energy isosurface plot
     pdb2reaction scan3d -i input.pdb -q 0 \
-        --scan-list '[(12,45,1.30,3.10),(10,55,1.20,3.20),(15,60,1.10,3.00)]' \
+        --scan-list(s) '[(12,45,1.30,3.10),(10,55,1.20,3.20),(15,60,1.10,3.00)]' \
         --max-step-size 0.20 --dump True --out-dir ./result_scan3d/ --opt-mode light \
         --preopt True --baseline min
 
     # Plot only from an existing surface.csv (skip new energy evaluation)
     pdb2reaction scan3d -i input.pdb -q 0 \
-        --scan-list '[(12,45,1.30,3.10),(10,55,1.20,3.20),(15,60,1.10,3.00)]' \
+        --scan-list(s) '[(12,45,1.30,3.10),(10,55,1.20,3.20),(15,60,1.10,3.00)]' \
         --csv ./result_scan3d/surface.csv --out-dir ./result_scan3d/
 
 Description
@@ -47,7 +47,7 @@ Description
 - A 3D grid scan driven by harmonic restraints on three inter-atomic distances (d1, d2, d3).
 - Provide exactly one Python-like list
       [(i1, j1, low1, high1), (i2, j2, low2, high2), (i3, j3, low3, high3)]
-  via **--scan-list**.
+  via **--scan-list(s)**.
   - Indices are **1-based by default**; pass **--one-based False** to interpret them as 0-based.
   - For PDB inputs, each atom entry can be an integer index or a selector string such as
     ``'TYR,285,CA'`` or ``'MMT,309,C10'`` (resname, resseq, atom).
@@ -486,7 +486,9 @@ def _unbiased_energy_hartree(geom, base_calc) -> float:
     help="Spin multiplicity (2S+1) for the ML region.",
 )
 @click.option(
-    "--scan-list", "scan_list_raw",
+    "--scan-list",
+    "--scan-lists",
+    "scan_list_raw",
     type=str,
     required=False,
     help=(


### PR DESCRIPTION
### Motivation

- Make the CLI and docs consistent about the new `--scan-list(s)` alias and the intended usage where multiple stage literals are passed after a single flag rather than by repeating the flag. 
- Prevent ambiguous parsing by enforcing that scan-list flags may appear at most once and must accept multiple space-separated stage literals after a single occurrence.

### Description

- Updated user-facing docs and README to use `--scan-list(s)` and to clarify that multiple stage literals should be passed after a single flag and that repeated flags are not accepted (`README.md`, `docs/all.md`, `docs/scan.md`, `docs/scan2d.md`, `docs/scan3d.md`).
- Added/adjusted CLI option aliases and help text so scan subcommands accept both `--scan-list`/`--scan-lists` spellings in usage text and examples across `scan`, `scan2d`, `scan3d`, and the `all` wrapper.
- In `pdb2reaction/all.py` introduced `_collect_single_option_values` and wired it into parsing so the `all` wrapper collects multiple stage literals from a single `--scan-list(s)` occurrence and raises a clear `click.BadParameter` if the flag is repeated.
- In `pdb2reaction/scan.py` enabled `context_settings` (`allow_extra_args`), added `@click.pass_context`, implemented `_collect_scan_list_values` and validation to gather stage literals after a single `--scan-list(s)` flag, updated option decorators to accept the alias, and adjusted parsing to require at least one scan-list literal for single-input runs.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977c37cc618832db1f8b921fa1f9c18)