### PR TITLE
Handle numpy arrays in freeze_atoms checks

### DIFF
--- a/pdb2reaction/utils.py
+++ b/pdb2reaction/utils.py
@@ -914,8 +914,17 @@ def set_freeze_atoms_or_warn(
     context: str,
 ) -> None:
     """Attach freeze_atoms to a geometry; warn once on failure."""
-    if not freeze_atoms:
+    if freeze_atoms is None:
         return
+    try:
+        if isinstance(freeze_atoms, np.ndarray):
+            if freeze_atoms.size == 0:
+                return
+        elif len(freeze_atoms) == 0:
+            return
+    except TypeError:
+        if not freeze_atoms:
+            return
     try:
         geom.freeze_atoms = np.array(sorted({int(i) for i in freeze_atoms}), dtype=int)
     except Exception:


### PR DESCRIPTION
### Motivation
- Fix a `ValueError` raised when `freeze_atoms` was a NumPy array because its truth value is ambiguous, which caused failures in the path search flow. 
- Ensure `set_freeze_atoms_or_warn` returns early for missing or empty `freeze_atoms` inputs to avoid attaching invalid data to geometries.

### Description
- Update `pdb2reaction/utils.py` `set_freeze_atoms_or_warn` to explicitly check for `None` and handle NumPy arrays by testing `freeze_atoms.size` before evaluating emptiness. 
- Add a fallback `len()` check and a `TypeError` catch that uses a boolean check for other iterable-like values. 
- Preserve the existing behavior of converting `freeze_atoms` into a sorted `np.array` of `int` and emitting a warning on failure.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b0aa751e4832d855197e95fb5e9d3)