### PR TITLE
docs: align getting-started small-molecule/cluster note with the README

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ pdb2reaction -i 1.R.pdb 3.P.pdb -c 'SAM,GPP,MG' -l 'SAM:1,GPP:-3'               
 pdb2reaction -i 1.R.pdb 3.P.pdb -c 'SAM,GPP,MG' -l 'SAM:1,GPP:-3' --tsopt --thermo --dft   # full
 ```
 
-Given (i) ≥ 2 PDBs (R → ... → P), (ii) one PDB with `--scan-lists/-s`, or (iii) one TS candidate with `--tsopt`, `pdb2reaction` extracts an **active-site cluster model**, runs an **MEP search** (GSM / DMF), and optionally chains TS optimization, IRC, frequencies, and single-point DFT. The same workflow also works for small-molecule systems — omit `--center/-c` and `--ligand-charge/-l` to use `.xyz` / `.gjf` inputs.
+Given (i) ≥ 2 PDBs (R → ... → P), (ii) one PDB with `--scan-lists/-s`, or (iii) one TS candidate with `--tsopt`, `pdb2reaction` extracts an **active-site cluster model**, runs an **MEP search** (GSM / DMF), and optionally chains TS optimization, IRC, frequencies, and single-point DFT. The same pipeline also runs without active-site extraction: pass a small molecule as `.xyz` / `.gjf` (set the net charge with `-q`), or a cluster model you built yourself as a PDB — omit `--center/-c` in either case and the structure is analyzed as given.
 
 Working examples (BezA C6-methyltransferase, both multi-structure MEP and scan modes): [`examples/`](https://github.com/t-0hmura/pdb2reaction/tree/main/examples). For setup see [Installation](installation.md); for symptom-first diagnosis see [Common Error Recipes](recipes-common-errors.md) and [Troubleshooting](troubleshooting.md).
 


### PR DESCRIPTION
Follow-up to the README change: getting-started's no-extraction note conflated the cases (omit -c and -l for .xyz/.gjf, no charge guidance). Align it with the README — small molecule as .xyz/.gjf with charge via -q, user-built cluster model as a PDB, omit --center/-c in either case.