### PR TITLE
Guard extract against multi-model inputs

### DIFF
--- a/pdb2reaction/extract.py
+++ b/pdb2reaction/extract.py
@@ -483,6 +483,17 @@ def load_structure(path: str, name: str) -> PDB.Structure.Structure:
     """
     parser = PDB.PDBParser(QUIET=True)
     structure = parser.get_structure(name, path)
+    models = list(structure.get_models())
+    if len(models) > 1:
+        logging.warning(
+            "Input '%s' contains %d MODELs; extract supports single-model PDBs only. "
+            "Using first model (%s) and ignoring the rest.",
+            path,
+            len(models),
+            models[0].id,
+        )
+        for model in models[1:]:
+            structure.detach_child(model.id)
     missing_elem = [a for a in structure.get_atoms() if not (getattr(a, "element", "") or "").strip()]
     if missing_elem:
         raise ValueError(


### PR DESCRIPTION
### Motivation
- The CLI/docs indicate `MODEL/ENDMDL` records are unsupported but the implementation could mix atoms/residues from multiple models, causing duplicate or incorrect selections, so only the first model should be used when a multi-model PDB is supplied.

### Description
- In `load_structure` (in `pdb2reaction/extract.py`) detect multiple models, log a warning, and remove extra models via `structure.detach_child(model.id)` so subsequent logic (e.g., the element-symbol validation) runs against the first model only.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977e02f87dc832dbaa604dd8f05cb98)