### PR TITLE
Add parallel predictor support in uma_ase (ParallelMLIPPredictUnit)

### DIFF
--- a/pdb2reaction/uma_pysis.py
+++ b/pdb2reaction/uma_pysis.py
@@ -752,10 +752,40 @@ class uma_ase(FAIRChemCalculator):
     ):
         if device == "auto":
             device = "cuda" if torch.cuda.is_available() else "cpu"
-        predictor = pretrained_mlip.get_predict_unit(
-            model,
-            device=device,
-            workers=int(workers),
-            workers_per_node=int(workers_per_node),
-        )
+        num_workers = int(workers) if workers is not None else 1
+        if num_workers < 1:
+            num_workers = 1
+
+        num_workers_per_node = int(workers_per_node) if workers_per_node is not None else 1
+        if num_workers_per_node < 1:
+            num_workers_per_node = 1
+
+        if num_workers > 1:
+            if (ParallelMLIPPredictUnit is None) or (guess_inference_settings is None):
+                raise ImportError(
+                    "workers>1 requested, but ParallelMLIPPredictUnit/guess_inference_settings "
+                    "could not be imported from fairchem. Please ensure your FAIR-Chem installation "
+                    "includes `fairchem-core[extras]`."
+                )
+            ckpt_path = pretrained_mlip.pretrained_checkpoint_path_from_name(model)
+            inference_settings = guess_inference_settings("default")
+
+            atom_refs = pretrained_mlip.get_reference_energies(model, reference_type="atom_refs")
+            form_elem_refs = pretrained_mlip.get_reference_energies(model, reference_type="form_elem_refs")
+
+            predictor = ParallelMLIPPredictUnit(
+                inference_model_path=str(ckpt_path),
+                device=device,
+                inference_settings=inference_settings,
+                atom_refs=atom_refs,
+                form_elem_refs=form_elem_refs,
+                num_workers=num_workers,
+                num_workers_per_node=num_workers_per_node,
+            )
+        else:
+            predictor = pretrained_mlip.get_predict_unit(
+                model,
+                device=device,
+                workers=num_workers,
+            )
         super().__init__(predictor, task_name=str(task_name))


### PR DESCRIPTION
### Motivation
- Fix a runtime TypeError caused by passing an unsupported `workers_per_node` argument into `pretrained_mlip.get_predict_unit` and to enable multi-worker inference. 
- Ensure `uma_ase` can construct a parallel predictor when `workers>1` and fall back to the single-worker API otherwise. 
- Normalize and validate `workers`/`workers_per_node` inputs to avoid invalid values.

### Description
- Update `uma_ase.__init__` to normalize `workers` and `workers_per_node` into `num_workers` and `num_workers_per_node` and clamp them to at least 1. 
- When `num_workers > 1`, validate presence of `ParallelMLIPPredictUnit` and `guess_inference_settings` and instantiate `ParallelMLIPPredictUnit(...)` by resolving the checkpoint path via `pretrained_mlip.pretrained_checkpoint_path_from_name` and passing `num_workers` and `num_workers_per_node`. 
- When `num_workers == 1`, call `pretrained_mlip.get_predict_unit(...)` without the unsupported `workers_per_node` keyword and pass `workers=num_workers`. 
- Raise an `ImportError` with a clear message if the parallel predictor pieces are not available in the FAIR-Chem installation.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697af46dedcc832d84548c23b858ff5b)