### PR TITLE
docs: add -c/-l to the README quickstart command so it runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An initial reaction path is one command:
 
 ```bash
 # Multi-PDB mode (R + P endpoints → MEP, with TS optimisation + thermo)
-pdb2reaction all -i R.pdb P.pdb -q 0 --tsopt --thermo
+pdb2reaction all -i R.pdb P.pdb -c 'LIG' -l 'LIG:-1' --tsopt --thermo
 ```
 
 > **Prerequisites:** input PDBs must already contain hydrogens; multiple PDBs must share the same atoms in the same order (only coordinates differ). Small-molecule `.xyz` / `.gjf` inputs work when `--center/-c` and `--ligand-charge/-l` are omitted.


### PR DESCRIPTION
The opening one-command example used PDB inputs without `--center/-c` or `--ligand-charge/-l`, so it would not extract an active-site model (as the Overview describes) and was inconsistent with the worked Examples below. Switch to `-c 'LIG' -l 'LIG:-1'` (matching the Examples section and the mlmm-toolkit README) and drop the redundant `-q 0` (`-l` supersedes it).