### PR TITLE
Document --ref-pdb option in CLI docstrings and docs

### DIFF
--- a/docs/dft.md
+++ b/docs/dft.md
@@ -9,7 +9,7 @@ pdb2reaction dft -i INPUT.{pdb|xyz|gjf|...} -q CHARGE [--ligand-charge <number|'
                  --func-basis 'FUNC/BASIS' \
                  [--max-cycle N] [--conv-tol Eh] [--grid-level L] \
                  [--out-dir DIR] [--engine gpu|cpu|auto] [--convert-files {True|False}] \
-                 [--args-yaml FILE]
+                 [--ref-pdb FILE] [--args-yaml FILE]
 ```
 
 ### Examples
@@ -22,7 +22,7 @@ pdb2reaction dft -i input.pdb -q 1 -m 2 --func-basis 'wb97m-v/def2-tzvpd' --max-
 ```
 
 ## Workflow
-1. **Input handling** – Any file loadable by `geom_loader` (.pdb/.xyz/.trj/…) is accepted. Coordinates are re-exported as `input_geometry.xyz`.
+1. **Input handling** – Any file loadable by `geom_loader` (.pdb/.xyz/.trj/…) is accepted. Coordinates are re-exported as `input_geometry.xyz`. For XYZ/GJF inputs, `--ref-pdb` supplies a reference PDB topology while keeping XYZ coordinates, enabling format-aware PDB/GJF output conversion.
 2. **Configuration merge** – Defaults → CLI → YAML (`dft` block). YAML overrides take precedence over CLI flags. Charge/multiplicity inherit `.gjf` metadata when present. If `-q` is omitted but `--ligand-charge` is provided, the structure is treated as an enzyme–substrate complex and `extract.py`’s charge summary derives the total charge; explicit `-q` still overrides. Otherwise charge defaults to `0` and multiplicity to `1`.
 3. **SCF build** – `--func-basis` is parsed into functional and basis. Density fitting is enabled automatically with PySCF defaults. `--engine` controls GPU/CPU preference (`gpu` tries GPU4PySCF before falling back; `cpu` forces CPU; `auto` tries GPU then CPU). Nonlocal corrections (e.g., VV10) are not configured explicitly beyond the backend defaults.
 4. **Population analysis & outputs** – After convergence (or failure) the command writes `result.yaml` summarizing energy (Hartree/kcal·mol⁻¹), convergence metadata, timing, backend info, and per-atom Mulliken/meta-Löwdin/IAO charges and spin densities (UKS only for spins). Any failed analysis column is set to `null` with a warning.
@@ -41,6 +41,7 @@ pdb2reaction dft -i input.pdb -q 1 -m 2 --func-basis 'wb97m-v/def2-tzvpd' --max-
 | `--out-dir TEXT` | Output directory (`dft.out_dir`). | `./result_dft/` |
 | `--engine [gpu\|cpu\|auto]` | Backend policy: GPU4PySCF first, CPU only, or auto. | `gpu` |
 | `--convert-files {True|False}` | Toggle XYZ → PDB/GJF companions for PDB/Gaussian inputs. | `True` |
+| `--ref-pdb FILE` | Reference PDB topology to use when the input is XYZ/GJF (keeps XYZ coordinates). | _None_ |
 | `--args-yaml FILE` | YAML overrides (see below). | _None_ |
 
 ## Outputs

--- a/docs/freq.md
+++ b/docs/freq.md
@@ -8,6 +8,8 @@ when the optional `thermoanalysis` package is installed, and can emit a YAML sum
 `--dump True`. Configuration starts from defaults, applies CLI switches, and finally
 applies YAML overrides (`geom`, `calc`, `freq`) with highest precedence, so the same
 template can drive both standalone runs and workflows launched by other subcommands.
+For XYZ/GJF inputs, `--ref-pdb` supplies a reference PDB topology while keeping XYZ coordinates,
+enabling format-aware PDB output conversion.
 
 ## Usage
 ```bash
@@ -17,7 +19,7 @@ pdb2reaction freq -i INPUT.{pdb|xyz|trj|...} [-q CHARGE] [--ligand-charge <numbe
                   [--sort value|abs] [--out-dir DIR] [--args-yaml FILE] \
                   [--temperature K] [--pressure atm] [--dump {True|False}] \
                   [--hessian-calc-mode Analytical|FiniteDifference] \
-                  [--convert-files {True|False}]
+                  [--convert-files {True|False}] [--ref-pdb FILE]
 ```
 
 ### Examples
@@ -73,6 +75,7 @@ pdb2reaction freq -i a.xyz -q -1 --args-yaml ./args.yaml --out-dir ./result_freq
 | `--dump BOOL` | Explicit `True`/`False`. Write `thermoanalysis.yaml`. | `False` |
 | `--hessian-calc-mode CHOICE` | UMA Hessian mode (`Analytical` or `FiniteDifference`). | _None_ (uses YAML/default of `FiniteDifference`) |
 | `--convert-files {True|False}` | Toggle XYZ/TRJ → PDB companions when a PDB template is available (GJF is not written). | `True` |
+| `--ref-pdb FILE` | Reference PDB topology to use when the input is XYZ/GJF (keeps XYZ coordinates). | _None_ |
 | `--args-yaml FILE` | YAML overrides (sections: `geom`, `calc`, `freq`). | _None_ |
 
 ## Outputs

--- a/docs/irc.md
+++ b/docs/irc.md
@@ -1,7 +1,7 @@
 # `irc` subcommand
 
 ## Overview
-Run EulerPC-based Intrinsic Reaction Coordinate (IRC) integrations with UMA. The CLI is intentionally narrow: anything not listed below must be provided through YAML so that geometry handling, calculator settings, and low-level EulerPC knobs remain explicit and reproducible.
+Run EulerPC-based Intrinsic Reaction Coordinate (IRC) integrations with UMA. The CLI is intentionally narrow: anything not listed below must be provided through YAML so that geometry handling, calculator settings, and low-level EulerPC knobs remain explicit and reproducible. For XYZ/GJF inputs, `--ref-pdb` supplies a reference PDB topology while keeping XYZ coordinates, enabling format-aware PDB/GJF output conversion.
 
 ## Usage
 ```bash
@@ -10,7 +10,7 @@ pdb2reaction irc -i INPUT.{pdb|xyz|trj|...} [-q CHARGE] [--ligand-charge <number
                  [--forward True|False] [--backward True|False]
                  [--freeze-links True|False]
                  [--out-dir DIR]
-                 [--convert-files {True|False}]
+                 [--convert-files {True|False}] [--ref-pdb FILE]
                  [--hessian-calc-mode Analytical|FiniteDifference]
                  [--args-yaml FILE]
 ```
@@ -47,6 +47,7 @@ pdb2reaction irc -i ts.pdb -q 0 -m 1 --max-cycles 50 --out-dir ./result_irc/
 | `--freeze-links BOOL` | For PDB inputs, freeze link-H parents (merged with `geom.freeze_atoms`). | `True` |
 | `--out-dir TEXT` | Output directory (`irc.out_dir`). | `./result_irc/` |
 | `--convert-files {True|False}` | Toggle XYZ/TRJ → PDB companions for PDB inputs. | `True` |
+| `--ref-pdb FILE` | Reference PDB topology to use when the input is XYZ/GJF (keeps XYZ coordinates). | _None_ |
 | `--hessian-calc-mode CHOICE` | UMA Hessian mode (`calc.hessian_calc_mode`). | `FiniteDifference` |
 | `--args-yaml FILE` | YAML overrides (see below). | _None_ |
 

--- a/docs/opt.md
+++ b/docs/opt.md
@@ -6,6 +6,8 @@
 When the starting structure is a PDB or Gaussian template, format-aware conversion mirrors the optimized structure into `.pdb` (PDB inputs) and `.gjf` (Gaussian templates) companions, controlled by `--convert-files {True|False}` (enabled by default). PDB-specific conveniences include:
 - With `--freeze-links` (default `True`), parent atoms of link hydrogens are detected and merged into `geom.freeze_atoms` (0-based indices).
 - Output conversion produces `final_geometry.pdb` (and `optimization.pdb` when dumping trajectories) using the input PDB as the topology reference.
+For XYZ/GJF inputs, `--ref-pdb` supplies a reference PDB topology while keeping XYZ coordinates,
+enabling format-aware PDB/GJF output conversion.
 
 A Gaussian `.gjf` template seeds the charge/spin defaults and enables automatic export of the optimized structure as `.gjf` when conversion is enabled.
 
@@ -16,7 +18,7 @@ pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} -q CHARGE [--ligand-charge <number|'
                  [--dist-freeze '[(i,j,target_A), ...]'] [--one-based {True|False}] \
                  [--bias-k K_eV_per_A2] [--dump BOOL] [--out-dir DIR] \
                  [--max-cycles N] [--thresh PRESET] [--args-yaml FILE] \
-                 [--convert-files {True|False}]
+                 [--convert-files {True|False}] [--ref-pdb FILE]
 ```
 
 ## Workflow
@@ -43,6 +45,7 @@ pdb2reaction opt -i INPUT.{pdb|xyz|trj|...} -q CHARGE [--ligand-charge <number|'
 | `--opt-mode TEXT` | Choose optimizer: `light` (LBFGS) or `heavy` (RFO). | `light` |
 | `--dump BOOL` | Emit trajectory dumps (`optimization.trj`). | `False` |
 | `--convert-files {True|False}` | Enable or disable XYZ/TRJ → PDB companions for PDB inputs and XYZ → GJF companions for Gaussian templates. | `True` |
+| `--ref-pdb FILE` | Reference PDB topology to use when the input is XYZ/GJF (keeps XYZ coordinates). | _None_ |
 | `--out-dir TEXT` | Output directory for all files. | `./result_opt/` |
 | `--thresh TEXT` | Override convergence preset (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | _None_ |
 | `--args-yaml FILE` | Supply YAML overrides (sections `geom`, `calc`, `opt`, `lbfgs`, `rfo`). | _None_ |

--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -1,7 +1,7 @@
 # `path-search` subcommand
 
 ## Overview
-Construct a continuous minimum-energy path (MEP) across **two or more** structures ordered along a reaction coordinate. `path-search` chains together GSM **or DMF** segments, selectively refines only those regions with covalent changes, and (optionally) merges PDB pockets back into full-size templates. The same recursive workflow runs for either segment generator via `--mep-mode`, with **GSM as the default**. Format-aware conversions mirror trajectories and HEI snapshots into `.pdb` or multi-geometry `.gjf` companions when `--convert-files` is enabled (default) and matching templates exist.
+Construct a continuous minimum-energy path (MEP) across **two or more** structures ordered along a reaction coordinate. `path-search` chains together GSM **or DMF** segments, selectively refines only those regions with covalent changes, and (optionally) merges PDB pockets back into full-size templates. The same recursive workflow runs for either segment generator via `--mep-mode`, with **GSM as the default**. Format-aware conversions mirror trajectories and HEI snapshots into `.pdb` or multi-geometry `.gjf` companions when `--convert-files` is enabled (default) and matching templates exist. For XYZ/GJF inputs, `--ref-pdb` supplies pocket-level PDB topologies while keeping XYZ coordinates, enabling PDB/GJF companion generation and full-template merges.
 
 ## Usage
 ```bash
@@ -11,7 +11,7 @@ pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb [-q CHARGE] [--ligand-charge
                          [--max-nodes N] [--max-cycles N] [--climb BOOL]
                          [--opt-mode light|heavy] [--dump BOOL]
                          [--out-dir DIR] [--preopt BOOL]
-                         [--align {True|False}] [--ref-full-pdb FILE ...]
+                         [--align {True|False}] [--ref-full-pdb FILE ...] [--ref-pdb FILE ...]
                          [--convert-files {True|False}]
                          [--args-yaml FILE]
 ```
@@ -51,6 +51,7 @@ pdb2reaction path-search -i R.pdb [I.pdb ...] P.pdb [-q CHARGE] [--ligand-charge
 | `--preopt BOOL` | Explicit `True`/`False`. Pre-optimize each endpoint before MEP search (recommended). | `True` |
 | `--align {True|False}` | Align all inputs to the first structure before searching. | `True` |
 | `--ref-full-pdb PATH...` | Full-size template PDBs (one per input, unless `--align` lets you reuse the first). | _None_ |
+| `--ref-pdb PATH...` | Pocket reference PDBs to use when inputs are XYZ/GJF (one per input; keeps XYZ coordinates). | _None_ |
 
 ## Workflow
 1. **Initial segment per pair (GSM/DMF)** – run `GrowingString` or DMF between each adjacent input (A→B) to obtain a coarse MEP and identify the highest-energy image (HEI).

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -11,12 +11,14 @@ to disk.
 When `--scan-list(s)` is supplied once the scan runs in a single stage; supplying
 multiple literals runs sequential stages, each starting from the previous stage’s
 relaxed result.
+For XYZ/GJF inputs, `--ref-pdb` supplies a reference PDB topology while keeping XYZ coordinates,
+enabling format-aware PDB/GJF output conversion.
 
 ## Usage
 ```bash
 pdb2reaction scan -i INPUT.{pdb|xyz|trj|...} -q CHARGE [--ligand-charge <number|'RES:Q,...'>] [-m MULT] \
                   --scan-list(s) '[(i,j,targetÅ), ...]' [options]
-                  [--convert-files {True|False}]
+                  [--convert-files {True|False}] [--ref-pdb FILE]
 ```
 
 ### Examples
@@ -79,6 +81,7 @@ pdb2reaction scan -i input.pdb -q 0 --scan-lists \
 | `--freeze-links BOOL` | When the input is PDB, freeze the parents of link hydrogens. | `True` |
 | `--dump BOOL` | Dump concatenated biased trajectories (`scan.trj`/`scan.pdb`). | `False` |
 | `--convert-files {True|False}` | Toggle XYZ/TRJ → PDB/GJF companions for PDB/Gaussian inputs. | `True` |
+| `--ref-pdb FILE` | Reference PDB topology to use when the input is XYZ/GJF (keeps XYZ coordinates). | _None_ |
 | `--out-dir TEXT` | Output directory root. | `./result_scan/` |
 | `--thresh TEXT` | Convergence preset override (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | _None_ |
 | `--args-yaml FILE` | YAML overrides for `geom`, `calc`, `opt`, `lbfgs`, `rfo`, `bias`, `bond`. | _None_ |

--- a/docs/scan2d.md
+++ b/docs/scan2d.md
@@ -10,12 +10,14 @@ and written alongside a ready-to-plot CSV/figure bundle. Energies reported in
 `surface.csv` are always evaluated **without bias** so you can compare grid
 points directly. Optimizations use LBFGS when `--opt-mode light` (default)
 or RFOptimizer when `--opt-mode heavy`.
+For XYZ/GJF inputs, `--ref-pdb` supplies a reference PDB topology while keeping XYZ coordinates,
+enabling format-aware PDB/GJF output conversion.
 
 ## Usage
 ```bash
 pdb2reaction scan2d -i INPUT.{pdb|xyz|trj|...} -q CHARGE [--ligand-charge <number|'RES:Q,...'>] [-m MULT] \
                     --scan-list(s) '[(i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ)]' [options]
-                    [--convert-files {True|False}]
+                    [--convert-files {True|False}] [--ref-pdb FILE]
 ```
 
 ### Examples
@@ -79,6 +81,7 @@ pdb2reaction scan2d -i input.pdb -q 0 \
 | `--freeze-links BOOL` | When the input is PDB, freeze parents of link hydrogens. | `True` |
 | `--dump BOOL` | Write `inner_path_d1_###.trj` for each outer step. | `False` |
 | `--convert-files {True|False}` | Toggle XYZ/TRJ → PDB/GJF companions for PDB/Gaussian inputs. | `True` |
+| `--ref-pdb FILE` | Reference PDB topology to use when the input is XYZ/GJF (keeps XYZ coordinates). | _None_ |
 | `--out-dir TEXT` | Output directory root for grids and plots. | `./result_scan2d/` |
 | `--thresh TEXT` | Convergence preset override (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | _None_ |
 | `--args-yaml FILE` | YAML overrides for `geom`, `calc`, `opt`, `lbfgs`, `rfo`, `bias`. | _None_ |

--- a/docs/scan3d.md
+++ b/docs/scan3d.md
@@ -10,6 +10,8 @@ with `--max-step-size`, reorders the values so that those nearest to the
 appropriate restraints active; unbiased energies are recorded so you can compare
 points directly. A precomputed `surface.csv` can also be visualized without
 rerunning the scan.
+For XYZ/GJF inputs, `--ref-pdb` supplies a reference PDB topology while keeping XYZ coordinates,
+enabling format-aware PDB/GJF output conversion.
 
 > If you want to adjust the plot for better visibility, we recommend adding the
 option to load the CSV after the scan finishes and changing `--zmin` and `--zmax`.
@@ -18,7 +20,7 @@ option to load the CSV after the scan finishes and changing `--zmin` and `--zmax
 ```bash
 pdb2reaction scan3d -i INPUT.{pdb|xyz|trj|...} -q CHARGE [--ligand-charge <number|'RES:Q,...'>] [-m MULT] \
                     --scan-list(s) '[(i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ), (i,j,lowÅ,highÅ)]' [options] \
-                    [--convert-files {True|False}]
+                    [--convert-files {True|False}] [--ref-pdb FILE]
 ```
 
 ### Examples
@@ -82,6 +84,7 @@ pdb2reaction scan3d -i input.pdb -q 0 \
 | `--freeze-links BOOL` | When the input is PDB, freeze parents of link hydrogens. | `True` |
 | `--dump BOOL` | Write `inner_path_d1_###_d2_###.trj` for each (d₁, d₂). | `False` |
 | `--convert-files {True|False}` | Toggle XYZ/TRJ → PDB/GJF companions for PDB/Gaussian inputs. | `True` |
+| `--ref-pdb FILE` | Reference PDB topology to use when the input is XYZ/GJF (keeps XYZ coordinates). | _None_ |
 | `--out-dir TEXT` | Output directory root for grids and plots. | `./result_scan3d/` |
 | `--csv PATH` | Load an existing `surface.csv` and only plot it (no new scan). | _None_ |
 | `--thresh TEXT` | Convergence preset override (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`). | _None_ |

--- a/docs/tsopt.md
+++ b/docs/tsopt.md
@@ -13,6 +13,8 @@ Both modes use the UMA calculator for energies/gradients/Hessians, inherit `geom
 settings from YAML, and always write the final imaginary mode in `.trj`. When
 `--convert-files` is enabled (default), PDB inputs mirror trajectories into `.pdb`
 companions and Gaussian templates receive multi-geometry `.gjf` exports.
+For XYZ/GJF inputs, `--ref-pdb` supplies a reference PDB topology while keeping XYZ coordinates,
+enabling format-aware PDB/GJF output conversion.
 
 ## Usage
 ```bash
@@ -21,7 +23,7 @@ pdb2reaction tsopt -i INPUT.{pdb|xyz|trj|...} [-q CHARGE] [--ligand-charge <numb
                     [--freeze-links {True|False}] [--max-cycles N] [--thresh PRESET] \
                     [--dump {True|False}] [--out-dir DIR] [--args-yaml FILE] \
                     [--hessian-calc-mode Analytical|FiniteDifference] \
-                    [--convert-files {True|False}]
+                    [--convert-files {True|False}] [--ref-pdb FILE]
 ```
 
 ### Examples
@@ -93,6 +95,7 @@ pdb2reaction tsopt -i ts_cand.pdb -q 0 -m 1 --opt-mode heavy \
 | `--flatten-imag-mode {True|False}` | Enable the extra-imaginary-mode flattening loop (`False` forces `flatten_max_iter=0`). Applies to both light (dimer loop) and heavy (post-RSIRFO) modes. | `False` |
 | `--hessian-calc-mode CHOICE` | UMA Hessian mode (`Analytical` or `FiniteDifference`). | _None_ (uses YAML/default of `FiniteDifference`) |
 | `--convert-files {True|False}` | Toggle XYZ/TRJ → PDB/GJF companions for PDB or Gaussian inputs. | `True` |
+| `--ref-pdb FILE` | Reference PDB topology to use when the input is XYZ/GJF (keeps XYZ coordinates). | _None_ |
 | `--args-yaml FILE` | YAML overrides (`geom`, `calc`, `opt`, `hessian_dimer`, `rsirfo`). | _None_ |
 
 ## Outputs (& directory layout)

--- a/pdb2reaction/dft.py
+++ b/pdb2reaction/dft.py
@@ -9,7 +9,7 @@ Usage (CLI)
     pdb2reaction dft -i INPUT.{pdb|xyz|gjf|...} [-q <charge>] [--ligand-charge <number|'RES:Q,...'>] [-m <multiplicity>] \
         [--func-basis 'FUNC/BASIS'] [--max-cycle <int>] [--conv-tol <hartree>] \
         [--grid-level <int>] [--out-dir <dir>] [--engine {gpu|cpu|auto}] \
-        [--convert-files {True|False}] [--args-yaml <file>]
+        [--convert-files {True|False}] [--ref-pdb <file>] [--args-yaml <file>]
 
 Examples
 --------
@@ -31,6 +31,8 @@ Description
 - RKS/UKS is selected automatically from the spin multiplicity (2S+1).
 - Inputs: any structure format supported by pysisyphus.helpers.geom_loader (.pdb, .xyz, .trj, …).
   The geometry is written back unchanged as input_geometry.xyz.
+- For XYZ/GJF inputs, `--ref-pdb` supplies a reference PDB topology while keeping XYZ coordinates, enabling
+  format-aware PDB/GJF output conversion.
 - Functional/basis specified as 'FUNC/BASIS' via --func-basis (e.g., 'wb97m-v/6-31g**', 'wb97m-v/def2-svp', 'wb97m-v/def2-tzvpd').
   Names are case-insensitive in PySCF.
 - Density fitting (DF) is enabled via PySCF's density_fit(); the auxiliary basis is left to

--- a/pdb2reaction/freq.py
+++ b/pdb2reaction/freq.py
@@ -12,7 +12,7 @@ Usage (CLI)
         [--out-dir <dir>] [--args-yaml <file>] [--temperature <K>] \
         [--pressure <atm>] [--dump {True|False}] \
         [--hessian-calc-mode {Analytical|FiniteDifference}] \
-        [--convert-files {True|False}]
+        [--convert-files {True|False}] [--ref-pdb <file>]
 
 Examples
 --------
@@ -27,6 +27,8 @@ Description
 - Computes vibrational frequencies and normal modes using the UMA calculator.
 - Supports Partial Hessian Vibrational Analysis (PHVA) when atoms are frozen.
 - Exports animated modes (.trj; and, for PDB inputs, optionally .pdb animations when ``--convert-files`` is enabled) and prints a Gaussian-style thermochemistry summary.
+- For XYZ/GJF inputs, ``--ref-pdb`` supplies a reference PDB topology while keeping XYZ coordinates, enabling
+  format-aware PDB/GJF output conversion.
 - Configuration can be provided via YAML (sections: ``geom``, ``calc``, ``freq``); YAML values override CLI.
 - Thermochemistry uses the PHVA frequencies (respecting ``freeze_atoms``). CLI pressure (atm) is converted internally to Pa.
 - The thermochemistry summary is printed when the optional ``thermoanalysis`` package is available; writing a YAML summary is controlled by ``--dump``.

--- a/pdb2reaction/irc.py
+++ b/pdb2reaction/irc.py
@@ -9,7 +9,7 @@ Usage (CLI)
     pdb2reaction irc -i INPUT.{pdb|xyz|trj|...} [-q <charge>] [--ligand-charge <number|'RES:Q,...'>] [-m <multiplicity>] \
         [--max-cycles <int>] [--step-size <float>] [--root <int>] \
         [--forward {True|False}] [--backward {True|False}] \
-        [--freeze-links {True|False}] [--convert-files {True|False}] \
+        [--freeze-links {True|False}] [--convert-files {True|False}] [--ref-pdb <file>] \
         [--out-dir <dir>] [--hessian-calc-mode {Analytical|FiniteDifference}] \
         [--args-yaml <file>]
 
@@ -27,6 +27,8 @@ Description
 - Purpose: Run Intrinsic Reaction Coordinate (IRC) calculations using the EulerPC predictor–corrector integrator.
 - Inputs: Any structure readable by `pysisyphus.helpers.geom_loader` (.pdb, .xyz, .trj, ...).
   If the input is `.pdb`, trajectory files written by the run are additionally converted to PDB (when conversion is enabled).
+- For XYZ/GJF inputs, `--ref-pdb` supplies a reference PDB topology while keeping XYZ coordinates, enabling
+  format-aware PDB/GJF output conversion.
 - Configuration model: Only the CLI options listed above are accepted. All other parameters
   (geometry options, UMA calculator configuration, and detailed EulerPC/IRC settings) must be provided via YAML.
   Final configuration precedence: built-in defaults → CLI → YAML.
@@ -48,6 +50,7 @@ CLI options
   - `--backward BOOL`: Run the backward IRC (explicit `True`/`False`); sets `irc.backward`.
   - `--freeze-links BOOL` (default `True`): Freeze parent atoms of link hydrogens when the input is PDB.
   - `--convert-files {True|False}` (default `True`): Convert XYZ/TRJ outputs into PDB/GJF companions based on the input format.
+  - `--ref-pdb PATH`: Reference PDB topology to use when the input is XYZ/GJF (keeps XYZ coordinates).
   - `--out-dir STR` (default `./result_irc/`): Output directory; sets `irc.out_dir`.
   - `--hessian-calc-mode {Analytical,FiniteDifference}`: How UMA builds the Hessian; sets `calc.hessian_calc_mode`.
   - `--args-yaml PATH`: YAML file with sections `geom`, `calc`, and `irc`.

--- a/pdb2reaction/opt.py
+++ b/pdb2reaction/opt.py
@@ -12,7 +12,7 @@ Usage (CLI)
         [--bias-k <float>] [--dump {True|False}] [--out-dir <dir>] \
         [--workers <int>] [--workers-per-node <int>] \
         [--max-cycles <int>] [--thresh <preset>] [--args-yaml <file>] \
-        [--convert-files {True|False}]
+        [--convert-files {True|False}] [--ref-pdb <file>]
 
 Examples
 --------
@@ -31,6 +31,8 @@ Description
 - Configuration via YAML sections `geom`, `calc`, `opt`, `lbfgs`, `rfo`. **Precedence:** defaults → CLI overrides → YAML overrides (highest). (If the same key is set in both `opt` and `lbfgs`/`rfo`, the `opt` value takes precedence.)
 - PDB-aware post-processing: if the input is a PDB, convert `final_geometry.xyz` → `final_geometry.pdb` and, when
   `--dump True`, `optimization.trj` → `optimization.pdb` using the input PDB as the topology reference.
+- For XYZ/GJF inputs, `--ref-pdb` supplies a reference PDB topology while keeping XYZ coordinates, enabling
+  format-aware PDB/GJF output conversion.
 - Format mirroring can be toggled with `--convert-files {True|False}` (default: enabled); when a Gaussian template
   is present, `.gjf` companions are emitted alongside `.xyz` and `.pdb` outputs.
 - Optional link-atom handling for PDBs: `--freeze-links True` (default) detects link hydrogen parents and freezes those

--- a/pdb2reaction/scan.py
+++ b/pdb2reaction/scan.py
@@ -11,7 +11,7 @@ Usage (CLI)
         [--one-based {True|False}] [--max-step-size <float>] \
         [--bias-k <float>] [--relax-max-cycles <int>] \
         [--opt-mode {light|heavy}] [--freeze-links {True|False}] \
-        [--dump {True|False}] [--convert-files {True|False}] \
+        [--dump {True|False}] [--convert-files {True|False}] [--ref-pdb <file>] \
         [--out-dir <dir>] [--thresh <preset>] [--args-yaml <file>] \
         [--preopt {True|False}] [--endopt {True|False}]
 
@@ -38,6 +38,8 @@ For non-PDB inputs, only integer indices are supported.
 If you pass one ``--scan-list(s)`` literal, the scan runs in a single stage; multiple
 literals are executed as sequential stages, each starting from the previous stage’s
 relaxed final structure.
+Use ``--ref-pdb`` with XYZ/GJF inputs to load a reference PDB topology while keeping
+the XYZ coordinates, enabling format-aware PDB/GJF output conversions.
 
 Scheduling
   - For scan tuples [(i, j, target_Å)], compute the Å‑space displacement Δ = target − current_distance_Å.

--- a/pdb2reaction/scan2d.py
+++ b/pdb2reaction/scan2d.py
@@ -15,7 +15,7 @@ Usage (CLI)
         [--opt-mode {light,heavy}] \
         [--freeze-links {True|False}] \
         [--dump {True|False}] \
-        [--convert-files {True|False}] \
+        [--convert-files {True|False}] [--ref-pdb FILE] \
         [--out-dir PATH] \
         [--args-yaml FILE] \
         [--preopt {True|False}] \
@@ -42,6 +42,8 @@ Description
   - Indices are **1-based by default**; pass **--one-based False** to interpret them as 0-based.
   - For PDB inputs, each atom entry can be an integer index or a selector string such as
     ``'TYR,285,CA'`` or ``'MMT,309,C10'`` (resname, resseq, atom).
+  - For XYZ/GJF inputs, ``--ref-pdb`` supplies a reference PDB topology while keeping the XYZ coordinates,
+    enabling format-aware PDB/GJF output conversion.
 - Step schedule (h = `--max-step-size` in Å):
   - `N1 = ceil(|high1 - low1| / h)`, `N2 = ceil(|high2 - low2| / h)`.
   - `d1_values = linspace(low1, high1, N1 + 1)` (or `[low1]` if the span is ~0)

--- a/pdb2reaction/scan3d.py
+++ b/pdb2reaction/scan3d.py
@@ -16,7 +16,7 @@ Usage (CLI)
         [--opt-mode {light,heavy}] \
         [--freeze-links {True|False}] \
         [--dump {True|False}] \
-        [--convert-files {True|False}] \
+        [--convert-files {True|False}] [--ref-pdb FILE] \
         [--out-dir PATH] \
         [--csv PATH] \
         [--args-yaml FILE] \
@@ -51,6 +51,8 @@ Description
   - Indices are **1-based by default**; pass **--one-based False** to interpret them as 0-based.
   - For PDB inputs, each atom entry can be an integer index or a selector string such as
     ``'TYR,285,CA'`` or ``'MMT,309,C10'`` (resname, resseq, atom).
+  - For XYZ/GJF inputs, ``--ref-pdb`` supplies a reference PDB topology while keeping the XYZ coordinates,
+    enabling format-aware PDB/GJF output conversion.
 - `-q/--charge` is required for non-`.gjf` inputs **unless** ``--ligand-charge`` is provided; `.gjf` templates supply
   charge/spin when available. When ``-q`` is omitted but ``--ligand-charge`` is set, the full complex is treated as an
   enzyme–substrate system and the total charge is inferred using ``extract.py``’s residue-aware logic. Explicit ``-q``

--- a/pdb2reaction/tsopt.py
+++ b/pdb2reaction/tsopt.py
@@ -10,7 +10,7 @@ Usage (CLI)
         [--opt-mode {light|heavy}] \
         [--freeze-links {True|False}] [--max-cycles <int>] [--dump {True|False}] \
         [--out-dir <dir>] [--args-yaml <file>] \
-        [--hessian-calc-mode {Analytical|FiniteDifference}]
+        [--hessian-calc-mode {Analytical|FiniteDifference}] [--ref-pdb <file>]
 
 Examples
 --------
@@ -70,6 +70,8 @@ an active-subspace (partial) Hessian block when `freeze_atoms` are present; fini
 Hessians honor the active subspace. `--hessian-calc-mode` selects Analytical or FiniteDifference.
 
 For PDB inputs, optimization trajectories and the final geometry are also converted to PDB.
+For XYZ/GJF inputs, `--ref-pdb` supplies a reference PDB topology while keeping XYZ coordinates, enabling
+format-aware PDB/GJF output conversion.
 The final imaginary mode is written as `.pdb` only when the input is PDB (the `.trj` is always written).
 
 Key behaviors and algorithmic notes


### PR DESCRIPTION
### Motivation
- Clarify the behavior and intended use of `--ref-pdb` when users supply XYZ/GJF inputs so PDB topologies can be used while preserving XYZ coordinates. 
- Make the option discoverable in command help and the reference documentation across scanning, optimization, frequency, IRC, TS, DFT and path-search workflows. 

### Description
- Added mentions of `--ref-pdb` to CLI docstrings in `pdb2reaction/scan.py`, `scan2d.py`, `scan3d.py`, `opt.py`, `dft.py`, `freq.py`, `irc.py`, and `tsopt.py` and included the flag in their usage lines. 
- Updated the user docs in `docs/scan.md`, `scan2d.md`, `scan3d.md`, `opt.md`, `dft.md`, `freq.md`, `irc.md`, `tsopt.md`, and `path_search.md` to include `--ref-pdb` in overviews, usage blocks, and CLI option tables with a short explanation that it supplies a reference PDB topology for XYZ/GJF inputs while keeping XYZ coordinates. 
- Small wording additions in the code docstrings to explain that `--ref-pdb` enables format-aware PDB/GJF output conversion and full-template merges for relevant subcommands. 

### Testing
- No automated tests were executed for this documentation-focused change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977cac2c368832dabe045fe87b9c6a5)