### PR TITLE
Add --ref-pdb support to path-opt and propagate reference through preopt/path_search/all

### DIFF
--- a/docs/path_opt.md
+++ b/docs/path_opt.md
@@ -11,7 +11,7 @@ pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} [-q CHARGE] [--lig
                       [--climb BOOL] [--dump BOOL] [--thresh PRESET] \
                       [--preopt BOOL] [--preopt-max-cycles N] [--opt-mode light|heavy] [--fix-ends BOOL] \
                       [--out-dir DIR] [--args-yaml FILE] \
-                      [--convert-files {True|False}]
+                      [--convert-files {True|False}] [--ref-pdb FILE]
 ```
 
 ## Workflow
@@ -24,7 +24,7 @@ pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} [-q CHARGE] [--lig
    - The highest-energy image (HEI) is written both as `.xyz` and `.pdb` when a PDB reference exists, and as `.gjf` when a Gaussian template is available; these conversions honor `--convert-files`.
 
 ### Key behaviors
-- **Endpoints**: Exactly two structures are required. Formats follow `geom_loader`. PDB inputs also enable trajectory/HEI PDB exports.
+- **Endpoints**: Exactly two structures are required. Formats follow `geom_loader`. PDB inputs (or XYZ/GJF with `--ref-pdb`) enable trajectory/HEI PDB exports.
 - **Charge/spin**: CLI overrides `.gjf` template metadata. If `-q` is omitted but `--ligand-charge` is provided, the endpoints are treated as an enzyme–substrate complex and `extract.py`’s charge summary computes the total charge when the inputs are PDBs; explicit `-q` still overrides. When no template/derivation applies, the charge defaults to `0` (spin defaults to `1`). Always set them explicitly for correct states.
 - **MEP segments**: `--max-nodes` controls the number of *internal* nodes/images for the GSM string or DMF path (total images = `max_nodes + 2` for GSM). GSM growth and the optional climbing-image refinement share a convergence threshold preset supplied via `--thresh` or YAML (`gau_loose`, `gau`, `gau_tight`, `gau_vtight`, `baker`, `never`).
 - **Climbing image**: `--climb` toggles both the standard climbing step and the Lanczos-based tangent refinement.
@@ -47,6 +47,7 @@ pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} [-q CHARGE] [--lig
 | `--dump BOOL` | Dump MEP trajectories/restarts (GSM/DMF). | `False` |
 | `--opt-mode TEXT` | Single-structure optimizer for endpoint preoptimization (`light` = LBFGS, `heavy` = RFO). | `light` |
 | `--convert-files {True|False}` | Toggle XYZ/TRJ → PDB/GJF companions for PDB/Gaussian inputs. | `True` |
+| `--ref-pdb FILE` | Reference PDB topology for XYZ/GJF inputs (keeps XYZ coordinates) to enable PDB conversions. | _None_ |
 | `--out-dir TEXT` | Output directory. | `./result_path_opt/` |
 | `--thresh TEXT` | Override convergence preset for GSM/string optimizer. | `gau` |
 | `--args-yaml FILE` | YAML overrides (sections `geom`, `calc`, `gs`, `opt`). | _None_ |
@@ -58,9 +59,9 @@ pdb2reaction path-opt -i REACTANT.{pdb|xyz} PRODUCT.{pdb|xyz} [-q CHARGE] [--lig
 ```
 out_dir/
 ├─ final_geometries.trj        # XYZ path; comment line holds energies when provided
-├─ final_geometries.pdb        # Only when the first endpoint was a PDB (conversion enabled)
+├─ final_geometries.pdb        # When a PDB reference is available (input PDB or --ref-pdb) and conversion enabled
 ├─ hei.xyz                     # Highest-energy image with its energy on the comment line
-├─ hei.pdb                     # HEI converted to PDB when the first endpoint was a PDB (conversion enabled)
+├─ hei.pdb                     # HEI converted to PDB when a PDB reference is available (conversion enabled)
 ├─ hei.gjf                     # HEI written using a detected Gaussian template (conversion enabled)
 ├─ align_refine/               # Intermediate files from the rigid alignment/refinement stage (created when alignment runs)
 └─ <optimizer dumps/restarts>  # Present when dumping is enabled

--- a/pdb2reaction/all.py
+++ b/pdb2reaction/all.py
@@ -3361,6 +3361,17 @@ def cli(
                 "--preopt",
                 "True" if preopt else "False",
             ]
+            ref_pdb_for_seg: Optional[Path] = None
+            if pocket_ref_pdbs and len(pocket_ref_pdbs) >= idx:
+                ref_pdb_for_seg = pocket_ref_pdbs[idx - 1]
+            elif pL.suffix.lower() == ".pdb":
+                ref_pdb_for_seg = pL
+            elif pR.suffix.lower() == ".pdb":
+                ref_pdb_for_seg = pR
+            elif is_single and has_scan and input_paths[0].suffix.lower() == ".pdb":
+                ref_pdb_for_seg = input_paths[0]
+            if ref_pdb_for_seg is not None:
+                po_args.extend(["--ref-pdb", str(ref_pdb_for_seg)])
             if thresh is not None:
                 po_args.extend(["--thresh", str(thresh)])
             if args_yaml is not None:

--- a/pdb2reaction/path_search.py
+++ b/pdb2reaction/path_search.py
@@ -1300,6 +1300,7 @@ def _build_multistep_path(
         out_dir,
         tag=f"{tag0}_left",
         prepared_input=prepared_input,
+        ref_pdb=ref_pdb_path,
     )
     right_end = _optimize_single(
         right_img,
@@ -1309,6 +1310,7 @@ def _build_multistep_path(
         out_dir,
         tag=f"{tag0}_right",
         prepared_input=prepared_input,
+        ref_pdb=ref_pdb_path,
     )
 
     try:
@@ -1334,6 +1336,7 @@ def _build_multistep_path(
                 out_dir,
                 tag=f"{tag0}_kink_int{i}",
                 prepared_input=prepared_input,
+                ref_pdb=ref_pdb_path,
             )
             opt_inters.append(g_opt)
         step_imgs = [left_end] + opt_inters + [right_end]
@@ -2345,6 +2348,7 @@ def cli(
                     out_dir_path,
                     tag=tag,
                     prepared_input=prepared_inputs[i] if i < len(prepared_inputs) else main_prepared,
+                    ref_pdb=ref_pdb_path,
                 )
                 new_geoms.append(g_opt)
             geoms = new_geoms


### PR DESCRIPTION
### Motivation
- Allow XYZ/GJF endpoints to be kept as coordinate inputs while providing a reference PDB topology used for PDB conversions, avoiding undesired coordinate rounding when converting intermediate/HEI frames.
- Ensure single-structure pre-optimizations use the same reference topology so converted outputs (e.g., `final_geometries.pdb`, `hei.pdb`) are generated when a ref-PDB is available.

### Description
- Added a `--ref-pdb` CLI option to `pdb2reaction path-opt` and threaded it into the command handling so prepared inputs may be overridden with a reference PDB via `apply_ref_pdb_override`.
- Extended `_optimize_single` in `pdb2reaction/path_opt.py` to accept a `ref_pdb` argument and use it when calling `convert_xyz_like_outputs` so single-structure preopt conversions respect the provided reference topology.
- Propagated the new `ref_pdb` parameter into `pdb2reaction/path_search.py` calls to `_optimize_single` so recursive path_search pre- and post-optimizations also honor the reference PDB.
- Updated `pdb2reaction/all.py` to forward an appropriate `--ref-pdb` to per-segment `path-opt` invocations when available, and updated documentation in `docs/path_opt.md` to describe the new flag and its effect on outputs.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979bd1a060c832d96874df46f15941b)