### PR TITLE
Fix freeze_atoms parsing and None handling

### DIFF
--- a/pdb2reaction/align_freeze_atoms.py
+++ b/pdb2reaction/align_freeze_atoms.py
@@ -255,9 +255,9 @@ def _freeze_union(g_ref, g_mob, n_atoms: Optional[int] = None) -> List[int]:
     Union of `freeze_atoms` from `g_ref` and `g_mob` (0-based).
     If `n_atoms` is given, out-of-range indices are removed. Returns [] if empty.
     """
-    fa0 = getattr(g_ref, "freeze_atoms", np.array([], int))
-    fa1 = getattr(g_mob, "freeze_atoms", np.array([], int))
-    cand = sorted(set(int(i) for i in list(fa0) + list(fa1)))
+    fa0 = getattr(g_ref, "freeze_atoms", None)
+    fa1 = getattr(g_mob, "freeze_atoms", None)
+    cand = sorted(set(int(i) for i in list(fa0 or []) + list(fa1 or [])))
     if n_atoms is None:
         return cand
     good = [i for i in cand if 0 <= i < int(n_atoms)]

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -544,9 +544,9 @@ def _make_linear_interpolations(gL, gR, n_internal: int) -> List[Any]:
     assert A.shape == B.shape and A.shape[1] == 3, "Atom counts must match for interpolation."
     atoms = [a for a in gL.atoms]
     coord_type = gL.coord_type
-    faL = getattr(gL, "freeze_atoms", np.array([], dtype=int))
-    faR = getattr(gR, "freeze_atoms", np.array([], dtype=int))
-    freeze_union = sorted(set(map(int, faL)) | set(map(int, faR)))
+    faL = getattr(gL, "freeze_atoms", None)
+    faR = getattr(gR, "freeze_atoms", None)
+    freeze_union = sorted(set(map(int, faL or [])) | set(map(int, faR or [])))
     interps: List[Any] = []
     for k in range(1, n_internal + 1):
         t = k / (n_internal + 1.0)


### PR DESCRIPTION
### Motivation
- `merge_freeze_atom_indices` treated any iterable (including strings) by iterating characters, causing `ValueError` or incorrect freeze lists when YAML/CLI strings like `"1,2,3"` or `"[1,2]"` were supplied.  
- `detect_freeze_links` could return `-1` for link hydrogens when the PDB contains link hydrogens but no other atoms, which propagates invalid indices into merged freeze lists.  
- Several call sites assumed `geom.freeze_atoms` is always an array and used `set(map(int, ...))` or `list(...)`, which raises `TypeError` when `freeze_atoms` is `None` and can crash interpolation/alignment routines.  

### Description
- In `pdb2reaction/utils.py` added a helper `_coerce_freeze_atoms` and updated `merge_freeze_atom_indices` to safely coerce `None`, string, and iterable inputs into a list of integers (using regex extraction for numeric tokens in strings and robust `int()` conversion).  
- In `pdb2reaction/utils.py` changed `detect_freeze_links` to return an empty list when link hydrogens exist but there are no other atoms, and to omit `-1` indices (only append non-negative indices).  
- In `pdb2reaction/path_search.py` updated `_make_linear_interpolations` to handle `None` `freeze_atoms` by treating them as empty lists when computing the union.  
- In `pdb2reaction/align_freeze_atoms.py` updated `_freeze_union` to treat `None` `freeze_atoms` as empty lists before forming the union and filtering out-of-range indices.  

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977d06966f0832d88c53c7af9ba28a3)